### PR TITLE
Fixed CredentialException propagation and authorize modal setting closes #1271

### DIFF
--- a/src/main/java/org/lantern/Launcher.java
+++ b/src/main/java/org/lantern/Launcher.java
@@ -587,9 +587,10 @@ public class Launcher {
                     } catch (final IOException e) {
                         LOG.debug("Could not login", e);
                     } catch (final CredentialException e) {
-                        LOG.debug("Bad credentials");
+                        LOG.debug("Bad credentials", e);
+                        Events.syncModal(model, Modal.authorize);
                     } catch (final NotInClosedBetaException e) {
-                        LOG.warn("Not in closed beta!!");
+                        LOG.warn("Not in closed beta!!", e);
                         internalState.setNotInvited(true);
                     }
                 }

--- a/src/main/java/org/lantern/endpoints/FriendApi.java
+++ b/src/main/java/org/lantern/endpoints/FriendApi.java
@@ -2,6 +2,8 @@ package org.lantern.endpoints;
 
 import java.io.IOException;
 
+import javax.security.auth.login.CredentialException;
+
 import org.lantern.JsonUtils;
 import org.lantern.LanternClientConstants;
 import org.lantern.LanternUtils;
@@ -39,8 +41,9 @@ public class FriendApi {
      * 
      * @return List of all entities persisted.
      * @throws IOException If there's an error making the call to the server.
+     * @throws CredentialException If the user's credentials are invalid.
      */
-    public ClientFriend[] listFriends() throws IOException {
+    public ClientFriend[] listFriends() throws IOException, CredentialException {
         if (LanternUtils.isFallbackProxy()) {
             log.debug("Ignoring friends call from fallback");
             return null;
@@ -57,8 +60,10 @@ public class FriendApi {
      * @param id The primary key of the java bean.
      * @return The entity with primary key id.
      * @throws IOException If there's an error making the call to the server.
+     * @throws CredentialException If the user's credentials are invalid.
      */
-    public ClientFriend getFriend(final long id) throws IOException {
+    public ClientFriend getFriend(final long id) throws IOException, 
+        CredentialException {
         if (LanternUtils.isFallbackProxy()) {
             log.debug("Ignoring friends call from fallback");
             return null;
@@ -75,9 +80,10 @@ public class FriendApi {
      * @param task The entity to be inserted.
      * @return The inserted entity.
      * @throws IOException If there's an error making the call to the server.
+     * @throws CredentialException If the user's credentials are invalid.
      */
     public ClientFriend insertFriend(final ClientFriend friend)
-            throws IOException {
+            throws IOException, CredentialException {
         if (LanternUtils.isFallbackProxy()) {
             log.debug("Ignoring friends call from fallback");
             return friend;
@@ -93,8 +99,10 @@ public class FriendApi {
      * @param friend The entity to be updated.
      * @return The updated entity.
      * @throws IOException If there's an error making the call to the server.
+     * @throws CredentialException If the user's credentials are invalid.
      */
-    public ClientFriend updateFriend(final ClientFriend friend) throws IOException {
+    public ClientFriend updateFriend(final ClientFriend friend) 
+            throws IOException, CredentialException {
         if (LanternUtils.isFallbackProxy()) {
             log.debug("Ignoring friends call from fallback");
             return friend;
@@ -105,7 +113,7 @@ public class FriendApi {
     }
 
     private ClientFriend post(final String url, final Friend friend) 
-            throws IOException {
+            throws IOException, CredentialException {
         final String json = JsonUtils.jsonify(friend);
         final String content = this.oauth.postRequest(url, json);
         return processResponse(content, ClientFriend.class);
@@ -118,8 +126,10 @@ public class FriendApi {
      * @param id The primary key of the entity to be deleted.
      * @return The deleted entity.
      * @throws IOException If there's an error making the call to the server.
+     * @throws CredentialException If the user's credentials are invalid.
      */
-    public void removeFriend(final long id) throws IOException {
+    public void removeFriend(final long id) throws IOException, 
+        CredentialException {
         if (LanternUtils.isFallbackProxy()) {
             log.debug("Ignoring friends call from fallback");
             return;

--- a/src/main/java/org/lantern/oauth/LanternSaslGoogleOAuth2Mechanism.java
+++ b/src/main/java/org/lantern/oauth/LanternSaslGoogleOAuth2Mechanism.java
@@ -3,6 +3,7 @@ package org.lantern.oauth;
 import java.io.IOException;
 
 import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.login.CredentialException;
 
 import org.jivesoftware.smack.ConnectionConfiguration;
 import org.jivesoftware.smack.SASLAuthentication;
@@ -56,7 +57,13 @@ public class LanternSaslGoogleOAuth2Mechanism extends SASLMechanism {
         this.authenticationId = username;
         this.hostname = host;
 
-        final TokenResponse refreshed = oauthUtils.oauthTokens();
+        final TokenResponse refreshed;
+        try {
+            refreshed = oauthUtils.oauthTokens();
+        } catch (CredentialException e) {
+            log.debug("Credentials error", e);
+            throw new XMPPException("Credentials error", e);
+        }
         final String accessToken = refreshed.getAccessToken();
 
         final String raw = "\0" + this.authenticationId + "\0" + accessToken;


### PR DESCRIPTION
Changed to propagate CredentialExceptions so we correctly discontinue persistent logins and added switch to authorize modal on bad oauth tokens
