### PR TITLE
add fix for https://github.com/getlantern/lantern/issues/2402

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -415,6 +415,12 @@ func (cfg Config) fetchCloudConfigForCountry(client *http.Client, country string
 		// Don't bother fetching if unchanged
 		req.Header.Set(ifNoneMatch, lastCloudConfigETag[url])
 	}
+
+	// make sure to close the connection after reading the Body
+	// this prevents the occasional EOFs errors we're seeing with
+	// successive requests
+	req.Close = true
+
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to fetch cloud config at %s: %s", url, err)


### PR DESCRIPTION
This is related to the error fetching ``cloud.yaml`` we've been seeing for a long time in Loggly. The ``resp.Body.Close() `` is insufficient, and we need to explicitly indicate the request should be closed after we finish reading the response body. More details here: https://stackoverflow.com/questions/17714494/golang-http-request-results-in-eof-errors-when-making-multiple-requests-successi