### PR TITLE
Run proguard on release builds

### DIFF
--- a/install.bash
+++ b/install.bash
@@ -11,4 +11,5 @@ then
   ls -la configureNetworkServices | grep rwsr | grep wheel || ./setNetUidOsx.bash
 fi
 
-mvn package -Dmaven.artifact.threads=1 -Dmaven.test.skip=true || die "Could not package"
+rm -f target/lantern*-small.jar
+mvn package -Dmaven.artifact.threads=1 -Dmaven.test.skip=true -Prelease || die "Could not package"

--- a/install/lantern.pro
+++ b/install/lantern.pro
@@ -1,14 +1,4 @@
--injars ../target/lantern-0.3-SNAPSHOT-jar-with-dependencies.jar
--outjars ../target/lanternpro.jar
-
-# XXX these paths are OS X only
--libraryjars <java.home>/../Classes/classes.jar
--libraryjars <java.home>/../Classes/jsse.jar
--libraryjars <java.home>/lib/jce.jar
--libraryjars <java.home>/lib/javaws.jar
--libraryjars <java.home>/lib/dt.jar
 -ignorewarnings
--target 1.6
 
 -keep public class org.lantern.Launcher {
      public static void main(java.lang.String[]);
@@ -22,16 +12,48 @@
     public protected *;
 }
 
-# -keep class org.eclipse.swt.widgets.Display,
-#             org.eclipse.swt.browser.** {
-#     *;
-# }
-
-
 -keep class org.eclipse.swt.** {
     *;
 }
+-keep class dbusjava_localized,
+            dbusjava_localized_en_GB
 
+-keep class org.freedesktop.** {
+    *;
+}
+
+-keep class cx.ath.matthew.** {
+    *;
+}
+
+-keep class org.jivesoftware.**
+
+-keep class fr.free.miniupnp.** {
+    <fields>;
+    <methods>;
+}
+
+-keepclassmembers class * {
+   @com.google.common.eventbus.Subscribe *;
+}
+
+-keep class com.sun.jna.** {
+    *;
+}
+
+-keepclassmembers class * extends com.sun.jna.** {
+    <fields>;
+    <methods>;
+}
+
+-keep class sun.proxy.** {
+    *;
+}
+
+#guice
+-keep class com.google.inject.** { *; } 
+-keep class javax.inject.** { *; } 
+-keep class javax.annotation.** { *; } 
 
 # enum gobbledygook
 -keepclassmembers enum * {
@@ -44,17 +66,19 @@
     native <methods>;
 }
 
