### PR TITLE
getlantern/lantern#1969 Not returning any friends until load succeeds

### DIFF
--- a/src/main/resources/log4j.properties
+++ b/src/main/resources/log4j.properties
@@ -43,7 +43,6 @@ log4j.logger.org.lantern.state=INFO
 log4j.logger.org.lantern.state.SyncService=INFO
 log4j.logger.org.lantern.state.CometDSyncStrategy=WARN
 log4j.logger.org.lantern.state.TransfersIo=WARN
-log4j.logger.org.lantern.state.DefaultFriendsHandler=DEBUG
 log4j.logger.org.lantern.StatsTracker=WARN
 log4j.logger.org.lantern.DefaultProxyTracker=INFO
 log4j.logger.org.lantern.proxy.DispatchingChainedProxyManager=DEBUG


### PR DESCRIPTION
Closes #1969 

I should note that I tested this to make sure that the happy path works (bring up friends dialog, add friend, reject friend).  The only way that I was able to reproduce the bug itself was by messing with the logic on the client that distinguishes between a known friend and a new suggestion.
