### PR TITLE
adjust log format in statserver/peer.go

### DIFF
--- a/src/github.com/getlantern/flashlight/geolookup/geolookup.go
+++ b/src/github.com/getlantern/flashlight/geolookup/geolookup.go
@@ -46,7 +46,7 @@ func Configure(newClient *http.Client) {
 	if service == nil {
 		err := registerService()
 		if err != nil {
-			log.Errorf("Unable to register service: %v", err)
+			log.Errorf("Unable to register service: %s", err)
 			return
 		}
 		go write()
@@ -91,7 +91,7 @@ func write() {
 			// Always publish location, even if unchanged
 			service.Out <- location
 		} else {
-			msg := fmt.Sprintf("Unable to get current location: %v", err)
+			msg := fmt.Sprintf("Unable to get current location: %s", err)
 			// When retrying after a failure, wait a different amount of time
 			retryWait := time.Duration(math.Pow(2, float64(consecutiveFailures))*float64(retryWaitMillis)) * time.Millisecond
 			if retryWait < wait {

--- a/src/github.com/getlantern/flashlight/statserver/peer.go
+++ b/src/github.com/getlantern/flashlight/statserver/peer.go
@@ -52,7 +52,7 @@ func (peer *Peer) run() {
 	err := peer.geolocate()
 
 	if err != nil {
-		log.Errorf("Unable to geolocate peer after %d attempts, stopping reporting. Last error was: %v", maxGeolocateTries, err)
+		log.Errorf("Unable to geolocate peer after %d attempts, stopping reporting. Last error was: %s", maxGeolocateTries, err)
 		return
 	}
 
@@ -102,7 +102,7 @@ func (peer *Peer) geolocate() error {
 		if i > 0 {
 			// Maximum sleep time: 2^(maxGeolocateTries - 1) * retryWaitTime
 			retryWait := time.Duration(math.Pow(2, float64(i)) * float64(retryWaitTime))
-			log.Errorf("Failed geolocation attempt %d/%d,  waiting %v before retrying: %v", i, maxGeolocateTries-1, retryWait, err)
+			log.Errorf("Failed geolocation attempt %d/%d,  waiting %v before retrying: %s", i, maxGeolocateTries-1, retryWait, err)
 			time.Sleep(retryWait)
 		}
 

--- a/src/github.com/getlantern/flashlight/statserver/peer.go
+++ b/src/github.com/getlantern/flashlight/statserver/peer.go
@@ -52,7 +52,7 @@ func (peer *Peer) run() {
 	err := peer.geolocate()
 
 	if err != nil {
-		log.Errorf("Unable to geolocate peer after %d attempts, stopping reporting. Last error was: %q", maxGeolocateTries, err)
+		log.Errorf("Unable to geolocate peer after %d attempts, stopping reporting. Last error was: %v", maxGeolocateTries, err)
 		return
 	}
 
@@ -102,7 +102,7 @@ func (peer *Peer) geolocate() error {
 		if i > 0 {
 			// Maximum sleep time: 2^(maxGeolocateTries - 1) * retryWaitTime
 			retryWait := time.Duration(math.Pow(2, float64(i)) * float64(retryWaitTime))
-			log.Errorf("Failed geolocation attempt %d/%d: %q. Waiting %v before retrying.", i, maxGeolocateTries-1, err, retryWait)
+			log.Errorf("Failed geolocation attempt %d/%d,  waiting %v before retrying: %v", i, maxGeolocateTries-1, retryWait, err)
 			time.Sleep(retryWait)
 		}
 


### PR DESCRIPTION
The log we just merged from https://github.com/getlantern/lantern/pull/2474 was like below

> May 06 01:59:32.616 - flashlight.statserver: peer.go:106 Failed geolocation attempt 9/9: "Could not get response from server: \"Get http://geo.getiantem.org/lookup/178.62.198.216: net/http: request canceled while waiting for connection\"". Waiting 4m16s before retrying.

It would be better to revise it a bit as
1. it results different message groups on Loggly, as the waiting time varies;
2. quotation mark and backslash makes the text a bit clutter.

@xiam How do you think?