### PR TITLE
Fixed: uname option to recognize hardware architecture

### DIFF
--- a/quickRun.bash
+++ b/quickRun.bash
@@ -33,7 +33,7 @@ fi
 
 if [ $(uname) == "Linux" ]
 then
-  proc=`uname -p`
+  proc=`uname -m`
   javaArgs="-Djava.library.path=lib/linux/$proc $javaArgs"
 fi
 


### PR DESCRIPTION
`uname -p` gives processor information

```
uname -p
Intel(R) Core(TM) i3-2130 CPU @ 3.40GHz
```

While `uname -m` gives CPU architecture information (bit-ness of CPU)

```
uname -m
x86_64
```

From the context of this statement, `uname -m` should be used here.
