### PR TITLE
add script to update the redis config from a cloud.yaml

### DIFF
--- a/src/github.com/getlantern/flashlight/README.md
+++ b/src/github.com/getlantern/flashlight/README.md
@@ -158,7 +158,7 @@ To add a bunch of servers to the queue of a datacenter, so they'll get pulled by
 
 - Generate a cloud.yaml from this fallbacks.json, as explained above.
 
-- In the `genconfig` directory, run `./cfg2redis.py cloud.yaml <dc>`.  Add the `--dc` option if you want to upload the datacenter configuration too (e.g., if this is a new datacenter).
+- In the `genconfig` directory, run `./cfg2redis.py cloud.yaml <dc>`, where `<dc>` is the datacenter where the servers are located.  Current values are 'doams3' for the Digital Ocean Amsterdam 3 datacenter, and 'vltok1' for the Vulture Tokyo datacenter.  Add the `--dc` option if you want to upload the datacenter configuration too (e.g., if this is a new datacenter), but of course make sure the cloud.yaml contains the right configuration for that datacenter (e.g. the right fronted round robin(s)).
 
 The cfg2redis has some prerequisites.  Just try it and it will tell you how to fulfill any missing ones.
 

--- a/src/github.com/getlantern/flashlight/README.md
+++ b/src/github.com/getlantern/flashlight/README.md
@@ -149,3 +149,21 @@ changes (e.g., when we launch or kill some server).  To learn how to reenerate
 the `fallbacks.json` file in that case, see [the relevant
 section](https://github.com/getlantern/lantern_aws#regenerating-flashlightgenconfigfallbackjson)
 of the README of the lantern_aws project.
+
+##### Uploading to redis
+
+To add a bunch of servers to the queue of a datacenter, so they'll get pulled by the config server as necessary,
+
+- Compile a fallbacks.json that only includes the given servers.  The quickest way to do this would be to generate the fallbacks.json with a prefix that only includes these servers.
+
+- Generate a cloud.yaml from this fallbacks.json, as explained above.
+
+- In the `genconfig` directory, run `./cfg2redis.py cloud.yaml <dc>`.  Add the `--dc` option if you want to upload the datacenter configuration too (e.g., if this is a new datacenter).
+
+The cfg2redis has some prerequisites.  Just try it and it will tell you how to fulfill any missing ones.
+
+If you *only* want to update the datacenter configuration you may say
+
+    echo "[]" > fallbacks.json
+    ./genconfig.bash
+    ./cfg2redis.py --dc cloud.yaml doams3

--- a/src/github.com/getlantern/flashlight/genconfig/cfg2redis.py
+++ b/src/github.com/getlantern/flashlight/genconfig/cfg2redis.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python
+
+import hashlib
+import os
+import sys
+
+try:
+    import redis
+except ImportError:
+    print "This requires redis-py.  Try something like"
+    print "    pip install hiredis ; pip install redis"
+    sys.exit(1)
+try:
+    import yaml
+except ImportError:
+    print "This requires PyYaml.  Try something like"
+    print "    pip install pyyaml"
+    sys.exit(1)
+
+def r():
+    if not hasattr(r, 'r'):
+        url = os.getenv("REDISCLOUD_PRODUCTION_URL")
+        if url is None:
+            print "A REDISCLOUD_PRODUCTION_URL environment variable is required."
+            print
+            print "Try `heroku config` in the root of the getlantern/config-server"
+            print "project to get the production one, or use 127.0.0.1:6379 for"
+            print "local testing (requires a running redis service)."
+            sys.exit(1)
+        r.r = redis.from_url(url)
+    return r.r
+
+def reset():
+    print
+    print "*** WARNING ***"
+    print
+    print "THIS WILL WIPE OUT THE DATABASE!!!"
+    print
+    if raw_input("Are you sure? (y/N): ").strip().lower() not in ["y", "yes"]:
+        sys.exit(0)
+    r().flushall()
+
+def feed(src, dc, globalcfg=False, dccfg=False, setdefaultdc=False):
+    p = r().pipeline(transaction=True)
+    cfg = yaml.load(file(src))
+    servers = cfg['client']['chainedservers']
+    if dccfg:
+        dccfg = "\n    " + yaml.dump(cfg['client']['frontedservers'])
+        p.hset("cfgbydc", dc, dccfg)
+    if setdefaultdc:
+        p.set("defaultdc", dc)
+    if globalcfg:
+        cfg['client']['frontedservers'] = "<DC CONFIG HERE>"
+        cfg['client']['chainedservers'] = "<SERVER CONFIG HERE>"
+        globalcfg = yaml.dump(cfg)
+        p.set("globalcfg", globalcfg)
+        p.set("globalcfgsha", hashlib.sha1(globalcfg).hexdigest())
+    p.rpush(dc + ":srvq",
+            *("%s|\n    %s" % (v['addr'].split(':')[0], yaml.dump({k: v}))
+              for k,v in servers.iteritems()))
+    p.execute()
+
+def usage():
+    print "%s [<opts>] src dc" % sys.argv[0]
+    print "Options:"
+    print "    --global : Upload global config."
+    print "    --dc : Upload dc config."
+    print "    --defaultdc : Set dc as default."
+    sys.exit(1)
+
+if __name__ == '__main__':
+    opts = sys.argv[1:]
+    glb = dc = defaultdc = False
+    try:
+        opts.remove("--global")
+        glb = True
+    except ValueError:
+        pass
+    try:
+        opts.remove("--dc")
+        dc = True
+    except ValueError:
+        pass
+    try:
+        opts.remove("--defaultdc")
+        defaultdc = True
+    except ValueError:
+        pass
+    try:
+        src, dc = opts
+    except ValueError:
+        usage()
+    feed(src, dc, glb, dc, defaultdc)


### PR DESCRIPTION
This adds a semi-manual way to update the configuration in the redis database that [the config server](https://github.com/getlantern/config-server) uses.

Soon(TM), servers will register themselves when they come up.  At the moment, launching servers in Tokyo is still a semi-manual process, so that would need be fixed first.

As soon as we officially stop supporting client versions that rely on static `cloud.yaml`s we may do a more aggressive rewrite of this whole system, to simplify it.