### PR TITLE
silence those insufferable bells from cert printing

### DIFF
--- a/src/main/java/org/lantern/DefaultXmppHandler.java
+++ b/src/main/java/org/lantern/DefaultXmppHandler.java
@@ -1135,7 +1135,7 @@ public class DefaultXmppHandler implements XmppHandler {
         if (StringUtils.isNotBlank(base64Cert)) {
             LOG.debug("Got certificate:\n"+
                 new String(Base64.decodeBase64(base64Cert),
-                    LanternConstants.UTF8));
+                    LanternConstants.UTF8).replaceAll( "\\W", "."));
             // Add the peer if we're able to add the cert.
             this.kscopeAdHandler.onBase64Cert(uri, base64Cert);
         } else {


### PR DESCRIPTION
replace all non-word characters with a '.' when DEBUG logging a certificate to
stdout so terminals that ring audible or visible bells when a non-printable
character is printed don't drive developers crazy
