### PR TITLE
Add: path_candidates for Gentoo Linux

### DIFF
--- a/src/main/java/org/lantern/ChromeRunner.java
+++ b/src/main/java/org/lantern/ChromeRunner.java
@@ -68,6 +68,7 @@ public class ChromeRunner {
             path_candidates.add("/usr/bin/google-chrome-unstable");
             path_candidates.add("/usr/bin/chromium");
             path_candidates.add("/usr/bin/chromium-browser");
+            path_candidates.add("/usr/bin/google-chrome-beta");
             for (String path: path_candidates) {
                 final File opt = new File(path);
                 if (opt.isFile() && opt.canExecute()) return path;


### PR DESCRIPTION
Gentoo Linux uses `google-chrome-beta` as the filename of executable.