-# Beanish things
--keep class org.lantern.Settings,
-            org.lantern.Whitelist,
-            org.lantern.WhitelistEntry,
-            org.lantern.Internet, 
-            org.lantern.ConnectivityStatus,
-            org.lantern.SettingsState,
-            org.lantern.Country,
-            org.lantern.Platform, 
-            org.lantern.httpseverywhere.* {
+# Use annotations to keep things
+-keep @org.lantern.annotation.Keep class *
+
+-keepclassmembers @org.lantern.annotation.Keep class * {
+     *;
+}
+
+-keep class org.lantern.LanternModule {
     *;
+}
+
+-keepclassmembers class * { 
+    @com.google.inject.Inject <init>(...) ; 
 }
 
 # Annotations
@@ -62,7 +86,7 @@
 
 # referenced by string
 -keep class org.lantern.SettingsJSONContextServer {
-    public proctected *;
+    public protected *;
 }
 
 -keep class org.jivesoftware.smack.sasl.** {
@@ -71,9 +95,7 @@
 
 -dontobfuscate
 -dontoptimize
+-dontwarn sun.misc.Unsafe
+-dontwarn com.google.common.collect.MinMaxPriorityQueue
 
-#-keeppackagenames org.apache.log4j.**
-
-
--verbose
 

--- a/installerBuild.bash
+++ b/installerBuild.bash
@@ -74,16 +74,16 @@ perl -pi -e "s/fallback_server_port_tok/$FALLBACK_SERVER_PORT/g" $CONSTANTS_FILE
 perl -pi -e "s/ExceptionalUtils.NO_OP_KEY/\"$GE_API_KEY\"/g" $CONSTANTS_FILE || die "Could not set exceptional key"
 
 mvn clean || die "Could not clean?"
-mvn $MVN_ARGS install -Dmaven.test.skip=true || die "Could not build?"
+mvn $MVN_ARGS -Drelease install -Dmaven.test.skip=true || die "Could not build?"
 
 echo "Reverting constants file"
 git checkout -- $CONSTANTS_FILE || die "Could not revert version file?"
 
 if [[ $VERSION == "HEAD" ]];
 then
-    cp target/lantern-*.jar install/common/lantern.jar || die "Could not copy jar?"
+    cp target/lantern-*-small.jar install/common/lantern.jar || die "Could not copy jar?"
 else
-    cp target/lantern-$VERSION.jar install/common/lantern.jar || die "Could not copy jar?"
+    cp target/lantern-$VERSION-small.jar install/common/lantern.jar || die "Could not copy jar?"
 fi
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,9 @@
     <slf4j.version>1.7.2</slf4j.version>
     <cometd.version>2.5.1</cometd.version>
     <github.global.server>github</github.global.server>
+    <rt.path>${java.home}/lib/rt.jar</rt.path>
+    <jce.path>${java.home}/lib/jce.jar</jce.path>
+    <jsse.path>${java.home}/lib/jsse.jar</jsse.path>
   </properties>
 
   <organization>
@@ -677,6 +680,19 @@
                     <execute />
                   </action>
                 </pluginExecution>
+                <pluginExecution>
+                  <pluginExecutionFilter>
+                    <groupId>com.github.wvengen</groupId>
+                    <artifactId>proguard-maven-plugin</artifactId>
+                    <versionRange>[2.0.6,)</versionRange>
+                    <goals>
+                      <goal>proguard</goal>
+                    </goals>
+                  </pluginExecutionFilter>
+                  <action>
+                    <ignore></ignore>
+                  </action>
+                </pluginExecution>
               </pluginExecutions>
             </lifecycleMappingMetadata>
           </configuration>
@@ -686,6 +702,73 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>mac-apple-java</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+        <file>
+          <!-- Oracle's JRE 7 apparently uses the traditional rt.jar
+               for this; this only activates the mac profile if
+               classes.jar exists (indicating Apple Java 6) -->
+          <exists>${java.home}/../Classes/classes.jar</exists>
+        </file>
+      </activation>
+      <properties>
+        <rt.path>${java.home}/../Classes/classes.jar</rt.path>
+        <jsse.path>${java.home}/../Classes/jsse.jar</jsse.path>
+      </properties>
+    </profile>
+    <profile>
+      <id>release</id>
+      <activation>
+        <property>
+          <name>release</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.github.wvengen</groupId>
+            <artifactId>proguard-maven-plugin</artifactId>
+            <version>2.0.6</version>
+            <executions>
+              <execution>
+                <id>package-with-proguard</id>
+                <phase>package</phase>
+                <goals>
+                  <goal>proguard</goal>
+                </goals>
+              </execution>
+            </executions>
+            <dependencies>
+              <dependency>
+                <groupId>net.sf.proguard</groupId>
+                <artifactId>proguard-base</artifactId>
+                <version>4.8</version>
+                <scope>runtime</scope>
+                <optional>true</optional>
+              </dependency>
+            </dependencies>
+            <configuration>
+              <proguardVersion>4.8</proguardVersion>
+              <libs>
+                <lib>${rt.path}</lib>
+                <lib>${jce.path}</lib>
+                <lib>${jsse.path}</lib>
+              </libs>
+              <injar>${project.build.finalName}.jar</injar>
+              <outjar>${project.build.finalName}-small.jar</outjar>
+              <includeDependency>true</includeDependency>
+              <obfuscate>false</obfuscate>
+              <attach>true</attach>
+              <addMavenDescriptor>false</addMavenDescriptor>
+              <maxMemory>2048m</maxMemory>
+              <proguardInclude>install/lantern.pro</proguardInclude>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>linux</id>
       <activation>

--- a/quickRun.bash
+++ b/quickRun.bash
@@ -17,7 +17,13 @@ done
 
 ls *.hprof &> /dev/null && echo "don't run now, there's an hprof file:" && ls *.hprof && die
 
-jar=target/lantern*SNAPSHOT.jar
+#run the minified version if available
+if [ -e target/lantern*SNAPSHOT-small.jar ]
+then
+    jar=target/lantern*SNAPSHOT-small.jar
+else
+    jar=target/lantern*SNAPSHOT.jar
+fi
 
 # We need to copy the bouncycastle jar in separately because it's signed.
 # The shaded jar includes it in the classpath in its manifest.

--- a/src/main/java/org/lantern/Censored.java
+++ b/src/main/java/org/lantern/Censored.java
@@ -1,9 +1,12 @@
 package org.lantern;
 
 import java.io.IOException;
+
+import org.lantern.annotation.Keep;
 /**
  * Interface for classes that keep track of censored countries.
  */
+@Keep
 public interface Censored {
 
     boolean isExportRestricted(String string) throws IOException;

--- a/src/main/java/org/lantern/Country.java
+++ b/src/main/java/org/lantern/Country.java
@@ -1,8 +1,10 @@
 package org.lantern;
 
+import org.lantern.annotation.Keep;
 import org.lantern.state.NPeers;
 import org.lantern.state.NUsers;
 
+@Keep
 public class Country {
 
     private String code;

--- a/src/main/java/org/lantern/CountryService.java
+++ b/src/main/java/org/lantern/CountryService.java
@@ -3,10 +3,13 @@ package org.lantern;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.lantern.annotation.Keep;
+
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 
 @Singleton
+@Keep
 public class CountryService {
 
     private static String[] countryTable = {

--- a/src/main/java/org/lantern/DefaultCensored.java
+++ b/src/main/java/org/lantern/DefaultCensored.java
@@ -5,6 +5,7 @@ import java.net.InetAddress;
 import java.util.Collection;
 import java.util.TreeSet;
 
+import org.lantern.annotation.Keep;
 import org.lantern.geoip.GeoIpLookupService;
 import org.lastbamboo.common.stun.client.PublicIpAddress;
 import org.slf4j.Logger;
@@ -18,6 +19,7 @@ import com.google.inject.Singleton;
  * Class that keeps track of which countries are considered censored.
  */
 @Singleton
+@Keep
 public class DefaultCensored implements Censored {
 
     private static final Logger LOG = 

--- a/src/main/java/org/lantern/GoogleTalkState.java
+++ b/src/main/java/org/lantern/GoogleTalkState.java
@@ -1,8 +1,11 @@
 package org.lantern;
 
+import org.lantern.annotation.Keep;
+
 /**
  * Enumeration of connectivity statuses.
  */
+@Keep
 public enum GoogleTalkState {
 
     notConnected,

--- a/src/main/java/org/lantern/Roster.java
+++ b/src/main/java/org/lantern/Roster.java
@@ -21,6 +21,7 @@ import org.kaleidoscope.BasicTrustGraphNodeId;
 import org.kaleidoscope.RandomRoutingTable;
 import org.kaleidoscope.TrustGraphNode;
 import org.kaleidoscope.TrustGraphNodeId;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.event.ModeChangedEvent;
 import org.lantern.event.ResetEvent;
@@ -46,6 +47,7 @@ import com.google.inject.Singleton;
  * Class that keeps track of all roster entries.
  */
 @Singleton
+@Keep
 public class Roster implements RosterListener {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/org/lantern/Stats.java
+++ b/src/main/java/org/lantern/Stats.java
@@ -1,7 +1,9 @@
 package org.lantern;
 
 import org.jboss.netty.channel.Channel;
+import org.lantern.annotation.Keep;
 
+@Keep
 public interface Stats {
 
     long getUptime();

--- a/src/main/java/org/lantern/StatsTracker.java
+++ b/src/main/java/org/lantern/StatsTracker.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.jboss.netty.channel.Channel;
 import org.json.simple.JSONObject;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.event.ResetEvent;
 import org.lantern.geoip.GeoIpLookupService;
@@ -25,6 +26,7 @@ import com.google.inject.Singleton;
 /**
  * Class for tracking statistics about Lantern.
  */
+@Keep
 @Singleton
 public class StatsTracker implements Stats {
     
@@ -392,6 +394,7 @@ public class StatsTracker implements Stats {
         return LanternClientConstants.VERSION;
     }
     
+    @Keep
     public final class CountryData {
         private final Set<InetAddress> addresses = new HashSet<InetAddress>();
         private volatile long bytes;

--- a/src/main/java/org/lantern/Upnp.java
+++ b/src/main/java/org/lantern/Upnp.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.lantern.annotation.Keep;
 import org.lastbamboo.common.portmapping.PortMapListener;
 import org.lastbamboo.common.portmapping.PortMappingProtocol;
 import org.littleshoot.util.NetworkUtils;
@@ -115,6 +116,7 @@ public class Upnp implements org.lastbamboo.common.portmapping.UpnpService {
         return 1;
     }
 
+    @Keep
     static class UpnpMapping {
         public PortMappingProtocol prot;
         public int internalPort;

--- a/src/main/java/org/lantern/Whitelist.java
+++ b/src/main/java/org/lantern/Whitelist.java
@@ -7,12 +7,14 @@ import java.util.TreeSet;
 import org.apache.commons.lang.StringUtils;
 import org.jboss.netty.handler.codec.http.HttpHeaders;
 import org.jboss.netty.handler.codec.http.HttpRequest;
+import org.lantern.annotation.Keep;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Keeps track of which domains are whitelisted.
  */
+@Keep
 public class Whitelist {
 
     private final Logger log = LoggerFactory.getLogger(Whitelist.class);

--- a/src/main/java/org/lantern/annotation/Keep.java
+++ b/src/main/java/org/lantern/annotation/Keep.java
@@ -1,0 +1,17 @@
+package org.lantern.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marker annotation for proguard
+ *
+ */
+@Retention(RetentionPolicy.CLASS)
+@Target({ElementType.TYPE})
+@Keep
+public @interface Keep {
+
+}

--- a/src/main/java/org/lantern/linux/AppIndicator.java
+++ b/src/main/java/org/lantern/linux/AppIndicator.java
@@ -1,5 +1,7 @@
 package org.lantern.linux;
 
+import org.lantern.annotation.Keep;
+
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
 import com.sun.jna.Pointer;
@@ -18,14 +20,17 @@ public interface AppIndicator extends Library {
     public static final int STATUS_ACTIVE    = 1;
     public static final int STATUS_ATTENTION = 2;
 
+    @Keep
     public interface Fallback extends Callback {
         public Pointer callback(AppIndicatorInstanceStruct self);
     }
 
+    @Keep
     public interface Unfallback extends Callback {
         public void callback(AppIndicatorInstanceStruct self, Pointer status_icon);
     }
 
+    @Keep
     public class AppIndicatorClassStruct extends Structure {
         public class ByReference extends AppIndicatorClassStruct implements Structure.ByReference {}
 
@@ -70,6 +75,7 @@ public interface AppIndicator extends Library {
         */
     }
 
+    @Keep
     public class AppIndicatorInstanceStruct extends Structure {
         public Gobject.GObjectStruct parent;
         public Pointer priv;

--- a/src/main/java/org/lantern/linux/Gobject.java
+++ b/src/main/java/org/lantern/linux/Gobject.java
@@ -1,7 +1,6 @@
 package org.lantern.linux;
 
-import java.util.Arrays;
-import java.util.List;
+import org.lantern.annotation.Keep;
 
 import com.sun.jna.Callback;
 import com.sun.jna.Library;
@@ -11,7 +10,7 @@ import com.sun.jna.Structure;
 
 public interface Gobject extends Library {
     
-
+    @Keep
     public class GTypeClassStruct extends Structure {
         public class ByValue extends GTypeClassStruct implements Structure.ByValue {}
         public class ByReference extends GTypeClassStruct implements Structure.ByReference {}
@@ -19,6 +18,7 @@ public interface Gobject extends Library {
         
     };
 
+    @Keep
     public class GTypeInstanceStruct extends Structure {
         public class ByValue extends GTypeInstanceStruct implements Structure.ByValue {}
         public class ByReference extends GTypeInstanceStruct implements Structure.ByReference {}
@@ -26,6 +26,7 @@ public interface Gobject extends Library {
         
     }
 
+    @Keep
     public class GObjectStruct extends Structure {
         public class ByValue extends GObjectStruct implements Structure.ByValue {}
         public class ByReference extends GObjectStruct implements Structure.ByReference {}
@@ -36,6 +37,7 @@ public interface Gobject extends Library {
         
     }
 
+    @Keep
     public class GObjectClassStruct extends Structure {
         public class ByValue extends GObjectClassStruct implements Structure.ByValue {}
         public class ByReference extends GObjectClassStruct implements Structure.ByReference {}
@@ -60,6 +62,7 @@ public interface Gobject extends Library {
         
     };
 
+    @Keep
     public interface GCallback extends Callback {
         public void callback(Pointer instance, Pointer data);
     }

--- a/src/main/java/org/lantern/state/CometDSyncStrategy.java
+++ b/src/main/java/org/lantern/state/CometDSyncStrategy.java
@@ -9,6 +9,7 @@ import java.util.concurrent.ThreadFactory;
 import org.cometd.bayeux.client.ClientSessionChannel;
 import org.cometd.bayeux.server.ServerSession;
 import org.lantern.JsonUtils;
+import org.lantern.annotation.Keep;
 import org.lantern.event.SyncType;
 import org.lantern.state.Model.Run;
 import org.slf4j.Logger;
@@ -71,6 +72,7 @@ public class CometDSyncStrategy implements SyncStrategy {
      *
      * https://github.com/getlantern/lantern-ui/blob/master/SPECS.md
      */
+    @Keep
     public static class SyncData {
         private final String op;
         private final String path;

--- a/src/main/java/org/lantern/state/Connectivity.java
+++ b/src/main/java/org/lantern/state/Connectivity.java
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.map.annotate.JsonView;
 import org.lantern.GoogleTalkState;
 import org.lantern.LanternConstants;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.event.GoogleTalkStateEvent;
 import org.lantern.state.Model.Persistent;
@@ -19,6 +20,7 @@ import com.google.common.eventbus.Subscribe;
 /**
  * Class representing data about Lantern's connectivity.
  */
+@Keep
 public class Connectivity {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/org/lantern/state/Friends.java
+++ b/src/main/java/org/lantern/state/Friends.java
@@ -4,6 +4,9 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.lantern.annotation.Keep;
+
+@Keep
 public class Friends {
 
     private Map<String, Friend> currentMap = 

--- a/src/main/java/org/lantern/state/Global.java
+++ b/src/main/java/org/lantern/state/Global.java
@@ -1,5 +1,8 @@
 package org.lantern.state;
 
+import org.lantern.annotation.Keep;
+
+@Keep
 public class Global {
 
     private final NUsers nusers = new NUsers();

--- a/src/main/java/org/lantern/state/Location.java
+++ b/src/main/java/org/lantern/state/Location.java
@@ -2,6 +2,7 @@ package org.lantern.state;
 
 import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.map.annotate.JsonView;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.state.Model.Persistent;
 import org.lantern.state.Model.Run;
@@ -9,6 +10,7 @@ import org.lantern.state.Model.Run;
 /**
  * Location data for the client.
  */
+@Keep
 public class Location {
 
     private String country = "";

--- a/src/main/java/org/lantern/state/Modal.java
+++ b/src/main/java/org/lantern/state/Modal.java
@@ -1,8 +1,11 @@
 package org.lantern.state;
 
+import org.lantern.annotation.Keep;
+
 /**
  * The state for the modal dialog.
  */
+@Keep
 public enum Modal {
 
 

--- a/src/main/java/org/lantern/state/Model.java
+++ b/src/main/java/org/lantern/state/Model.java
@@ -20,6 +20,7 @@ import org.lantern.LanternUtils;
 import org.lantern.Roster;
 import org.lantern.RosterDeserializer;
 import org.lantern.RosterSerializer;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.event.InvitesChangedEvent;
 import org.lantern.event.SetupCompleteEvent;
@@ -31,6 +32,7 @@ import org.slf4j.LoggerFactory;
 /**
  * State model of the application for the UI to display.
  */
+@Keep
 public class Model {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/org/lantern/state/NPeers.java
+++ b/src/main/java/org/lantern/state/NPeers.java
@@ -1,5 +1,8 @@
 package org.lantern.state;
 
+import org.lantern.annotation.Keep;
+
+@Keep
 public class NPeers {
     private PeerCount online = new PeerCount();
     private PeerCount ever = new PeerCount();

--- a/src/main/java/org/lantern/state/NUsers.java
+++ b/src/main/java/org/lantern/state/NUsers.java
@@ -1,5 +1,8 @@
 package org.lantern.state;
 
+import org.lantern.annotation.Keep;
+
+@Keep
 public class NUsers {
     private long online;
     private long ever;

--- a/src/main/java/org/lantern/state/Notification.java
+++ b/src/main/java/org/lantern/state/Notification.java
@@ -1,8 +1,13 @@
 package org.lantern.state;
 
+import org.lantern.annotation.Keep;
+
+@Keep
 public class Notification {
     private MessageType type;
     private String message;
+
+    @Keep
     public enum MessageType {
         info, warning, error, success, important;
     }

--- a/src/main/java/org/lantern/state/Peer.java
+++ b/src/main/java/org/lantern/state/Peer.java
@@ -10,6 +10,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize.Inclusion;
 import org.codehaus.jackson.map.annotate.JsonView;
 import org.lantern.LanternClientConstants;
 import org.lantern.LanternRosterEntry;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.state.Model.Persistent;
 import org.lantern.state.Model.Run;
@@ -19,12 +20,14 @@ import org.lantern.util.LanternTrafficCounter;
  * Class containing data for an individual peer, including active connections,
  * IP address, etc.
  */
+@Keep
 public class Peer {
 
     private String peerid = "";
 
     private String country = "";
     
+    @Keep
     public enum Type {
         pc,
         cloud,

--- a/src/main/java/org/lantern/state/PeerCount.java
+++ b/src/main/java/org/lantern/state/PeerCount.java
@@ -2,7 +2,9 @@ package org.lantern.state;
 
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize;
+import org.lantern.annotation.Keep;
 
+@Keep
 @JsonSerialize(using = PeerCountSerializer.class)
 @JsonDeserialize(using = PeerCountDeserializer.class)
 public class PeerCount {

--- a/src/main/java/org/lantern/state/Peers.java
+++ b/src/main/java/org/lantern/state/Peers.java
@@ -4,8 +4,11 @@ import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.lantern.annotation.Keep;
+
 import com.google.common.collect.ImmutableMap;
 
+@Keep
 public class Peers {
 
     private Map<URI, Peer> peers = new ConcurrentHashMap<URI, Peer>();

--- a/src/main/java/org/lantern/state/Profile.java
+++ b/src/main/java/org/lantern/state/Profile.java
@@ -2,9 +2,11 @@ package org.lantern.state;
 
 import org.codehaus.jackson.map.annotate.JsonView;
 import org.lantern.LanternUtils;
+import org.lantern.annotation.Keep;
 import org.lantern.state.Model.Persistent;
 import org.lantern.state.Model.Run;
 
+@Keep
 public class Profile {
     
     private String id = "";

--- a/src/main/java/org/lantern/state/Settings.java
+++ b/src/main/java/org/lantern/state/Settings.java
@@ -10,6 +10,7 @@ import org.codehaus.jackson.map.annotate.JsonView;
 import org.lantern.LanternConstants;
 import org.lantern.LanternUtils;
 import org.lantern.Whitelist;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.event.SystemProxyChangedEvent;
 import org.lantern.state.Model.Persistent;
@@ -23,6 +24,7 @@ import com.google.common.collect.Sets;
 /**
  * Base Lantern settings.
  */
+@Keep
 public class Settings {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/org/lantern/state/SyncService.java
+++ b/src/main/java/org/lantern/state/SyncService.java
@@ -13,6 +13,7 @@ import org.cometd.bayeux.server.ConfigurableServerChannel;
 import org.cometd.bayeux.server.ServerSession;
 import org.lantern.LanternClientConstants;
 import org.lantern.LanternService;
+import org.lantern.annotation.Keep;
 import org.lantern.event.ClosedBetaEvent;
 import org.lantern.event.Events;
 import org.lantern.event.SyncEvent;
@@ -29,6 +30,7 @@ import com.google.inject.Singleton;
  */
 @Service("sync")
 @Singleton
+@Keep
 public class SyncService implements LanternService {
 
     private final Logger log = LoggerFactory.getLogger(getClass());

--- a/src/main/java/org/lantern/state/SyncStrategy.java
+++ b/src/main/java/org/lantern/state/SyncStrategy.java
@@ -1,12 +1,14 @@
 package org.lantern.state;
 
 import org.cometd.bayeux.server.ServerSession;
+import org.lantern.annotation.Keep;
 import org.lantern.event.SyncType;
 
 /**
  * Interface for supporting various methods of syncing with clients using some
  * form of server-side push.
  */
+@Keep
 public interface SyncStrategy {
 
     void sync(ServerSession session, SyncType syncType, String path,

--- a/src/main/java/org/lantern/state/SystemData.java
+++ b/src/main/java/org/lantern/state/SystemData.java
@@ -8,6 +8,7 @@ import java.lang.management.ManagementFactory;
 import org.apache.commons.io.FileSystemUtils;
 import org.apache.commons.lang3.SystemUtils;
 import org.codehaus.jackson.map.annotate.JsonView;
+import org.lantern.annotation.Keep;
 import org.lantern.state.Model.Run;
 
 import com.sun.management.OperatingSystemMXBean;
@@ -15,6 +16,7 @@ import com.sun.management.OperatingSystemMXBean;
 /**
  * Class containing data about the users system.
  */
+@Keep
 public class SystemData {
 
     private final String os;

--- a/src/main/java/org/lantern/state/Transfers.java
+++ b/src/main/java/org/lantern/state/Transfers.java
@@ -3,12 +3,14 @@ package org.lantern.state;
 import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.map.annotate.JsonView;
 import org.lantern.Stats;
+import org.lantern.annotation.Keep;
 import org.lantern.state.Model.Persistent;
 import org.lantern.state.Model.Run;
 
 /**
  * Class representing all uploads and downloads data.
  */
+@Keep
 public class Transfers {
 
     private Stats statsTracker;

--- a/src/main/java/org/lantern/state/Version.java
+++ b/src/main/java/org/lantern/state/Version.java
@@ -10,6 +10,7 @@ import org.codehaus.jackson.map.annotate.JsonSerialize;
 import org.codehaus.jackson.map.annotate.JsonView;
 import org.lantern.LanternClientConstants;
 import org.lantern.LanternConstants;
+import org.lantern.annotation.Keep;
 import org.lantern.event.Events;
 import org.lantern.event.SyncEvent;
 import org.lantern.event.UpdateEvent;
@@ -21,6 +22,7 @@ import com.google.common.eventbus.Subscribe;
 /**
  * Class containing version data for clients.
  */
+@Keep
 public class Version {
 
     private final Installed installed = new Installed();
@@ -59,6 +61,7 @@ public class Version {
         this.updateAvailable = updateAvailable;
     }
 
+    @Keep
     public class Installed {
 
         private final int major;
@@ -165,6 +168,7 @@ public class Version {
 
     }
 
+    @Keep
     public class SemanticVersion {
         private final int major;
 


### PR DESCRIPTION
This seems to work.  But I can't test that the build process does what it is supposed to, because debInstall64bit.bash is still not working.

I do notice that this only reduces the size of the deb file by about 30% (down to 40MB).  That's because the JRE itself is not affected by proguard, and the JRE takes up like 20 MB compressed .  It might be possible to change this, but I think that would probably be (a) a lot of work and (b) a mistake.

There is probably ~3 or so megs of slack left in there. I was a bit sloppy with the proguard matching because the build process is super-slow.  I wasn't able to figure out a clean way to handle swt, smack, and a few other things, so I just included them all in.
