### PR TITLE
log detailed error if dialDetour() failed

### DIFF
--- a/src/github.com/getlantern/detour/detour.go
+++ b/src/github.com/getlantern/detour/detour.go
@@ -135,7 +135,7 @@ func Dialer(d dialFunc) dialFunc {
 		dc.setState(stateDetour)
 		dc.conn, err = dc.dialDetour(network, addr)
 		if err != nil {
-			log.Errorf("Dial %s to %s failed", dc.stateDesc(), addr)
+			log.Errorf("Dial %s to %s failed: %s", dc.stateDesc(), addr, err)
 			return nil, err
 		}
 		log.Tracef("Dial %s to %s succeeded", dc.stateDesc(), addr)


### PR DESCRIPTION
Now the error message will look like:

> May 04 01:08:52.524 - detour: detour.go:139 Dial detoured to ssl.gstatic.com:443 failed: No dialers left