### PR TITLE
add US round robin and IP prefixes

### DIFF
--- a/src/github.com/getlantern/peerscanner/host.go
+++ b/src/github.com/getlantern/peerscanner/host.go
@@ -43,7 +43,18 @@ var (
 	// tests may time out.
 	testSites = []string{"www.google.com", "www.youtube.com", "www.facebook.com"}
 
-	fallbackNamePattern = regexp.MustCompile(`^fl-([a-z]{2})-.+$`)
+	// Old style (country centric): fl-nl-20150302-025
+	// New style (datacenter centric): fl-donyc3-20150302-025
+	fallbackNamePattern = regexp.MustCompile(`^fl-([a-z]{2,5}[0-9]?)-.+$`)
+	fallbackCountries   = map[string]string{
+		// Backwards compatibility
+		"nl": "nl",
+		"jp": "jp",
+		// New-style
+		"doams3": "nl",
+		"donyc3": "us",
+		"vltok1": "jp",
+	}
 )
 
 type status struct {
@@ -548,7 +559,9 @@ func (h *host) reallyDoIsAbleToProxy(port string) (bool, bool, error) {
 func fallbackCountry(name string) string {
 	sub := fallbackNamePattern.FindSubmatch([]byte(name))
 	if len(sub) == 2 {
-		return string(sub[1]) + ".fallbacks"
+		if ret, found := fallbackCountries[string(sub[1])]; found {
+			return ret + ".fallbacks"
+		}
 	}
 	return ""
 }

--- a/src/github.com/getlantern/peerscanner/web.go
+++ b/src/github.com/getlantern/peerscanner/web.go
@@ -216,7 +216,9 @@ func isFallbackIp(ip string) bool {
 var fallbackIPPrefixes = []string{
 	"43.224.",
 	"45.63.",
+	"104.131",
 	"104.156.",
+	"104.236",
 	"104.238.",
 	"107.191.",
 	"108.61.",


### PR DESCRIPTION
This is live in the production peerscanner and working well.