### PR TITLE
#1147 Allow Lantern to use another local(system) proxy setting

### DIFF
--- a/src/main/java/org/lantern/PacFileGenerator.java
+++ b/src/main/java/org/lantern/PacFileGenerator.java
@@ -37,7 +37,10 @@ public class PacFileGenerator {
             sb.append(site);
             sb.append("\";\n");
         }
-        return template.replace("allDomainsTok", sb.toString().trim());
+
+        final String defaultProxy = loadFile(Proxifier.PROXY_OFF).replace("FindProxyForURL","findDefaultProxyForURL");
+
+        return template.replace("allDomainsTok", sb.toString().trim()).replace("defaultProxy",defaultProxy.trim());
     }
 
     private static String loadTemplate() {
@@ -61,6 +64,22 @@ public class PacFileGenerator {
         }
         LOG.error("Could not load template!!");
         throw new Error("Could not load template!!");
+    }
+
+    private static String loadFile(final File file) {
+        if (file.isFile()) {
+            FileInputStream fr = null;
+            try {
+                fr = new FileInputStream(file);
+                return IOUtils.toString(fr);
+            } catch (final IOException e) {
+
+            } finally {
+                IOUtils.closeQuietly(fr);
+            }
+        }
+        LOG.error("Could not loadFile", e);
+        throw new Error("Could not loadFile!", e);
     }
 
     public static void generatePacFile(final Collection<String> entries, 

--- a/src/main/resources/proxy_on.pac.template
+++ b/src/main/resources/proxy_on.pac.template
@@ -19,5 +19,7 @@ function FindProxyForURL(url, host) {
         return "PROXY 127.0.0.1:8787; DIRECT";
     }
     
-    return "DIRECT";
+    return findDefaultProxyForURL(url, host);
 }
+
+defaultProxy


### PR DESCRIPTION
Users who want to use local proxy settings need modify proxy_off.pac
with their customization.
Lantern may use this local proxy setting to bootstrap or proxy service.
Remember: Users may need use UI to update running .pac through changing
Lantern proxy sites.
And user defined proxy_off.pac can be this,
function FindProxyForURL(url, host) {
return "PROXY 172.1.2.3:8080; DIRECT";
}
or like this complicate one,
var localDomains = new Array();
var j=0;
localDomains[j++] = "compay.com";
localDomains[j++] = "compay.net";
localDomains[j++] = "172.*";
for(j in localDomains) {
localDomains[j] = localDomains[j].split(/./).join(".");
}
var localDomainsRegx = new RegExp("(" + localDomains.join("|") + ")$",
"i");
function FindProxyForURL(url, host) {
if( host == "localhost" ||
host == "127.0.0.1"||
localDomainsRegx.exec(host)) {
return "DIRECT";
}
return "PROXY 172.1.2.3:8080; DIRECT";
}
