### PR TITLE
withClient

### DIFF
--- a/src/github.com/getlantern/flashlight/analytics/analytics.go
+++ b/src/github.com/getlantern/flashlight/analytics/analytics.go
@@ -25,9 +25,11 @@ var (
 )
 
 func Configure(cfg *config.Config, serverSession bool, wc func(func(*http.Client))) {
-
-	withClient = wc
-
+	if wc == nil {
+		withClient = func(f func(*http.Client)) { f(nil) }
+	} else {
+		withClient = wc
+	}
 	sessionPayload := &analytics.Payload{
 		HitType: analytics.EventType,
 		Event: &analytics.Event{

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -219,7 +219,7 @@ func runClientProxy(cfg *config.Config, mch withclient.MakerChan) {
 	settings.Configure(cfg, version, buildDate)
 	proxiedsites.Configure(cfg.ProxiedSites)
 
-	mch.UpdateClientDirectFronter(&cfg.Client)
+	mch.UpdateClientDirectFronter(cfg.Client)
 	wdc := mch.MakeWithClient()
 	geolookup.Configure(wdc)
 	statserver.Configure(wdc)
@@ -243,7 +243,7 @@ func runClientProxy(cfg *config.Config, mch withclient.MakerChan) {
 			// XXX: wrt fronted servers, we only really care if the one with highest QOS
 			// is still the same one.
 			if oldCfg == nil || !(reflect.DeepEqual(oldCfg.Client.FrontedServers, cfg.Client.FrontedServers) && reflect.DeepEqual(oldCfg.Client.MasqueradeSets, cfg.Client.MasqueradeSets)) {
-				mch.UpdateClientDirectFronter(&cfg.Client)
+				mch.UpdateClientDirectFronter(cfg.Client)
 			}
 			settings.Configure(cfg, version, buildDate)
 			logging.Configure(cfg, version, buildDate)

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -219,7 +219,7 @@ func runClientProxy(cfg *config.Config, mch withclient.MakerChan) {
 	settings.Configure(cfg, version, buildDate)
 	proxiedsites.Configure(cfg.ProxiedSites)
 
-	withclient.UpdateClientDirectFronter(cfg, mch)
+	mch.UpdateClientDirectFronter(&cfg.Client)
 	wdc := mch.MakeWithClient()
 	geolookup.Configure(wdc)
 	statserver.Configure(wdc)
@@ -243,7 +243,7 @@ func runClientProxy(cfg *config.Config, mch withclient.MakerChan) {
 			// XXX: wrt fronted servers, we only really care if the one with highest QOS
 			// is still the same one.
 			if oldCfg == nil || !(reflect.DeepEqual(oldCfg.Client.FrontedServers, cfg.Client.FrontedServers) && reflect.DeepEqual(oldCfg.Client.MasqueradeSets, cfg.Client.MasqueradeSets)) {
-				withclient.UpdateClientDirectFronter(cfg, mch)
+				mch.UpdateClientDirectFronter(&cfg.Client)
 			}
 			settings.Configure(cfg, version, buildDate)
 			logging.Configure(cfg, version, buildDate)
@@ -264,7 +264,7 @@ func runClientProxy(cfg *config.Config, mch withclient.MakerChan) {
 func runServerProxy(cfg *config.Config, mch withclient.MakerChan) {
 	useAllCores()
 
-	withclient.UpdateServerConfigClient(cfg, mch)
+	mch.UpdateServerConfigClient(cfg)
 	pkFile, err := config.InConfigDir("proxypk.pem")
 	if err != nil {
 		log.Fatal(err)
@@ -297,7 +297,7 @@ func runServerProxy(cfg *config.Config, mch withclient.MakerChan) {
 		for {
 			cfg := <-configUpdates
 			if cfg.CloudConfigCA != oldca {
-				withclient.UpdateServerConfigClient(cfg, mch)
+				mch.UpdateServerConfigClient(cfg)
 				oldca = cfg.CloudConfigCA
 			}
 			statreporter.Configure(cfg.Stats)

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -5,12 +5,10 @@ import (
 	"flag"
 	"fmt"
 	"math/rand"
-	"net/http"
 	"os"
 	"reflect"
 	"runtime"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/getlantern/fronted"
@@ -30,7 +28,7 @@ import (
 	"github.com/getlantern/flashlight/statreporter"
 	"github.com/getlantern/flashlight/statserver"
 	"github.com/getlantern/flashlight/ui"
-	"github.com/getlantern/flashlight/util"
+	"github.com/getlantern/flashlight/withclient"
 )
 
 var (
@@ -93,81 +91,6 @@ func _main() {
 	os.Exit(0)
 }
 
-// The following are mostly meant to
-//   (i)   keep track of directly fronted Dialers, closing them when they
-//         get superseded by a config update.
-//   (ii)  avoid creating more Dialers than needed (one per config update).
-//   (iii) make these dialers available to the config custom poll, without
-//         introducing globals.
-//   (iv)  present a uniform interface in the server side, currently for
-//         the benefit of the config custom poll.
-//
-// Thus, most of the functionality is meant for the client side, and we
-// use mostly placeholders in the server side.  Because of this and for
-// agility of exposition, the comments below refer to the client side.
-
-type clientWithCloseThunk struct {
-	// A particular reference to the directly fronted http.Client (aka fronter).
-	client *http.Client
-	// Placeholder for any cleanup required when this reference is no longer
-	// needed.  We keep track of currently used references with a WaitGroup,
-	// and we use this function to signal we're Done() with this one.
-	close func()
-}
-
-type clientMaker struct {
-	// Generates structures like the one above.  A closure over a fronted.Dialer.
-	make func() clientWithCloseThunk
-	// Placeholder for any cleanup required when this clientMaker is no longer
-	// current because we have got a new one (by a config update).
-	close func()
-}
-
-// To synchronize access to the current clientMaker.  Used as a promise that
-// can be updated.
-type makerChan chan clientMaker
-
-func newMakerChan() makerChan {
-	return make(chan clientMaker, 1)
-}
-
-// Returns the old one, if any.
-func (ch makerChan) updateMaker(c clientMaker) (ret clientMaker) {
-	select {
-	case ret = <-ch:
-	default:
-	}
-	ch <- c
-	return ret
-}
-
-func (ch makerChan) getMaker() clientMaker {
-	ret := <-ch
-	ch <- ret
-	return ret
-}
-
-// Creates a "context" function that takes care of all the bookkeeping involved
-// in making sure Dialers are kept only for as long as needed and closed as soon as
-// nobody is using them-- but no sooner.
-//
-// The function returned by this call is meant to be used like this:
-//
-// withClient(func(c *http.Client) {
-//    ... use `c` here ...
-// })
-//
-// No explicit cleanup is required in the body where `c` is used, but `c` should
-// never be used after the body has returned.  So don't assign `c` to variables
-// or data structures outside the body, don't use it inside a goroutine, etc.
-func (ch makerChan) makeWithClient() func(func(*http.Client)) {
-	return func(f func(*http.Client)) {
-		cc := ch.getMaker().make()
-		defer cc.close()
-		f(cc.client)
-	}
-}
-
 func doMain() error {
 	err := logging.Init()
 	if err != nil {
@@ -190,9 +113,9 @@ func doMain() error {
 
 	parseFlags()
 
-	mch := newMakerChan()
+	mch := withclient.NewMakerChan()
 
-	cfg, err := config.Init(mch.makeWithClient())
+	cfg, err := config.Init(mch.MakeWithClient())
 	if err != nil {
 		return fmt.Errorf("Unable to initialize configuration: %v", err)
 	}
@@ -260,7 +183,7 @@ func parseFlags() {
 }
 
 // runClientProxy runs the client-side (get mode) proxy.
-func runClientProxy(cfg *config.Config, mch makerChan) {
+func runClientProxy(cfg *config.Config, mch withclient.MakerChan) {
 	var err error
 
 	// Set Lantern as system proxy by creating and using a PAC file.
@@ -296,8 +219,8 @@ func runClientProxy(cfg *config.Config, mch makerChan) {
 	settings.Configure(cfg, version, buildDate)
 	proxiedsites.Configure(cfg.ProxiedSites)
 
-	updateClientDirectFronter(cfg, mch)
-	wdc := mch.makeWithClient()
+	withclient.UpdateClientDirectFronter(cfg, mch)
+	wdc := mch.MakeWithClient()
 	geolookup.Configure(wdc)
 	statserver.Configure(wdc)
 	analytics.Configure(cfg, false, wdc)
@@ -320,7 +243,7 @@ func runClientProxy(cfg *config.Config, mch makerChan) {
 			// XXX: wrt fronted servers, we only really care if the one with highest QOS
 			// is still the same one.
 			if oldCfg == nil || !(reflect.DeepEqual(oldCfg.Client.FrontedServers, cfg.Client.FrontedServers) && reflect.DeepEqual(oldCfg.Client.MasqueradeSets, cfg.Client.MasqueradeSets)) {
-				updateClientDirectFronter(cfg, mch)
+				withclient.UpdateClientDirectFronter(cfg, mch)
 			}
 			settings.Configure(cfg, version, buildDate)
 			logging.Configure(cfg, version, buildDate)
@@ -337,40 +260,11 @@ func runClientProxy(cfg *config.Config, mch makerChan) {
 	}()
 }
 
-func updateClientDirectFronter(cfg *config.Config, mch makerChan) {
-	log.Debug("Updating client direct fronter")
-	hqfd := cfg.Client.HighestQOSFrontedDialer()
-	if hqfd == nil {
-		log.Errorf("No fronted dialer available, not enabling geolocation, stats or analytics")
-		return
-	}
-	// An *http.Client that uses the highest QOS dialer.
-	hqfdClient := hqfd.NewDirectDomainFronter()
-	wg := sync.WaitGroup{}
-	old := mch.updateMaker(
-		clientMaker{
-			make: func() clientWithCloseThunk {
-				wg.Add(1)
-				return clientWithCloseThunk{
-					client: hqfdClient,
-					close:  wg.Done,
-				}
-			},
-			close: func() {
-				wg.Wait()
-				hqfd.Close()
-			}})
-	if old.close != nil {
-		log.Debug("Closing old dialer")
-		go old.close()
-	}
-}
-
 // Runs the server-side proxy
-func runServerProxy(cfg *config.Config, mch makerChan) {
+func runServerProxy(cfg *config.Config, mch withclient.MakerChan) {
 	useAllCores()
 
-	updateServerConfigClient(cfg, mch)
+	withclient.UpdateServerConfigClient(cfg, mch)
 	pkFile, err := config.InConfigDir("proxypk.pem")
 	if err != nil {
 		log.Fatal(err)
@@ -403,7 +297,7 @@ func runServerProxy(cfg *config.Config, mch makerChan) {
 		for {
 			cfg := <-configUpdates
 			if cfg.CloudConfigCA != oldca {
-				updateServerConfigClient(cfg, mch)
+				withclient.UpdateServerConfigClient(cfg, mch)
 				oldca = cfg.CloudConfigCA
 			}
 			statreporter.Configure(cfg.Stats)
@@ -422,24 +316,6 @@ func runServerProxy(cfg *config.Config, mch makerChan) {
 	if err != nil {
 		log.Fatalf("Unable to run server proxy: %s", err)
 	}
-}
-
-func updateServerConfigClient(cfg *config.Config, mch makerChan) {
-	client, err := util.HTTPClient(cfg.CloudConfigCA, "")
-	if err != nil {
-		log.Errorf("Couldn't create http.Client for fetching the config")
-		return
-	}
-	doNothing := func() {}
-	ret := clientWithCloseThunk{
-		client: client,
-		close:  doNothing,
-	}
-	mch.updateMaker(
-		clientMaker{
-			make:  func() clientWithCloseThunk { return ret },
-			close: doNothing,
-		})
 }
 
 func useAllCores() {

--- a/src/github.com/getlantern/flashlight/statserver/peer.go
+++ b/src/github.com/getlantern/flashlight/statserver/peer.go
@@ -2,6 +2,7 @@ package statserver
 
 import (
 	"math"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -118,7 +119,12 @@ func (peer *Peer) geolocate() error {
 }
 
 func (peer *Peer) doGeolocate() error {
-	geodata, err := geolookup.LookupIPWithClient(peer.IP, geoClient)
+	var geodata *geolookup.City
+	var err error
+	wc := withClient.Load().(func(func(*http.Client)))
+	wc(func(c *http.Client) {
+		geodata, err = geolookup.LookupIPWithClient(peer.IP, c)
+	})
 
 	if err != nil {
 		return err

--- a/src/github.com/getlantern/flashlight/statserver/statserver.go
+++ b/src/github.com/getlantern/flashlight/statserver/statserver.go
@@ -3,6 +3,7 @@ package statserver
 import (
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/getlantern/golog"
 
@@ -14,15 +15,15 @@ var (
 
 	service    *ui.Service
 	cfgMutex   sync.RWMutex
-	geoClient  *http.Client
+	withClient atomic.Value
 	peers      map[string]*Peer
 	peersMutex sync.RWMutex
 )
 
-func Configure(newClient *http.Client) {
+func Configure(wc func(func(*http.Client))) {
 	cfgMutex.Lock()
 	defer cfgMutex.Unlock()
-	geoClient = newClient
+	withClient.Store(wc)
 	if service == nil {
 		err := registerService()
 		if err != nil {

--- a/src/github.com/getlantern/flashlight/withclient/withclient.go
+++ b/src/github.com/getlantern/flashlight/withclient/withclient.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/getlantern/golog"
 
+	"github.com/getlantern/flashlight/client"
 	"github.com/getlantern/flashlight/config"
 	"github.com/getlantern/flashlight/util"
 )
@@ -89,9 +90,9 @@ func (ch MakerChan) MakeWithClient() func(func(*http.Client)) {
 	}
 }
 
-func UpdateClientDirectFronter(cfg *config.Config, mch MakerChan) {
+func (ch MakerChan) UpdateClientDirectFronter(cfg *client.ClientConfig) {
 	log.Debug("Updating client direct fronter")
-	hqfd := cfg.Client.HighestQOSFrontedDialer()
+	hqfd := cfg.HighestQOSFrontedDialer()
 	if hqfd == nil {
 		log.Errorf("No fronted dialer available, not enabling geolocation, stats or analytics")
 		return
@@ -99,7 +100,7 @@ func UpdateClientDirectFronter(cfg *config.Config, mch MakerChan) {
 	// An *http.Client that uses the highest QOS dialer.
 	hqfdClient := hqfd.NewDirectDomainFronter()
 	wg := sync.WaitGroup{}
-	old := mch.updateMaker(
+	old := ch.updateMaker(
 		clientMaker{
 			make: func() clientWithCloseThunk {
 				wg.Add(1)
@@ -118,7 +119,7 @@ func UpdateClientDirectFronter(cfg *config.Config, mch MakerChan) {
 	}
 }
 
-func UpdateServerConfigClient(cfg *config.Config, mch MakerChan) {
+func (ch MakerChan) UpdateServerConfigClient(cfg *config.Config) {
 	client, err := util.HTTPClient(cfg.CloudConfigCA, "")
 	if err != nil {
 		log.Errorf("Couldn't create http.Client for fetching the config")
@@ -129,7 +130,7 @@ func UpdateServerConfigClient(cfg *config.Config, mch MakerChan) {
 		client: client,
 		close:  doNothing,
 	}
-	mch.updateMaker(
+	ch.updateMaker(
 		clientMaker{
 			make:  func() clientWithCloseThunk { return ret },
 			close: doNothing,

--- a/src/github.com/getlantern/flashlight/withclient/withclient.go
+++ b/src/github.com/getlantern/flashlight/withclient/withclient.go
@@ -1,0 +1,137 @@
+package withclient
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/getlantern/golog"
+
+	"github.com/getlantern/flashlight/config"
+	"github.com/getlantern/flashlight/util"
+)
+
+var (
+	log = golog.LoggerFor("withclient")
+)
+
+// The following are mostly meant to
+//   (i)   keep track of directly fronted Dialers, closing them when they
+//         get superseded by a config update.
+//   (ii)  avoid creating more Dialers than needed (one per config update).
+//   (iii) make these dialers available to the config custom poll, without
+//         introducing globals.
+//   (iv)  present a uniform interface in the server side, currently for
+//         the benefit of the config custom poll.
+//
+// Thus, most of the functionality is meant for the client side, and we
+// use mostly placeholders in the server side.  Because of this and for
+// agility of exposition, the comments below refer to the client side.
+
+type clientWithCloseThunk struct {
+	// A particular reference to the directly fronted http.Client (aka fronter).
+	client *http.Client
+	// Placeholder for any cleanup required when this reference is no longer
+	// needed.  We keep track of currently used references with a WaitGroup,
+	// and we use this function to signal we're Done() with this one.
+	close func()
+}
+
+type clientMaker struct {
+	// Generates structures like the one above.  A closure over a fronted.Dialer.
+	make func() clientWithCloseThunk
+	// Placeholder for any cleanup required when this clientMaker is no longer
+	// current because we have got a new one (by a config update).
+	close func()
+}
+
+// To synchronize access to the current clientMaker.  Used as a promise that
+// can be updated.
+type MakerChan chan clientMaker
+
+func NewMakerChan() MakerChan {
+	return make(chan clientMaker, 1)
+}
+
+// Returns the old one, if any.
+func (ch MakerChan) updateMaker(c clientMaker) (ret clientMaker) {
+	select {
+	case ret = <-ch:
+	default:
+	}
+	ch <- c
+	return ret
+}
+
+func (ch MakerChan) getMaker() clientMaker {
+	ret := <-ch
+	ch <- ret
+	return ret
+}
+
+// Creates a "context" function that takes care of all the bookkeeping involved
+// in making sure Dialers are kept only for as long as needed and closed as soon as
+// nobody is using them-- but no sooner.
+//
+// The function returned by this call is meant to be used like this:
+//
+// withClient(func(c *http.Client) {
+//    ... use `c` here ...
+// })
+//
+// No explicit cleanup is required in the body where `c` is used, but `c` should
+// never be used after the body has returned.  So don't assign `c` to variables
+// or data structures outside the body, don't use it inside a goroutine, etc.
+func (ch MakerChan) MakeWithClient() func(func(*http.Client)) {
+	return func(f func(*http.Client)) {
+		cc := ch.getMaker().make()
+		defer cc.close()
+		f(cc.client)
+	}
+}
+
+func UpdateClientDirectFronter(cfg *config.Config, mch MakerChan) {
+	log.Debug("Updating client direct fronter")
+	hqfd := cfg.Client.HighestQOSFrontedDialer()
+	if hqfd == nil {
+		log.Errorf("No fronted dialer available, not enabling geolocation, stats or analytics")
+		return
+	}
+	// An *http.Client that uses the highest QOS dialer.
+	hqfdClient := hqfd.NewDirectDomainFronter()
+	wg := sync.WaitGroup{}
+	old := mch.updateMaker(
+		clientMaker{
+			make: func() clientWithCloseThunk {
+				wg.Add(1)
+				return clientWithCloseThunk{
+					client: hqfdClient,
+					close:  wg.Done,
+				}
+			},
+			close: func() {
+				wg.Wait()
+				hqfd.Close()
+			}})
+	if old.close != nil {
+		log.Debug("Closing old dialer")
+		go old.close()
+	}
+}
+
+func UpdateServerConfigClient(cfg *config.Config, mch MakerChan) {
+	client, err := util.HTTPClient(cfg.CloudConfigCA, "")
+	if err != nil {
+		log.Errorf("Couldn't create http.Client for fetching the config")
+		return
+	}
+	doNothing := func() {}
+	ret := clientWithCloseThunk{
+		client: client,
+		close:  doNothing,
+	}
+	mch.updateMaker(
+		clientMaker{
+			make:  func() clientWithCloseThunk { return ret },
+			close: doNothing,
+		})
+}

--- a/src/github.com/getlantern/lantern-android/client/client_test.go
+++ b/src/github.com/getlantern/lantern-android/client/client_test.go
@@ -57,12 +57,12 @@ func TestListenAndServeProxy(t *testing.T) {
 	for uri, expectedContent := range testURLs {
 		wg.Add(1)
 
-		go func(wg *sync.WaitGroup) {
+		go func(wg *sync.WaitGroup, uri string, expectedContent []byte) {
 			if err := testReverseProxy(uri, expectedContent); err != nil {
 				t.Fatal(err)
 			}
 			wg.Done()
-		}(&wg)
+		}(&wg, uri, expectedContent)
 
 	}
 

--- a/src/github.com/getlantern/lantern-android/client/config.go
+++ b/src/github.com/getlantern/lantern-android/client/config.go
@@ -4,7 +4,6 @@ import (
 	"compress/gzip"
 	"crypto/x509"
 	"errors"
-	"fmt"
 	"io"
 	"io/ioutil"
 	"log"
@@ -98,7 +97,6 @@ func pullConfigFile(cli *http.Client) ([]byte, error) {
 
 // defaultConfig returns the embedded configuration.
 func defaultConfig() *config {
-
 	cfg := &config{
 		Client: &client.ClientConfig{
 			FrontedServers: []*client.FrontedServerInfo{
@@ -117,40 +115,6 @@ func defaultConfig() *config {
 		TrustedCAs: defaultTrustedCAs,
 	}
 	return cfg
-}
-
-// getConfig attempts to provide a
-func getConfig() (*config, error) {
-	var err error
-	var buf []byte
-
-	defaultCfg := defaultConfig()
-
-	hqfdc := directHttpClientFromConfig(defaultCfg)
-	if hqfdc == nil {
-		return defaultCfg, fmt.Errorf("Couldn't create initial fronted dialer")
-	}
-
-	var cfg config
-
-	// Attempt to download configuration file.
-	if buf, err = pullConfigFile(hqfdc); err != nil {
-		return defaultCfg, err
-	}
-
-	if err = cfg.updateFrom(buf); err != nil {
-		return defaultCfg, err
-	}
-
-	return &cfg, nil
-}
-
-func directHttpClientFromConfig(cfg *config) *http.Client {
-	hqfd := cfg.Client.HighestQOSFrontedDialer()
-	if hqfd == nil {
-		return nil
-	}
-	return hqfd.NewDirectDomainFronter()
 }
 
 func (c *config) updateFrom(buf []byte) error {

--- a/src/github.com/getlantern/lantern-android/client/config.go
+++ b/src/github.com/getlantern/lantern-android/client/config.go
@@ -114,6 +114,7 @@ func defaultConfig() *config {
 			},
 			MasqueradeSets: defaultMasqueradeSets,
 		},
+		TrustedCAs: defaultTrustedCAs,
 	}
 	return cfg
 }

--- a/src/github.com/getlantern/lantern-android/client/config.go
+++ b/src/github.com/getlantern/lantern-android/client/config.go
@@ -43,9 +43,8 @@ var (
 
 const (
 	cloudConfigCA = ``
-	// URL of the configuration file.  It is plain HTTP because we're using direct
-	// domain fronting to fetch it.
-	remoteConfigURL = `http://config.getiantem.org/cloud.default.yaml.gz`
+	// URL of the configuration file.
+	remoteConfigURL = `https://config.getiantem.org/cloud.yaml.gz`
 )
 
 // pullConfigFile attempts to retrieve a configuration file over the network,


### PR DESCRIPTION
See [this comment](https://github.com/getlantern/lantern/commit/e34ddc94168b7410886f8e2a16d257eafe993f1b#diff-f51f873318b593f0a492e1abb11a57c2R96).

I actually like this approach although I admit it's on the terse side.

One thing it doesn't try to do (yet) is to close the Dialer when the Client is closed.  Per se, that would be easy to do, but the ramifications are unclear to me.  I think we would need to stop a few loops that are currently going on forever, e.g., [this one](https://github.com/getlantern/lantern/blob/e34ddc94168b7410886f8e2a16d257eafe993f1b/src/github.com/getlantern/flashlight/flashlight.go#L309).  

Note that this doesn't matter for the regular lantern client, only for lantern-android.  I'll need to take a deeper look at why lantern-android wants to be able to Stop the client without exiting the app.