### PR TITLE
Issue 2552

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ PACKAGE_URL := https://www.getlantern.org
 
 LANTERN_BINARIES_PATH ?= ../lantern-binaries
 
-GO_MOBILE_REVISION=717c2c
+GO_MOBILE_REVISION=754ad3cfda342ad8c5d07a5ef9334f8a62b6aefa
 
 GH_USER := getlantern
 #GH_USER := xiam

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ PACKAGE_URL := https://www.getlantern.org
 
 LANTERN_BINARIES_PATH ?= ../lantern-binaries
 
+GO_MOBILE_REVISION=717c2c
+
 GH_USER := getlantern
 #GH_USER := xiam
 
@@ -192,9 +194,11 @@ docker-golang-android: require-mercurial
 	@$(call docker-up) && \
 	source setenv.bash && \
 	if [ -z "$$(docker images | grep golang/mobile)" ]; then \
-		docker pull golang/mobile && \
 		$(GO) get -d golang.org/x/mobile/example/... && \
-		$(GO) get golang.org/x/mobile/cmd/gobind; \
+		$(GO) get golang.org/x/mobile/cmd/gobind && \
+		cd src/golang.org/x/mobile && \
+		git checkout $(GO_MOBILE_REVISION) && \
+		docker build -t golang/mobile .; \
 	fi
 
 linux: genassets linux-386 linux-amd64

--- a/Makefile
+++ b/Makefile
@@ -190,6 +190,7 @@ docker: system-checks
 
 docker-golang-android: require-mercurial
 	@$(call docker-up) && \
+	source setenv.bash && \
 	if [ -z "$$(docker images | grep golang/mobile)" ]; then \
 		docker pull golang/mobile && \
 		$(GO) get -d golang.org/x/mobile/example/... && \


### PR DESCRIPTION
This should fix problems we were having by trying to build against the unstable golang/mobile repo.

See https://github.com/getlantern/lantern/issues/2552

In order to fully test this remove the golang/mobile docker image: `docker rmi -f golang/mobile` and try to create the Android's libjni