### PR TITLE
Adding waitforserver when creating HTTP proxy client.

### DIFF
--- a/src/github.com/getlantern/flashlight/util/http.go
+++ b/src/github.com/getlantern/flashlight/util/http.go
@@ -37,18 +37,8 @@ func HTTPClient(rootCA string, proxyAddr string) (*http.Client, error) {
 // proxyAddr is specified, the client will proxy through the given http proxy.
 func httpClient(rootCA string, proxyAddr string, persistent bool) (*http.Client, error) {
 
-	log.Debugf("Waiting for proxy server...")
-
-	// Waiting for proxy server to came online.
-	err := waitforserver.WaitForServer("tcp", proxyAddr, 60*time.Second)
-	if err != nil {
-		// Instead of finishing here we just log the error and continue, the client
-		// we are going to create will surely fail when used and return errors,
-		// those errors should be handled by the code that depends on such client.
-		log.Errorf("Proxy never came online at %v: %q", proxyAddr, err)
-	}
-
 	log.Debugf("Creating new HTTPClient with proxy: %v", proxyAddr)
+
 	tr := &http.Transport{
 		Dial: (&net.Dialer{
 			Timeout:   60 * time.Second,
@@ -75,17 +65,37 @@ func httpClient(rootCA string, proxyAddr string, persistent bool) (*http.Client,
 			RootCAs: caCert.PoolContainingCert(),
 		}
 	}
+
 	if proxyAddr != "" {
+
+		host, _, err := net.SplitHostPort(proxyAddr)
+		if err != nil {
+			return nil, fmt.Errorf("Unable to split host and port for %v: %v", proxyAddr, err)
+		}
+
+		noHostSpecified := host == ""
+		if noHostSpecified {
+			// For addresses of the form ":8080", prepend the loopback IP
+			host = "127.0.0.1"
+			proxyAddr = host + proxyAddr
+		}
+
+		var ip net.IP
+		if ip = net.ParseIP(host); ip != nil {
+			if ip.IsLoopback() {
+				log.Debugf("Waiting for loopback proxy server to came online...")
+				// Waiting for proxy server to came online.
+				err := waitforserver.WaitForServer("tcp", proxyAddr, 60*time.Second)
+				if err != nil {
+					// Instead of finishing here we just log the error and continue, the client
+					// we are going to create will surely fail when used and return errors,
+					// those errors should be handled by the code that depends on such client.
+					log.Errorf("Proxy never came online at %v: %q", proxyAddr, err)
+				}
+			}
+		}
+
 		tr.Proxy = func(req *http.Request) (*url.URL, error) {
-			host, _, err := net.SplitHostPort(proxyAddr)
-			if err != nil {
-				return nil, fmt.Errorf("Unable to split host and port for %v: %v", proxyAddr, err)
-			}
-			noHostSpecified := host == ""
-			if noHostSpecified {
-				// For addresses of the form ":8080", prepend the loopback IP
-				proxyAddr = "127.0.0.1" + proxyAddr
-			}
 			return url.Parse("http://" + proxyAddr)
 		}
 	}


### PR DESCRIPTION
Hello @atavism, @myleshorton, this is a suggested fix for https://github.com/getlantern/lantern/pull/2541, I think it would be better to handle the waitforserver call inside the proxy creation routine, could you give it a look?