### PR TITLE
Send user back to the login screen if credentials aren't working closes #1844

### DIFF
--- a/src/main/java/org/lantern/XmppConnector.java
+++ b/src/main/java/org/lantern/XmppConnector.java
@@ -92,6 +92,7 @@ public class XmppConnector {
             xmppHandler.connect();
         } catch (final CredentialException e) {
             log.error("Could not log in with OAUTH?", e);
+            Events.syncModal(model, Modal.authorize);
         } catch (final IOException e) {
             log.info("We can't connect (internet connection died?). " +
                 "The XMPP layer should automatically retry.", e);


### PR DESCRIPTION
Pretty basic here if you want to review @oxtoacart. The theory with the prior change was that CredentialException was somehow being thrown when we in fact just couldn't find a proxy. That appears not to be the case, however, and we get CredentialException when the credentials are in fact incorrect. 

Ideally we'd add more messaging, but this will solve the problem I think fine, particularly given that the user has to actively invalidate her token and will likely expect something to not work as normal.
