### PR TITLE
Re-shuffling code partially using events to further decouple roster, xmpphandler, and friendshandler

### DIFF
--- a/src/main/java/org/lantern/Whitelist.java
+++ b/src/main/java/org/lantern/Whitelist.java
@@ -11,6 +11,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.TreeSet;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.codehaus.jackson.map.annotate.JsonView;
 import org.lantern.annotation.Keep;
@@ -104,7 +105,7 @@ public class Whitelist {
         } catch (Throwable t) {
             log.warn("Unable to apply whitelist {}", whitelistPath, t);
         } finally {
-
+            IOUtils.closeQuietly(reader);
         }
     }
 

--- a/src/main/java/org/lantern/XmppHandler.java
+++ b/src/main/java/org/lantern/XmppHandler.java
@@ -54,10 +54,6 @@ public interface XmppHandler extends LanternService {
 
     void addToRoster(String jid);
 
-    void subscribe(String jid);
-
-    void subscribed(String jid);
-
     @Override
     void start();
 
@@ -68,7 +64,5 @@ public interface XmppHandler extends LanternService {
 
     MappedServerSocket getMappedServer();
 
-    //void sendPacket(Packet packet);
-    
     ProxyTracker getProxyTracker();
 }

--- a/src/main/java/org/lantern/event/IncomingPeerMessageEvent.java
+++ b/src/main/java/org/lantern/event/IncomingPeerMessageEvent.java
@@ -1,0 +1,17 @@
+package org.lantern.event;
+
+import org.jivesoftware.smack.packet.Presence;
+
+public class IncomingPeerMessageEvent {
+
+    private final Presence presence;
+
+    public IncomingPeerMessageEvent(final Presence presence) {
+        this.presence = presence;
+    }
+
+    public Presence getPresence() {
+        return presence;
+    }
+
+}

--- a/src/main/java/org/lantern/event/TypedPacketEvent.java
+++ b/src/main/java/org/lantern/event/TypedPacketEvent.java
@@ -1,0 +1,22 @@
+package org.lantern.event;
+
+import org.jivesoftware.smack.packet.Presence.Type;
+
+public class TypedPacketEvent {
+
+    private final String recipient;
+    private final Type type;
+
+    public TypedPacketEvent(final String recipient, final Type type) {
+        this.recipient = recipient;
+        this.type = type;
+    }
+
+    public String getRecipient() {
+        return recipient;
+    }
+
+    public Type getType() {
+        return type;
+    }
+}

--- a/src/test/java/org/lantern/TestingUtils.java
+++ b/src/test/java/org/lantern/TestingUtils.java
@@ -195,7 +195,7 @@ public class TestingUtils {
         
         final XmppHandler xmppHandler = new DefaultXmppHandler(model,
             updateTimer, stats, ksm, socketsUtil, xmppUtil, modelUtils,
-            roster, proxyTracker, kscopeAdHandler, natPmpService, upnpService,
+            proxyTracker, kscopeAdHandler, natPmpService, upnpService,
             new UdtServerFiveTupleListener(null, model),
             friendsHandler, networkTracker, censored);
         return xmppHandler;


### PR DESCRIPTION
Better separation of concerns, decouples roster from DefaultXmppHandler a bit. Will comment more inline.
