### PR TITLE
Fetch config via direct domain fronting, fixes #2520

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -220,7 +220,7 @@ func runClientProxy(cfg *config.Config) {
 		log.Errorf("No fronted dialer available, not enabling geolocation, stats or analytics")
 	} else {
 		// An *http.Client that uses the highest QOS dialer.
-		hqfdClient := hqfd.DirectHttpClient()
+		hqfdClient := hqfd.NewDirectDomainFronter()
 
 		geolookup.Configure(hqfdClient)
 		statserver.Configure(hqfdClient)
@@ -242,7 +242,7 @@ func runClientProxy(cfg *config.Config) {
 				// Create and pass the *http.Client that uses the highest QOS dialer to
 				// critical modules that require continual comunication with external
 				// services.
-				hqfdClient := hqfd.DirectHttpClient()
+				hqfdClient := hqfd.NewDirectDomainFronter()
 
 				geolookup.Configure(hqfdClient)
 				statserver.Configure(hqfdClient)

--- a/src/github.com/getlantern/flashlight/statserver/peer.go
+++ b/src/github.com/getlantern/flashlight/statserver/peer.go
@@ -2,6 +2,7 @@ package statserver
 
 import (
 	"math"
+	"net/http"
 	"sync/atomic"
 	"time"
 
@@ -118,7 +119,7 @@ func (peer *Peer) geolocate() error {
 }
 
 func (peer *Peer) doGeolocate() error {
-	geodata, err := geolookup.LookupIPWithClient(peer.IP, geoClient)
+	geodata, err := geolookup.LookupIPWithClient(peer.IP, geoClient.Load().(*http.Client))
 
 	if err != nil {
 		return err

--- a/src/github.com/getlantern/flashlight/statserver/statserver.go
+++ b/src/github.com/getlantern/flashlight/statserver/statserver.go
@@ -3,6 +3,7 @@ package statserver
 import (
 	"net/http"
 	"sync"
+	"sync/atomic"
 
 	"github.com/getlantern/golog"
 
@@ -14,7 +15,7 @@ var (
 
 	service    *ui.Service
 	cfgMutex   sync.RWMutex
-	geoClient  *http.Client
+	geoClient  atomic.Value
 	peers      map[string]*Peer
 	peersMutex sync.RWMutex
 )
@@ -22,7 +23,7 @@ var (
 func Configure(newClient *http.Client) {
 	cfgMutex.Lock()
 	defer cfgMutex.Unlock()
-	geoClient = newClient
+	geoClient.Store(newClient)
 	if service == nil {
 		err := registerService()
 		if err != nil {

--- a/src/github.com/getlantern/fronted/dialer.go
+++ b/src/github.com/getlantern/fronted/dialer.go
@@ -87,7 +87,7 @@ type Config struct {
 	BufferRequests bool
 
 	// DialTimeoutMillis: how long to wait on dialing server before timing out
-	// (defaults to 20 seconds)
+	// (defaults to 30 seconds)
 	DialTimeoutMillis int
 
 	// RedialAttempts: number of times to try redialing. The total number of
@@ -271,7 +271,7 @@ func (d *dialer) dialServer() (net.Conn, error) {
 func (d *dialer) dialServerWith(masquerade *Masquerade) (net.Conn, error) {
 	dialTimeout := time.Duration(d.DialTimeoutMillis) * time.Millisecond
 	if dialTimeout == 0 {
-		dialTimeout = 20 * time.Second
+		dialTimeout = 30 * time.Second
 	}
 
 	// Note - we need to suppress the sending of the ServerName in the client

--- a/src/github.com/getlantern/fronted/dialer.go
+++ b/src/github.com/getlantern/fronted/dialer.go
@@ -46,15 +46,15 @@ type Dialer interface {
 	// specified Masquerade.
 	HttpClientUsing(masquerade *Masquerade) *http.Client
 
-	// DirectHttpClient creates an HttpClient that domain-fronts but instead of
-	// using enproxy proxies routes to the destination server directly from the
+	// NewDirectDomainFronter creates an HttpClient that domain-fronts but instead
+	// of using enproxy proxies routes to the destination server directly from the
 	// CDN. This is useful for web properties registered on the CDN itself, for
 	// example geo.getiantem.org.
 	//
 	// Note - the connection is already encrypted by domain-fronting, so this
 	// client should only be used to make HTTP requests. Using it for HTTPS
 	// requests will result in an error.
-	DirectHttpClient() *http.Client
+	NewDirectDomainFronter() *http.Client
 }
 
 // Config captures the configuration of a domain-fronted dialer.
@@ -201,7 +201,7 @@ func (d *dialer) HttpClientUsing(masquerade *Masquerade) *http.Client {
 	}
 }
 
-func (d *dialer) DirectHttpClient() *http.Client {
+func (d *dialer) NewDirectDomainFronter() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Dial: func(network, addr string) (net.Conn, error) {

--- a/src/github.com/getlantern/fronted/dialer.go
+++ b/src/github.com/getlantern/fronted/dialer.go
@@ -205,11 +205,7 @@ func (d *dialer) NewDirectDomainFronter() *http.Client {
 	return &http.Client{
 		Transport: &http.Transport{
 			Dial: func(network, addr string) (net.Conn, error) {
-				var masquerade *Masquerade
-				if d.masquerades != nil {
-					masquerade = d.masquerades.nextVerified()
-				}
-				return d.dialServerWith(masquerade)
+				return d.dialServer()
 			},
 		},
 	}

--- a/src/github.com/getlantern/fronted/fronted_test.go
+++ b/src/github.com/getlantern/fronted/fronted_test.go
@@ -240,7 +240,7 @@ func TestIntegrationDirect(t *testing.T) {
 	d := integrationDialer(t, nil)
 	defer d.Close()
 
-	client := d.DirectHttpClient()
+	client := d.NewDirectDomainFronter()
 	resp, err := client.Get("http://geo.getiantem.org/lookup")
 	if assert.NoError(t, err, "Should be able to call geo.getiantem.org") {
 		defer resp.Body.Close()

--- a/src/github.com/getlantern/lantern-android/client/client.go
+++ b/src/github.com/getlantern/lantern-android/client/client.go
@@ -59,7 +59,7 @@ func NewClient(addr, appName string) *MobileClient {
 
 	hqfd := client.Configure(clientConfig.Client)
 
-	hqfdc := hqfd.DirectHttpClient()
+	hqfdc := hqfd.NewDirectDomainFronter()
 
 	// store GA session event
 	sessionPayload := &analytics.Payload{

--- a/src/github.com/getlantern/lantern-android/client/client.go
+++ b/src/github.com/getlantern/lantern-android/client/client.go
@@ -127,6 +127,10 @@ func (client *MobileClient) pollConfiguration() {
 			var err error
 			if err = client.updateConfig(); err == nil {
 				// Configuration changed, lets reload.
+				err := globals.SetTrustedCAs(clientConfig.getTrustedCerts())
+				if err != nil {
+					log.Printf("Unable to configure trusted CAs: %s", err)
+				}
 				hqfc := client.Configure(clientConfig.Client)
 				client.fronter = hqfc.NewDirectDomainFronter()
 			}

--- a/src/github.com/getlantern/lantern-android/client/client.go
+++ b/src/github.com/getlantern/lantern-android/client/client.go
@@ -33,14 +33,7 @@ type MobileClient struct {
 
 // init attempts to setup client configuration.
 func init() {
-	var err error
-	// Initial attempt to get configuration, without a proxy. If this request
-	// fails we'll use the default configuration.
-	if clientConfig, err = getConfig(); err != nil {
-		// getConfig() guarantees to return a *Config struct, so we can log the
-		// error without stopping the program.
-		log.Printf("Error updating configuration over the network: %q.", err)
-	}
+	clientConfig = defaultConfig()
 }
 
 // NewClient creates a proxy client.

--- a/src/github.com/getlantern/lantern-android/client/client_test.go
+++ b/src/github.com/getlantern/lantern-android/client/client_test.go
@@ -57,12 +57,12 @@ func TestListenAndServeProxy(t *testing.T) {
 	for uri, expectedContent := range testURLs {
 		wg.Add(1)
 
-		go func(wg *sync.WaitGroup) {
+		go func(wg *sync.WaitGroup, uri string, expectedContent []byte) {
 			if err := testReverseProxy(uri, expectedContent); err != nil {
 				t.Fatal(err)
 			}
 			wg.Done()
-		}(&wg)
+		}(&wg, uri, expectedContent)
 
 	}
 

--- a/src/github.com/getlantern/lantern-android/client/config.go
+++ b/src/github.com/getlantern/lantern-android/client/config.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"reflect"
-	"time"
 
 	"github.com/getlantern/keyman"
 	"github.com/getlantern/yaml"
@@ -21,8 +20,6 @@ const (
 	httpIfNoneMatch = "If-None-Match"
 	httpEtag        = "Etag"
 )
-
-var httpDefaultClient = &http.Client{Timeout: time.Second * 5}
 
 var lastCloudConfigETag string
 
@@ -118,25 +115,6 @@ func defaultConfig() *config {
 		},
 	}
 	return cfg
-}
-
-// getConfig attempts to provide a
-func getConfig() (*config, error) {
-	var err error
-	var buf []byte
-
-	var cfg config
-
-	// Attempt to download configuration file.
-	if buf, err = pullConfigFile(httpDefaultClient); err != nil {
-		return defaultConfig(), err
-	}
-
-	if err = cfg.updateFrom(buf); err != nil {
-		return defaultConfig(), err
-	}
-
-	return &cfg, nil
 }
 
 func (c *config) updateFrom(buf []byte) error {

--- a/src/github.com/getlantern/lantern-android/client/config.go
+++ b/src/github.com/getlantern/lantern-android/client/config.go
@@ -113,6 +113,7 @@ func defaultConfig() *config {
 			},
 			MasqueradeSets: defaultMasqueradeSets,
 		},
+		TrustedCAs: defaultTrustedCAs,
 	}
 	return cfg
 }

--- a/src/github.com/getlantern/lantern-android/client/config.go
+++ b/src/github.com/getlantern/lantern-android/client/config.go
@@ -43,7 +43,7 @@ var (
 const (
 	cloudConfigCA = ``
 	// URL of the configuration file. Remember to use HTTPs.
-	remoteConfigURL = `https://s3.amazonaws.com/lantern_config/cloud.2.0.0-nl.yaml.gz`
+	remoteConfigURL = `https://config.getiantem.org/cloud.yaml.gz`
 )
 
 // pullConfigFile attempts to retrieve a configuration file over the network,

--- a/src/github.com/getlantern/lantern-android/client/config_test.go
+++ b/src/github.com/getlantern/lantern-android/client/config_test.go
@@ -1,17 +1,27 @@
 package client
 
 import (
+	"net/http"
 	"testing"
+	"time"
 )
 
 func TestConfigDownload(t *testing.T) {
+	httpDefaultClient := &http.Client{Timeout: time.Second * 5}
+	var buf []byte
 	var err error
 
 	// Resetting Etag.
 	lastCloudConfigETag = ""
 
 	// Pulling first time.
-	if _, err = pullConfigFile(httpDefaultClient); err != nil {
+	if buf, err = pullConfigFile(httpDefaultClient); err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that we got a valid config.
+	cfg := &config{}
+	if err = cfg.updateFrom(buf); err != nil {
 		t.Fatal(err)
 	}
 
@@ -20,21 +30,5 @@ func TestConfigDownload(t *testing.T) {
 		if err != errConfigurationUnchanged {
 			t.Fatal(err)
 		}
-	}
-}
-
-func TestConfigParse(t *testing.T) {
-	var cfg *config
-	var err error
-
-	// Resetting Etag.
-	lastCloudConfigETag = ""
-
-	if cfg, err = getConfig(); err != nil {
-		t.Fatal(err)
-	}
-
-	if cfg == nil {
-		t.Fatal("Expecting non-nil config file.")
 	}
 }


### PR DESCRIPTION
@myleshorton : I think the only really necessary thing that the withclient scheme did was to clean up the extra fronted.Dialers that we were creating for direct domain fronting, as a result of extracting 'HighestQOSFrontedDialer'.  If we leave that logic at the balancer, the balancer takes care of cleaning those up alright.  

This PR makes a smaller change, while cherry picking all the useful things that came up while working on #2520 and #2529, as per: 

https://github.com/getlantern/lantern/pull/2529#issuecomment-102879786

I also made the commits tidier so they make it easier to understand the changes.  I think it will be faster to review this if you read the individual commits.