### PR TITLE
Changed to use a single thread for most public roster methods to avoid race conditions closes #1309

### DIFF
--- a/src/main/java/org/lantern/util/Threads.java
+++ b/src/main/java/org/lantern/util/Threads.java
@@ -56,4 +56,9 @@ public class Threads {
         return Executors.newSingleThreadScheduledExecutor(newDaemonThreadFactory(name));
     }
     
+    public static ExecutorService newSingleThreadExecutor(
+            String name) {
+        return Executors.newSingleThreadExecutor(newDaemonThreadFactory(name));
+    }
+    
 }


### PR DESCRIPTION
Also rearranged methods a bit to more clearly separate the main public interface methods that end up causing race conditions with the roster.
