### PR TITLE
close both clientConn and connOut to resolve #2330

### DIFF
--- a/src/github.com/getlantern/detour/detour.go
+++ b/src/github.com/getlantern/detour/detour.go
@@ -124,6 +124,7 @@ func Dialer(d dialFunc) dialFunc {
 					return dc, nil
 				}
 				log.Debugf("Dial %s to %s, dns hijacked, try detour", dc.stateDesc(), addr)
+				dc.conn.Close()
 			} else if detector.TamperingSuspected(err) {
 				log.Debugf("Dial %s to %s failed, try detour: %s", dc.stateDesc(), addr, err)
 			} else {

--- a/src/github.com/getlantern/flashlight/client/handler.go
+++ b/src/github.com/getlantern/flashlight/client/handler.go
@@ -105,6 +105,7 @@ func pipeData(clientConn net.Conn, connOut net.Conn, req *http.Request) {
 		// after completed send / receive so that won't cause problem.
 		wg.Wait()
 		clientConn.Close()
+		connOut.Close()
 	}()
 
 	// Respond OK


### PR DESCRIPTION
It is too simple to believe, but we just closed wrong connections. `io.Copy` will not return if there's nothing to read from `connOut` unless we close it. Though we should dig more into why `idletiming` doesn't cause `connOut.Read()` to return.

To verify, run below command at any time to see if the ingress and egress connection count equals.

```
PID=`ps -ef | grep lantern | grep -v grep | cut -d " " -f 4` && lsof -nPp $PID | grep TCP | grep "8787->" | grep EST | wc && lsof -nPp $PID | grep TCP | grep ":443 (ESTABLISHED)" | wc
```