### PR TITLE
adding heroku and loggly to proxied sites list #2482

### DIFF
--- a/src/github.com/getlantern/flashlight/genconfig/proxiedsites/original.txt
+++ b/src/github.com/getlantern/flashlight/genconfig/proxiedsites/original.txt
@@ -1,3 +1,5 @@
+herokuapp.com
+loggly.com
 masihalinejad.com
 babakdad.blogspot.fr
 asgharagha.com


### PR DESCRIPTION
This doesn't fully close out the issue but at least adds these to the list.