### PR TITLE
Keystore password fixes #1546

### DIFF
--- a/src/main/java/org/lantern/LanternKeyStoreManager.java
+++ b/src/main/java/org/lantern/LanternKeyStoreManager.java
@@ -38,14 +38,8 @@ public class LanternKeyStoreManager implements LanternService {
     
     private final File CERT_FILE;
 
-    private static final String PASS;
-
-    static {
-        //initialize PASS to a value with 128 bits of entropy
-        byte[] bytes = new byte[16];
-        new SecureRandom().nextBytes(bytes);
-        PASS = Base64.encodeBase64URLSafeString(bytes);
-    }
+    private static final String PASS = 
+            String.valueOf(new SecureRandom().nextLong());
 
     private static final String KEYSIZE = "2048";
     


### PR DESCRIPTION
Changed back to just using a secure random long.
