### PR TITLE
use untrusted dialers if no trusted one available

### DIFF
--- a/src/github.com/getlantern/flashlight/genconfig/cloud.yaml.tmpl
+++ b/src/github.com/getlantern/flashlight/genconfig/cloud.yaml.tmpl
@@ -17,8 +17,8 @@ client:
       authtoken: "{{.auth_token}}"
       pipelined: true
       weight: 1000000
-      qos: 10{{end}}
-      trusted: true
+      qos: 10
+      trusted: true{{end}}
   masqueradesets:
     cloudflare:{{range .masquerades}}
     - domain: {{.Domain}}

--- a/src/github.com/getlantern/flashlight/genconfig/fallbacks.go.tmpl
+++ b/src/github.com/getlantern/flashlight/genconfig/fallbacks.go.tmpl
@@ -12,5 +12,6 @@ var fallbacks = map[string]*client.ChainedServerInfo{ {{range .fallbacks}}
     Pipelined: true,
     Weight:    1000000,
     QOS:       10,
+    trusted:   true,
   }, {{end}}
 }


### PR DESCRIPTION
Resolves #2440

We also need to run genconfig.bash again to mark all current servers as trusted. Trying…