### PR TITLE
Proof-of-concept refactor for sending packets

### DIFF
--- a/src/main/java/org/lantern/Roster.java
+++ b/src/main/java/org/lantern/Roster.java
@@ -394,7 +394,7 @@ public class Roster implements RosterListener {
             ad = new LanternKscopeAdvertisement(user, address, ms.getHostAddress());
         }
 
-        final TrustGraphNode tgn = new LanternTrustGraphNode(xmppHandler);
+        final TrustGraphNode tgn = new LanternTrustGraphNode();
         // set ttl to max for now
         ad.setTtl(tgn.getMaxRouteLength());
         final String adPayload = JsonUtils.jsonify(ad);

--- a/src/main/java/org/lantern/XmppHandler.java
+++ b/src/main/java/org/lantern/XmppHandler.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 
 import javax.security.auth.login.CredentialException;
 
-import org.jivesoftware.smack.packet.Packet;
 import org.jivesoftware.smack.packet.Presence;
 import org.lastbamboo.common.ice.MappedServerSocket;
 import org.littleshoot.commom.xmpp.XmppP2PClient;
@@ -69,7 +68,7 @@ public interface XmppHandler extends LanternService {
 
     MappedServerSocket getMappedServer();
 
-    void sendPacket(Packet packet);
+    //void sendPacket(Packet packet);
     
     ProxyTracker getProxyTracker();
 }

--- a/src/main/java/org/lantern/kscope/DefaultKscopeAdHandler.java
+++ b/src/main/java/org/lantern/kscope/DefaultKscopeAdHandler.java
@@ -15,7 +15,6 @@ import org.lantern.JsonUtils;
 import org.lantern.LanternTrustStore;
 import org.lantern.LanternUtils;
 import org.lantern.ProxyTracker;
-import org.lantern.XmppHandler;
 import org.lantern.event.Events;
 import org.lantern.event.KscopeAdEvent;
 import org.lantern.network.InstanceInfo;
@@ -33,7 +32,6 @@ public class DefaultKscopeAdHandler implements KscopeAdHandler,
         NetworkTrackerListener<URI, ReceivedKScopeAd> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final XmppHandler xmppHandler;
 
     private final ProxyTracker proxyTracker;
     private final LanternTrustStore trustStore;
@@ -45,12 +43,10 @@ public class DefaultKscopeAdHandler implements KscopeAdHandler,
             final ProxyTracker proxyTracker,
             final LanternTrustStore trustStore,
             final RandomRoutingTable routingTable,
-            final XmppHandler xmppHandler,
             final NetworkTracker<String, URI, ReceivedKScopeAd> networkTracker) {
         this.proxyTracker = proxyTracker;
         this.trustStore = trustStore;
         this.routingTable = routingTable;
-        this.xmppHandler = xmppHandler;
         this.networkTracker = networkTracker;
 
         this.networkTracker.addListener(this);
@@ -136,8 +132,7 @@ public class DefaultKscopeAdHandler implements KscopeAdHandler,
                         relayAd.getTtl()
                 );
 
-        final TrustGraphNode tgn =
-                new LanternTrustGraphNode(xmppHandler);
+        final TrustGraphNode tgn = new LanternTrustGraphNode();
 
         tgn.sendAdvertisement(message, nextNid, relayAd.getTtl());
     }

--- a/src/main/java/org/lantern/kscope/LanternTrustGraphNode.java
+++ b/src/main/java/org/lantern/kscope/LanternTrustGraphNode.java
@@ -6,7 +6,7 @@ import org.kaleidoscope.TrustGraphNode;
 import org.kaleidoscope.TrustGraphNodeId;
 import org.lantern.JsonUtils;
 import org.lantern.LanternConstants;
-import org.lantern.XmppHandler;
+import org.lantern.event.Events;
 import org.lastbamboo.common.p2p.P2PConstants;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -24,12 +24,6 @@ public class LanternTrustGraphNode extends TrustGraphNode {
     private static final int MAX_ROUTE_LENGTH =  4; // aka "w_max"
     private static final int MIN_ROUTE_LENGTH =   2; // aka "w_min"
 
-    private final XmppHandler handler;
-
-    public LanternTrustGraphNode(final XmppHandler handler) {
-        this.handler = handler;
-    }
-    
     @Override
     public void advertiseSelf(TrustGraphAdvertisement message) {
         super.advertiseSelf(message);
@@ -61,7 +55,7 @@ public class LanternTrustGraphNode extends TrustGraphNode {
         msg.setTo(id);
         log.debug("Sending kscope ad to {}.", id);
         log.debug("-- Payload: {}", payload);
-        handler.sendPacket(msg);
+        Events.asyncEventBus().post(msg);
     }
 
     @Override

--- a/src/test/java/org/lantern/TestingUtils.java
+++ b/src/test/java/org/lantern/TestingUtils.java
@@ -165,7 +165,7 @@ public class TestingUtils {
             new DefaultProxyTracker(model, peerFactory, trustStore);
         final KscopeAdHandler kscopeAdHandler = 
             new DefaultKscopeAdHandler(proxyTracker, trustStore, routingTable, 
-                null, networkTracker);
+                networkTracker);
         final NatPmpService natPmpService = new NatPmpService() {
             @Override
             public void shutdown() {}


### PR DESCRIPTION
I decided to break this change up into more digestible pieces, but the general idea here is to make greater use of queues to further decouple core Lantern classes. The key conceptual change is illustrated in the following:

``` java
-    @Override
+    @Subscribe
      public void sendPacket(final Packet packet) {
```

The @Override is only relevant in that removing it means we're removing that method from the implemented interface. Since classes only know about that method via the interface, this effectively means that we're saying that method should now never be called. 

It will now only be called if another class creates a Packet "event" via something like the following:

``` java
Events.asyncEventBus().post(packet);
```

This is handy because any class that wants to send an XMPP message can now be fully decoupled from the actual class that sends the message (DefaultXmppHandler). This is very similar to actors in Akka, which is really borrowed from Erlang (although without the same degree of fault tolerance), and it makes concurrency easier because all of this stuff can be happening on whatever thread you feel like without thinking about it (as long as the data in the queues is immutable). We're basically using the Guava events library as a poor man's Akka, but Guava events are pretty handy in this regard because they're super easy to use and less disruptive to the code (plus Akka is friggin' huge!).

The only downsides I think are potential performance implications and lack of compile time checking (you're effectively calling a method on another actor without making sure of that at compile time).

Anyway, we could take this much further to fully decouple most modules in Lantern and to have them simply pass data between them, so the focus becomes that flow of data.
