### PR TITLE
fix client side of #2568

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -29,8 +29,8 @@ import (
 const (
 	CloudConfigPollInterval = 1 * time.Minute
 	cloudflare              = "cloudflare"
-	etag                    = "ETag"
-	ifNoneMatch             = "If-None-Match"
+	etag                    = "X-Lantern-Etag"
+	ifNoneMatch             = "X-Lantern-If-None-Match"
 )
 
 var (

--- a/src/github.com/getlantern/fronted/dialer.go
+++ b/src/github.com/getlantern/fronted/dialer.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"time"
@@ -212,6 +213,8 @@ func (ddf *DirectDomainTransport) RoundTrip(req *http.Request) (resp *http.Respo
 	// create a copy.
 	norm := new(http.Request)
 	*norm = *req // includes shallow copies of maps, but okay
+	norm.URL = new(url.URL)
+	*norm.URL = *req.URL
 	norm.URL.Scheme = "http"
 	return ddf.Transport.RoundTrip(norm)
 }

--- a/src/github.com/getlantern/fronted/dialer.go
+++ b/src/github.com/getlantern/fronted/dialer.go
@@ -16,6 +16,7 @@ import (
 
 	"encoding/asn1"
 	"github.com/getlantern/connpool"
+	"github.com/getlantern/deepcopy"
 	"github.com/getlantern/enproxy"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/proxy"
@@ -211,6 +212,9 @@ func (ddf *DirectDomainTransport) RoundTrip(req *http.Request) (resp *http.Respo
 	norm, err := http.NewRequest(req.Method, normalized, nil)
 	if err != nil {
 		return nil, fmt.Errorf("Unable to construct request for url '%s' with error '%v'", normalized, err)
+	}
+	if err = deepcopy.Copy(&norm.Header, req.Header); err != nil {
+		return nil, fmt.Errorf("Unable to copy request headers: %v", err)
 	}
 	return ddf.Transport.RoundTrip(norm)
 }


### PR DESCRIPTION
- Copy over the headers of direct fronted requests.

- Change to proprietary headers for caching, so CDNs and middleware
  will hopefully keep their dirty hands off them.

These won't take effect until we deploy the config server, but in the meanwhile they won't make things any more broken either.