### PR TITLE
Fall back when AppIndicator fails

### DIFF
--- a/src/main/java/org/lantern/AppIndicatorTray.java
+++ b/src/main/java/org/lantern/AppIndicatorTray.java
@@ -51,20 +51,13 @@ public class AppIndicatorTray implements SystemTray {
     private static AppIndicator libappindicator = null;
     
     static {
-        if (SystemUtils.IS_OS_LINUX) {
-            try {
-                libappindicator = (AppIndicator) Native.loadLibrary("appindicator", AppIndicator.class);
-                libgtk = (Gtk) Native.loadLibrary("gtk-x11-2.0", Gtk.class);
-                libgobject = (Gobject) Native.loadLibrary("gobject-2.0", Gobject.class);
-                libglib = (Glib) Native.loadLibrary("glib-2.0", Glib.class);
-                //libunique = (Unique) Native.loadLibrary("unique-3.0", Unique.class);
-                
-                libgtk.gtk_init(0, null);
-            }
-            catch (final Throwable ex) {
-                LOG.warn("no supported version of appindicator libs found", ex);
-            }
-        }
+        libappindicator = (AppIndicator) Native.loadLibrary("appindicator", AppIndicator.class);
+        libgtk = (Gtk) Native.loadLibrary("gtk-x11-2.0", Gtk.class);
+        libgobject = (Gobject) Native.loadLibrary("gobject-2.0", Gobject.class);
+        libglib = (Glib) Native.loadLibrary("glib-2.0", Glib.class);
+        //libunique = (Unique) Native.loadLibrary("unique-3.0", Unique.class);
+
+        libgtk.gtk_init(0, null);
     }
     
     @Override

--- a/src/main/java/org/lantern/LanternModule.java
+++ b/src/main/java/org/lantern/LanternModule.java
@@ -195,10 +195,14 @@ public class LanternModule extends AbstractModule {
     SystemTray provideSystemTray(final BrowserService browserService,
         final Model model) {
         if (SystemUtils.IS_OS_LINUX) {
-            return new AppIndicatorTray(browserService, model);
-        } else {
-            return new SystemTrayImpl(browserService, model);
+            try {
+                return new AppIndicatorTray(browserService, model);
+            } catch (final java.lang.UnsatisfiedLinkError ex) {
+                log.warn("no supported version of appindicator libs found, "
+                         + "falling back to generic system tray");
+            }
         }
+        return new SystemTrayImpl(browserService, model);
     }
 
     @Provides @Singleton


### PR DESCRIPTION
Makes lantern work in non-Unity Linux desktops.
