### PR TITLE
Adding "release" target and removing some responsabilities from "release-qa"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GO := $(shell which go 2> /dev/null)
 NODE := $(shell which node 2> /dev/null)
 NPM := $(shell which npm 2> /dev/null)
 S3CMD := $(shell which s3cmd 2> /dev/null)
+WGET := $(shell which wget 2> /dev/null)
 RUBY := $(shell which ruby 2> /dev/null)
 
 APPDMG := $(shell which appdmg 2> /dev/null)
@@ -198,7 +199,10 @@ system-checks:
 	if [[ -z "$(GO)" ]]; then echo 'Missing "go" command.'; exit 1; fi
 
 require-s3cmd:
-	@if [[ -z "$(S3CMD)" ]]; then echo 'Missing "s3cmd" command.. See https://github.com/s3tools/s3cmd/blob/master/INSTALL'; exit 1; fi
+	@if [[ -z "$(S3CMD)" ]]; then echo 'Missing "s3cmd" command. See https://github.com/s3tools/s3cmd/blob/master/INSTALL'; exit 1; fi
+
+require-wget:
+	@if [[ -z "$(WGET)" ]]; then echo 'Missing "wget" command.'; exit 1; fi
 
 require-mercurial:
 	@if [[ -z "$$(which hg 2> /dev/null)" ]]; then echo 'Missing "hg" command.'; exit 1; fi
@@ -304,12 +308,9 @@ binaries: docker genassets linux windows darwin
 
 packages: require-version require-secrets clean binaries package-windows package-linux package-darwin
 
-release-qa: require-tag require-gh-token require-s3cmd require-ruby
+release-qa: require-tag require-s3cmd
 	@BASE_NAME="lantern-installer-qa" && \
 	rm -f $$BASE_NAME* && \
-	$(RUBY) ./installer-resources/tools/createrelease.rb "$(GH_USER)" "$(GH_RELEASE_REPOSITORY)" $$TAG && \
-	git tag -a "$$TAG" -f --annotate -m"Tagged $$VERSION" && \
-	git push --tags -f && \
 	cp lantern-installer.exe $$BASE_NAME.exe && \
 	cp Lantern.dmg $$BASE_NAME.dmg && \
 	cp lantern_*386.deb $$BASE_NAME-32-bit.deb && \
@@ -325,6 +326,36 @@ release-qa: require-tag require-gh-token require-s3cmd require-ruby
 		echo "Copying $$VERSIONED" && \
 		$(S3CMD) cp s3://$(S3_BUCKET)/$$NAME s3://$(S3_BUCKET)/$$VERSIONED; \
 	done && \
