### PR TITLE
Issue 2095 - UI relays browser name

### DIFF
--- a/src/main/java/org/lantern/SystemTrayImpl.java
+++ b/src/main/java/org/lantern/SystemTrayImpl.java
@@ -149,7 +149,7 @@ public class SystemTrayImpl implements org.lantern.SystemTray {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     log.debug("Reopening browser?");
-                    if (syncService.getBrowserType().equals("Chrome") &&
+                    if (syncService.getClientBrowser().equals("Chrome") &&
                         syncService.clientSynced()) {
                         syncService.sendClientPing();
                     } else {

--- a/src/main/java/org/lantern/SystemTrayImpl.java
+++ b/src/main/java/org/lantern/SystemTrayImpl.java
@@ -149,13 +149,11 @@ public class SystemTrayImpl implements org.lantern.SystemTray {
                 @Override
                 public void actionPerformed(ActionEvent e) {
                     log.debug("Reopening browser?");
-                    if (!syncService.clientSynced()) {
-                        /* only re-open if UI 
-                         * isn't already open 
-                         */
-                        browserService.reopenBrowser();
-                    } else {
+                    if (syncService.getBrowserType().equals("Chrome") &&
+                        syncService.clientSynced()) {
                         syncService.sendClientPing();
+                    } else {
+                        browserService.reopenBrowser();
                     }
                 }
             });

--- a/src/main/java/org/lantern/http/InteractionServlet.java
+++ b/src/main/java/org/lantern/http/InteractionServlet.java
@@ -217,8 +217,8 @@ public class InteractionServlet extends HttpServlet {
         }
 
         if (inter == Interaction.BROWSERREF) {
-            final String browserType = JsonUtils.getValueFromJson("type", json);
-            syncService.setBrowserType(browserType);
+            final String clientBrowser = JsonUtils.getValueFromJson("type", json);
+            syncService.setClientBrowser(clientBrowser);
             return;
         }
 

--- a/src/main/java/org/lantern/http/InteractionServlet.java
+++ b/src/main/java/org/lantern/http/InteractionServlet.java
@@ -32,6 +32,7 @@ import org.lantern.state.FriendsHandler;
 import org.lantern.state.InternalState;
 import org.lantern.state.JsonModelModifier;
 import org.lantern.state.LocationChangedEvent;
+import org.lantern.state.SyncService;
 import org.lantern.state.Modal;
 import org.lantern.state.Mode;
 import org.lantern.state.Model;
@@ -78,7 +79,8 @@ public class InteractionServlet extends HttpServlet {
         UPDATEAVAILABLE,
         CHANGELANG, // TODO https://github.com/getlantern/lantern/issues/1088
         REJECT,
-        ROUTERCONFIG
+        ROUTERCONFIG,
+        BROWSERREF
     }
 
     // modals the user can switch to from other modals
@@ -108,6 +110,8 @@ public class InteractionServlet extends HttpServlet {
 
     private final Censored censored;
 
+    private final SyncService syncService;
+
     private final LogglyHelper logglyHelper;
 
     private final FriendsHandler friender;
@@ -121,6 +125,7 @@ public class InteractionServlet extends HttpServlet {
         final ModelService modelService,
         final InternalState internalState,
         final ModelIo modelIo, 
+        final SyncService syncService,
         final Censored censored, final LogglyHelper logglyHelper,
         final FriendsHandler friender,
         final Messages msgs,
@@ -134,6 +139,7 @@ public class InteractionServlet extends HttpServlet {
         this.friender = friender;
         this.msgs = msgs;
         this.refreshToken = refreshToken;
+        this.syncService = syncService;
         Events.register(this);
     }
 
@@ -208,6 +214,12 @@ public class InteractionServlet extends HttpServlet {
             } catch (InterruptedException e) {
                 log.error("Could not open gateway?", e);
             }
+        }
+
+        if (inter == Interaction.BROWSERREF) {
+            final String browserType = JsonUtils.getValueFromJson("type", json);
+            syncService.setBrowserType(browserType);
+            return;
         }
 
         if (inter == Interaction.URL) {

--- a/src/main/java/org/lantern/state/SyncService.java
+++ b/src/main/java/org/lantern/state/SyncService.java
@@ -47,7 +47,7 @@ public class SyncService implements LanternService {
 
     private boolean clientSynced;
     
-    private String browserType;
+    private String clientBrowser;
 
     /**
      * Creates a new sync service.
@@ -62,7 +62,7 @@ public class SyncService implements LanternService {
         this.model = model;
         this.timer = timer;
         this.clientSynced = false;
-        this.browserType = "unknown";
+        this.clientBrowser = "unknown";
         // Make sure the config class is added as a listener before this class.
         Events.register(this);
     }
@@ -100,12 +100,12 @@ public class SyncService implements LanternService {
         return clientSynced;
     }
 
-    public void setBrowserType(String browserType) {
-        this.browserType = browserType;
+    public void setClientBrowser(String clientBrowser) {
+        this.clientBrowser = clientBrowser;
     }
 
-    public String getBrowserType() {
-        return this.browserType;
+    public String getClientBrowser() {
+        return this.clientBrowser;
     }
 
     @Configure("/service/sync")

--- a/src/main/java/org/lantern/state/SyncService.java
+++ b/src/main/java/org/lantern/state/SyncService.java
@@ -46,6 +46,8 @@ public class SyncService implements LanternService {
     private final Timer timer;
 
     private boolean clientSynced;
+    
+    private String browserType;
 
     /**
      * Creates a new sync service.
@@ -60,6 +62,7 @@ public class SyncService implements LanternService {
         this.model = model;
         this.timer = timer;
         this.clientSynced = false;
+        this.browserType = "unknown";
         // Make sure the config class is added as a listener before this class.
         Events.register(this);
     }
@@ -95,6 +98,14 @@ public class SyncService implements LanternService {
 
     public boolean clientSynced() {
         return clientSynced;
+    }
+
+    public void setBrowserType(String browserType) {
+        this.browserType = browserType;
+    }
+
+    public String getBrowserType() {
+        return this.browserType;
     }
 
     @Configure("/service/sync")


### PR DESCRIPTION
Changes to store browser name the UI is running in. This also includes updates to send an alert when the browser is Chrome and the UI is already open in an existing tab; otherwise, the UI is always opened in a new tab.