### PR TITLE
change cloud config URL to one that can be served dynamically; fixes …

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -229,7 +229,7 @@ func (cfg *Config) ApplyDefaults() {
 	}
 
 	if cfg.CloudConfig == "" {
-		cfg.CloudConfig = fmt.Sprintf("https://s3.amazonaws.com/lantern_config/cloud.%v.yaml.gz", countryPlaceholder)
+		cfg.CloudConfig = fmt.Sprintf("https://config.getiantem.org/cloud.%v.yaml.gz", countryPlaceholder)
 	}
 
 	// Make sure we always have a stats config


### PR DESCRIPTION
…#2517

There is a CNAME entry in Cloudflare pointing to a 'config.getiantem.org' bucket that has the 'cn' and 'default' cloud configs.  This bucket name was required for TLS validation.

I'll modify the `genconfig` part of this next.  It needs to be implemented as a branch of the as-of-yet unmerged https://github.com/getlantern/lantern/pull/2493.  The new bucket name also requires a not-yet-released version of `s3cmd`, because of

https://github.com/s3tools/s3cmd/issues/437