### PR TITLE
Added an error log when sending user back to authorize in response to a ...

### DIFF
--- a/src/main/java/org/lantern/XmppConnector.java
+++ b/src/main/java/org/lantern/XmppConnector.java
@@ -51,7 +51,7 @@ public class XmppConnector {
     }
 
     private void connect() {
-        log.debug("Setting gtalk authorized");
+        log.debug("Connecting to XMPP");
 
         if (!model.isSetupComplete()) {
             log.debug("Still setting up...");
@@ -92,7 +92,6 @@ public class XmppConnector {
             xmppHandler.connect();
         } catch (final CredentialException e) {
             log.error("Could not log in with OAUTH?", e);
-            Events.syncModal(model, Modal.authorize);
         } catch (final IOException e) {
             log.info("We can't connect (internet connection died?). " +
                 "The XMPP layer should automatically retry.", e);

--- a/src/main/java/org/lantern/http/GoogleOauth2CallbackServlet.java
+++ b/src/main/java/org/lantern/http/GoogleOauth2CallbackServlet.java
@@ -118,7 +118,7 @@ public class GoogleOauth2CallbackServlet extends HttpServlet {
             // This will happen when the user cancels oauth.
             log.debug("Did not get authorization code in params: {}", params);
             final String error = params.get("error");
-            log.debug("Got error: {}", error);
+            log.error("Got error: {}", error);
             log.debug("Setting modal on model: {}", model);
             this.model.setModal(Modal.authorize);
             redirectToDashboard(resp);


### PR DESCRIPTION
...bad oauth code and don't send the user back when we can't log in to Google Talk closes #1830 

We really don't need Google Talk as an essential service anymore, so we don't need to re-authorize the user if we can't connect.
