### PR TITLE
Patch for skipping a failing test than rendered our docker image usel…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,7 +37,7 @@ RUN mkdir -p $GOROOT && \
   git checkout release-branch.go1.4
 
 # Patch for skipping a failing test in new docker versions. See https://github.com/getlantern/lantern/issues/2578
-RUN yum install -y patch && yumm clean all
+RUN yum install -y patch && yum clean all
 RUN curl https://gist.githubusercontent.com/xiam/f50f6dd6085f9a07ccfd/raw/5e0f472221f9c1556fe34788ff01724b63980337/docker_golang | patch -p0
 
 # Bootstrapping Go.

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,11 @@ RUN (curl -sSL $GO_PACKAGE_URL | tar -xvz -C /tmp) && \
 RUN mkdir -p $GOROOT && \
   git clone https://go.googlesource.com/go $GOROOT && \
   cd $GOROOT && \
-  git checkout -b go1.4 origin/release-branch.go1.4
+  git checkout release-branch.go1.4
+
+# Patch for skipping a failing test in new docker versions. See https://github.com/getlantern/lantern/issues/2578
+RUN yum install -y patch && yumm clean all
+RUN curl https://gist.githubusercontent.com/xiam/f50f6dd6085f9a07ccfd/raw/5e0f472221f9c1556fe34788ff01724b63980337/docker_golang | patch -p0
 
 # Bootstrapping Go.
 RUN cd $GOROOT/src && CGO_ENABLED=1 ./all.bash


### PR DESCRIPTION
This should fix https://github.com/getlantern/lantern/issues/2578 and should allow us to continue using the docker image for building Lantern with go1.4.