### PR TITLE
http caching tweaks

### DIFF
--- a/src/main/java/org/lantern/Launcher.java
+++ b/src/main/java/org/lantern/Launcher.java
@@ -841,7 +841,6 @@ public class Launcher {
     public static final String OPTION_PASS = "pass";
     public static final String OPTION_GET = "force-get";
     public static final String OPTION_GIVE = "force-give";
-    public static final String OPTION_NO_CACHE = "no-cache";
     public static final String OPTION_VERSION = "version";
     public static final String OPTION_NEW_UI = "new-ui";
     public static final String OPTION_REFRESH_TOK = "refresh-tok";
@@ -884,8 +883,6 @@ public class Launcher {
             "Google password -- WARNING INSECURE - ONLY USE THIS FOR TESTING!");
         options.addOption(null, OPTION_GET, false, "Force running in get mode");
         options.addOption(null, OPTION_GIVE, false, "Force running in give mode");
-        options.addOption(null, OPTION_NO_CACHE, false,
-            "Don't allow caching of static files in the dashboard");
         options.addOption(null, OPTION_VERSION, false,
             "Print the Lantern version");
         options.addOption(null, OPTION_NEW_UI, false,
@@ -998,11 +995,6 @@ public class Launcher {
             model.getSettings().setMode(Mode.give);
         } else if (cmd.hasOption(OPTION_GET)) {
             model.getSettings().setMode(Mode.get);
-        }
-
-        model.setCache(!LanternUtils.isDevMode());
-        if (cmd.hasOption(OPTION_NO_CACHE)) {
-            model.setCache(false);
         }
     }
 }

--- a/src/main/java/org/lantern/http/InteractionServlet.java
+++ b/src/main/java/org/lantern/http/InteractionServlet.java
@@ -725,7 +725,6 @@ public class InteractionServlet extends HttpServlet {
             }
         }
         final Model base = new Model();
-        model.setCache(base.isCache());
         model.setLaunchd(base.isLaunchd());
         model.setModal(base.getModal());
         model.setNinvites(base.getNinvites());

--- a/src/main/java/org/lantern/http/JettyLauncher.java
+++ b/src/main/java/org/lantern/http/JettyLauncher.java
@@ -161,12 +161,7 @@ public class JettyLauncher implements LanternService {
                 }
             }
         });
-        if (model.isCache()) {
-            ds.setInitParameter("cacheControl", "private, max-age=" +
-                LanternConstants.DASHCACHE_MAXAGE);
-        } else {
-            ds.setInitParameter("cacheControl", "no-cache");
-        }
+        ds.setInitParameter("cacheControl", "no-cache");
         ds.setInitParameter("aliases", "true");
 
         ds.setInitOrder(3);

--- a/src/main/java/org/lantern/http/PhotoServlet.java
+++ b/src/main/java/org/lantern/http/PhotoServlet.java
@@ -43,8 +43,8 @@ public final class PhotoServlet extends HttpServlet {
     
     private static XMPPConnection conn;
     
-    private static final int CACHE_DURATION_IN_SECOND = 60 * 60 * 24 * 4; 
-    private static final long CACHE_DURATION_IN_MS = CACHE_DURATION_IN_SECOND  * 1000;
+    private static final int CACHE_DURATION_IN_S = 60 * 60 * 24; // 1 day
+    private static final long CACHE_DURATION_IN_MS = CACHE_DURATION_IN_S * 1000;
     
     /**
      * Generated serial ID.
@@ -128,7 +128,7 @@ public final class PhotoServlet extends HttpServlet {
         
         
         resp.addHeader(HttpHeaders.Names.CACHE_CONTROL, 
-            "max-age=" + CACHE_DURATION_IN_SECOND);
+            "max-age=" + CACHE_DURATION_IN_S);
         resp.setDateHeader(HttpHeaders.Names.EXPIRES, 
             System.currentTimeMillis() + CACHE_DURATION_IN_MS);
         

--- a/src/main/java/org/lantern/state/Model.java
+++ b/src/main/java/org/lantern/state/Model.java
@@ -60,8 +60,6 @@ public class Model {
 
     private boolean launchd;
 
-    private boolean cache;
-
     private String nodeId = String.valueOf(new SecureRandom().nextLong());
 
     private Map<String, Country> countries = Country.allCountries();
@@ -188,15 +186,6 @@ public class Model {
 
     public void setLaunchd(boolean launchd) {
         this.launchd = launchd;
-    }
-
-    @JsonIgnore
-    public boolean isCache() {
-        return cache;
-    }
-
-    public void setCache(boolean cache) {
-        this.cache = cache;
     }
 
     @JsonView({Run.class, Persistent.class})


### PR DESCRIPTION
- no longer tell browsers they can cache static files when not in dev mode,
  not worth risking their using stale copies
- decrease expire time of cached copies of profile photos from 4 days to 1
