### PR TITLE
Adjusting error threshold in peer geolocation.

### DIFF
--- a/src/github.com/getlantern/geolookup/geolookup.go
+++ b/src/github.com/getlantern/geolookup/geolookup.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	geoServeEndpoint = `http://geo.getiantem.org/lookup/%s`
-	geoLookupTimeout = 20 * time.Second
+	geoLookupTimeout = 60 * time.Second
 )
 
 var (


### PR DESCRIPTION
`retryWait` was producing small values and error reporting was incomplete.

This could help fixing https://github.com/getlantern/lantern/issues/2394