+	for NAME in $$(ls -1 update_darwin_amd64.bz2 update_linux_386.bz2 update_linux_amd64.bz2 update_windows_386.bz2); do \
+		echo "Copying update binary $$NAME..." && \
+		$(S3CMD) put -P $$NAME s3://$(S3_BUCKET); \
+	done
+
+release-beta: require-s3cmd
+	@BASE_NAME="lantern-installer-qa" && \
+	BETA_BASE_NAME="lantern-installer-beta" && \
+	for URL in $$($(S3CMD) ls s3://$(S3_BUCKET)/ | grep $$BASE_NAME | awk '{print $$4}'); do \
+		NAME=$$(basename $$URL) && \
+		BETA=$$(echo $$NAME | sed s/"$$BASE_NAME"/$$BETA_BASE_NAME/) && \
+		$(S3CMD) cp s3://$(S3_BUCKET)/$$NAME s3://$(S3_BUCKET)/$$BETA; \
+	done
+
+release: require-tag require-s3cmd require-gh-token require-wget require-ruby
+	@BASE_NAME="lantern-installer-beta" && \
+	PROD_BASE_NAME="lantern-installer" && \
+	for URL in $$($(S3CMD) ls s3://$(S3_BUCKET)/ | grep $$BASE_NAME | awk '{print $$4}'); do \
+		NAME=$$(basename $$URL) && \
+		PROD=$$(echo $$NAME | sed s/"$$BASE_NAME"/$$PROD_BASE_NAME/) && \
+		$(S3CMD) cp s3://$(S3_BUCKET)/$$NAME s3://$(S3_BUCKET)/$$PROD; \
+	done && \
+	for URL in $$($(S3CMD) ls s3://$(S3_BUCKET)/ | grep update_ | awk '{print $$4}'); do \
+		NAME=$$(basename $$URL) && \
+		URL=https://$(S3_BUCKET).s3.amazonaws.com/$$NAME && \
+		$(WGET) -O $$NAME $$URL; \
+	done && \
+	$(RUBY) ./installer-resources/tools/createrelease.rb "$(GH_USER)" "$(GH_RELEASE_REPOSITORY)" $$TAG && \
+	git tag -a "$$TAG" -f --annotate -m"Tagged $$VERSION" && \
+	git push --tags -f && \
 	echo "Uploading Windows binary for auto-updates" && \
 	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_windows_386.bz2 && \
 	echo "Uploading OSX binary for auto-updates" && \
@@ -332,15 +363,6 @@ release-qa: require-tag require-gh-token require-s3cmd require-ruby
 	echo "Uploading Linux binaries for auto-updates" && \
 	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_linux_amd64.bz2 && \
 	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_linux_386.bz2
-
-release-beta:
-	@BASE_NAME="lantern-installer-qa" && \
-	BETA_BASE_NAME="lantern-installer-beta" && \
-	for NAME in $$(ls -1 $$BASE_NAME.exe $$BASE_NAME.dmg $$BASE_NAME-32-bit.deb $$BASE_NAME-64-bit.deb); do \
-		BETA=$$(echo $$NAME | sed s/"$$BASE_NAME"/$$BETA_BASE_NAME/) && \
-		echo "Copying alpha $$NAME to beta $$BETA..." && \
-		$(S3CMD) cp s3://$(S3_BUCKET)/$$NAME s3://$(S3_BUCKET)/$$BETA; \
-	done
 
 update-icons:
 	@(which go-bindata >/dev/null) || (echo 'Missing command "go-bindata". Sett https://github.com/jteeuwen/go-bindata.' && exit 1) && \

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,8 @@ PACKAGE_VENDOR := Brave New Software Project, Inc
 PACKAGE_MAINTAINER := Lantern Team <team@getlantern.org>
 PACKAGE_URL := https://www.getlantern.org
 
+LANTERN_BINARIES_PATH ?= ../lantern-binaries
+
 GH_USER := getlantern
 #GH_USER := xiam
 
@@ -151,6 +153,12 @@ require-secrets:
 	@if [[ -z "$$BNS_CERT_PASS" ]]; then echo "BNS_CERT_PASS environment value is required."; exit 1; fi && \
 	if [[ -z "$$SECRETS_DIR" ]]; then echo "SECRETS_DIR environment value is required."; exit 1; fi
 
+require-lantern-binaries:
+	@if [[ ! -d "$(LANTERN_BINARIES_PATH)" ]]; then \
+		echo "Missing lantern binaries repository (https://github.com/getlantern/lantern-binaries). Set it with LANTERN_BINARIES_PATH=\"/path/to/repository\" make ..." && \
+		exit 1; \
+	fi
+
 docker-package-linux-386: docker-linux-386 docker-package-debian-386
 
 docker-package-linux-amd64: docker-linux-amd64 docker-package-debian-amd64
@@ -199,7 +207,7 @@ system-checks:
 	if [[ -z "$(GO)" ]]; then echo 'Missing "go" command.'; exit 1; fi
 
 require-s3cmd:
-	@if [[ -z "$(S3CMD)" ]]; then echo 'Missing "s3cmd" command. See https://github.com/s3tools/s3cmd/blob/master/INSTALL'; exit 1; fi
+	@if [[ -z "$(S3CMD)" ]]; then echo 'Missing "s3cmd" command. Use "brew install s3cmd" or see https://github.com/s3tools/s3cmd/blob/master/INSTALL'; exit 1; fi
 
 require-wget:
 	@if [[ -z "$(WGET)" ]]; then echo 'Missing "wget" command.'; exit 1; fi
@@ -329,7 +337,9 @@ release-qa: require-tag require-s3cmd
 	for NAME in $$(ls -1 update_darwin_amd64.bz2 update_linux_386.bz2 update_linux_amd64.bz2 update_windows_386.bz2); do \
 		echo "Copying update binary $$NAME..." && \
 		$(S3CMD) put -P $$NAME s3://$(S3_BUCKET); \
-	done
+	done && \
+	git tag -a "$$TAG" -f --annotate -m"Tagged $$VERSION" && \
+	git push --tags -f
 
 release-beta: require-s3cmd
 	@BASE_NAME="lantern-installer-qa" && \
@@ -340,8 +350,12 @@ release-beta: require-s3cmd
 		$(S3CMD) cp s3://$(S3_BUCKET)/$$NAME s3://$(S3_BUCKET)/$$BETA; \
 	done
 
-release: require-tag require-s3cmd require-gh-token require-wget require-ruby
-	@BASE_NAME="lantern-installer-beta" && \
+release: require-tag require-s3cmd require-gh-token require-wget require-ruby require-lantern-binaries
+	@TAG_COMMIT=$$(git rev-list --abbrev-commit -1 $$TAG) && \
+	if [[ -z "$$TAG_COMMIT" ]]; then \
+		echo "Could not find given tag $$TAG."; \
+	fi && \
+	BASE_NAME="lantern-installer-beta" && \
 	PROD_BASE_NAME="lantern-installer" && \
 	for URL in $$($(S3CMD) ls s3://$(S3_BUCKET)/ | grep $$BASE_NAME | awk '{print $$4}'); do \
 		NAME=$$(basename $$URL) && \
@@ -350,19 +364,32 @@ release: require-tag require-s3cmd require-gh-token require-wget require-ruby
 	done && \
 	for URL in $$($(S3CMD) ls s3://$(S3_BUCKET)/ | grep update_ | awk '{print $$4}'); do \
 		NAME=$$(basename $$URL) && \
-		URL=https://$(S3_BUCKET).s3.amazonaws.com/$$NAME && \
-		$(WGET) -O $$NAME $$URL; \
+		$(S3CMD) get --force s3://$(S3_BUCKET)/$$NAME $$NAME; \
 	done && \
 	$(RUBY) ./installer-resources/tools/createrelease.rb "$(GH_USER)" "$(GH_RELEASE_REPOSITORY)" $$TAG && \
-	git tag -a "$$TAG" -f --annotate -m"Tagged $$VERSION" && \
-	git push --tags -f && \
 	echo "Uploading Windows binary for auto-updates" && \
 	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_windows_386.bz2 && \
 	echo "Uploading OSX binary for auto-updates" && \
 	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_darwin_amd64.bz2 && \
 	echo "Uploading Linux binaries for auto-updates" && \
 	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_linux_amd64.bz2 && \
-	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_linux_386.bz2
+	$(RUBY) ./installer-resources/tools/uploadghasset.rb $(GH_USER) $(GH_RELEASE_REPOSITORY) $$TAG update_linux_386.bz2 && \
+	echo "Copying binaries to $(LANTERN_BINARIES_PATH)..." && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer-32-bit.deb $(LANTERN_BINARIES_PATH)/lantern-installer-32.deb && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer-32-bit.deb.sha1 $(LANTERN_BINARIES_PATH)/lantern-installer-32.deb.sha1 && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer-64-bit.deb $(LANTERN_BINARIES_PATH)/lantern-installer-64.deb && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer-64-bit.deb.sha1 $(LANTERN_BINARIES_PATH)/lantern-installer-64.deb.sha1 && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer.dmg $(LANTERN_BINARIES_PATH)/lantern-installer.dmg && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer.dmg.sha1 $(LANTERN_BINARIES_PATH)/lantern-installer.dmg.sha1 && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer.exe $(LANTERN_BINARIES_PATH)/lantern-installer.exe && \
+	$(S3CMD) get --force s3://$(S3_BUCKET)/lantern-installer.exe.sha1 $(LANTERN_BINARIES_PATH)/lantern-installer.exe.sha1 && \
+	cp $(LANTERN_BINARIES_PATH)/lantern-installer-32.deb.sha1 $(LANTERN_BINARIES_PATH)/lantern-$$TAG-$$TAG_COMMIT-32-bit.deb.sha1 && \
+	cp $(LANTERN_BINARIES_PATH)/lantern-installer-64.deb.sha1 $(LANTERN_BINARIES_PATH)/lantern-$$TAG-$$TAG_COMMIT-64-bit.deb.sha1 && \
+	cp $(LANTERN_BINARIES_PATH)/lantern-installer.dmg.sha1 $(LANTERN_BINARIES_PATH)/lantern-$$TAG-$$TAG_COMMIT.dmg.sha1 && \
+	cp $(LANTERN_BINARIES_PATH)/lantern-installer.exe.sha1 $(LANTERN_BINARIES_PATH)/lantern-$$TAG-$$TAG_COMMIT.exe.sha1
+	@cd $(LANTERN_BINARIES_PATH) && \
+	git add lantern-$$TAG-$$TAG_COMMIT* && \
+	(git commit -am "Latest binaries for Lantern $$TAG ($$TAG_COMMIT)." && git push origin master) || true
 
 update-icons:
 	@(which go-bindata >/dev/null) || (echo 'Missing command "go-bindata". Sett https://github.com/jteeuwen/go-bindata.' && exit 1) && \

--- a/README.md
+++ b/README.md
@@ -188,12 +188,12 @@ Finally, use `release-qa` to upload the packages that were just generated to
 both AWS S3 and the Github release page:
 
 ```
-TAG='2.0.0-beta5' GH_TOKEN=$GITHUB_TOKEN make release-qa
+TAG=2.0.0-beta5 make release-qa
 ```
 
 ### Releasing Beta
 
-If you want to release a Beta you must have created a package for QA first,
+If you want to release a beta you must have created a package for QA first,
 then use the `release-beta` task:
 
 ```
@@ -201,6 +201,15 @@ make release-beta
 ```
 
 `release-beta` will promote the QA files that are currently in S3 to beta.
+
+### Releasing for production
+
+After you're satisfied with a beta version, it will be time to promote beta
+packages to production and to publish the packages for auto-updates:
+
+```
+TAG=2.0.0-beta5 GH_TOKEN=$GITHUB_TOKEN make release
+```
 
 ## Other tasks
 

--- a/README.md
+++ b/README.md
@@ -211,6 +211,10 @@ packages to production and to publish the packages for auto-updates:
 TAG=2.0.0-beta5 GH_TOKEN=$GITHUB_TOKEN make release
 ```
 
+`make release` expects a `lantern-binaries` directory at `../lantern-binaries`.
+You can provide a different directory by passing the `LANTERN_BINARIES_PATH`
+env variable.
+
 ## Other tasks
 
 ### Creating libgojni.so


### PR DESCRIPTION
This PR adds a new target `release` that can be used to promote a beta version to a production release. `release` also pushes binaries that can be used by the auto-update server.

See https://github.com/getlantern/lantern/issues/2453
