### PR TITLE
Add Loggly setup to lantern-android

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ android-lib: docker-golang-android
 		mkdir -p bindings/go_bindings && \
 		gobind -lang=go github.com/getlantern/lantern-android/libflashlight/bindings > bindings/go_bindings/go_bindings.go && \
 		gobind -lang=java github.com/getlantern/lantern-android/libflashlight/bindings > bindings/Flashlight.java || exit 1;
-	@$(DOCKER) run -v $$PWD/src:/src golang/mobile /bin/bash -c \ "cd /src/github.com/getlantern/lantern-android/libflashlight && ./make.bash" && \
+	@$(DOCKER) run -v $$PWD/src:/src golang/mobile /bin/bash -c \ "cd /src/github.com/getlantern/lantern-android/libflashlight && ./make.bash $(GIT_REVISION) $(BUILD_DATE)" && \
 	ls -l src/github.com/getlantern/lantern-android/app/libs/armeabi-v7a/libgojni.so && \
 	if [ -d "$(FIRETWEET_DIR)" ]; then \
 		cp -v src/github.com/getlantern/lantern-android/app/libs/armeabi-v7a/libgojni.so $(FIRETWEET_DIR)/firetweet/src/main/jniLibs/armeabi-v7a && \

--- a/src/github.com/getlantern/flashlight/logging/logging.go
+++ b/src/github.com/getlantern/flashlight/logging/logging.go
@@ -137,7 +137,11 @@ func enableLoggly(addr string, cloudConfigCA string, instanceId string,
 }
 
 func addLoggly(logglyWriter io.Writer) {
-	golog.SetOutputs(NonStopWriter(errorOut, logglyWriter), debugOut)
+	if runtime.GOOS == "android" {
+		golog.SetOutputs(logglyWriter, os.Stdout)
+	} else {
+		golog.SetOutputs(NonStopWriter(errorOut, logglyWriter), debugOut)
+	}
 }
 
 func removeLoggly() {

--- a/src/github.com/getlantern/lantern-android/client/client.go
+++ b/src/github.com/getlantern/lantern-android/client/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/getlantern/analytics"
 	"github.com/getlantern/flashlight/client"
 	"github.com/getlantern/flashlight/globals"
+	"github.com/getlantern/flashlight/logging"
 	"github.com/getlantern/golog"
 )
 
@@ -17,6 +18,8 @@ const (
 
 // clientConfig holds global configuration settings for all clients.
 var (
+	version       string
+	buildDate     string
 	log           = golog.LoggerFor("lantern-android.client")
 	clientConfig  = defaultConfig()
 	trackingCodes = map[string]string{
@@ -54,8 +57,19 @@ func NewClient(addr, appName string) *MobileClient {
 		fronter: hqfd.NewDirectDomainFronter(),
 		appName: appName,
 	}
-	go mClient.updateConfig()
+	mClient.updateConfig()
 	return mClient
+}
+
+func init() {
+
+	if version == "" {
+		version = "development"
+	}
+
+	if buildDate == "" {
+		buildDate = "now"
+	}
 }
 
 func (client *MobileClient) ServeHTTP() {
@@ -64,6 +78,7 @@ func (client *MobileClient) ServeHTTP() {
 		onListening := func() {
 			log.Debugf("Now listening for connections...")
 			analytics.Configure(trackingCodes["FireTweet"], "", client.Client.Addr)
+			logging.Configure(client.Client.Addr, cloudConfigCA, InstanceId, version, buildDate)
 		}
 
 		defer func() {

--- a/src/github.com/getlantern/lantern-android/client/config.go
+++ b/src/github.com/getlantern/lantern-android/client/config.go
@@ -25,6 +25,7 @@ var lastCloudConfigETag string
 type config struct {
 	Client     *client.ClientConfig `yaml:"client"`
 	TrustedCAs []*ca                `yaml:"trustedcas"`
+	InstanceId string               `yaml:"instanceid"`
 }
 
 var (
@@ -43,6 +44,7 @@ const (
 	cloudConfigCA = ``
 	// URL of the configuration file. Remember to use HTTPs.
 	remoteConfigURL = `https://config.getiantem.org/cloud.yaml.gz`
+	InstanceId      = ``
 )
 
 // pullConfigFile attempts to retrieve a configuration file over the network,

--- a/src/github.com/getlantern/lantern-android/libflashlight/make.bash
+++ b/src/github.com/getlantern/lantern-android/libflashlight/make.bash
@@ -15,6 +15,12 @@ if [ ! -f make.bash ]; then
 fi
 
 ANDROID_APP=$PWD/../app
+GIT_REVISION=$1
+BUILD_DATE=$2
+LOGGLY_TOKEN=d730c074-1f0a-415d-8d71-1ebf1d8bd736                                                                                                          
+#LDFLAGS="-shared -w -X main.version $GIT_REVISION -X main.buildDate $BUILD_DATE -X github.com/getlantern/flashlight/logging.logglyToken $LOGGLY_TOKEN"
+
+echo $LDFLAGS
 
 mkdir -p gen src
 
@@ -24,7 +30,7 @@ mkdir -p $ANDROID_APP/libs/armeabi-v7a
 
 (cd $GOPATH/src/golang.org/x/mobile && cp $PWD/app/*.java $ANDROID_APP/src/go)
 (cd $GOPATH/src/golang.org/x/mobile && cp $PWD/bind/java/Seq.java $ANDROID_APP/src/go)
-CGO_ENABLED=1 GOOS=android GOARCH=arm GOARM=7 go build -ldflags="-shared" -o $ANDROID_APP/libs/armeabi-v7a/libgojni.so *.go
+CGO_ENABLED=1 GOOS=android GOARCH=arm GOARM=7 go build -ldflags='-shared -w -X main.version 8c79ebb -X main.buildDate 20150610.173859 -X github.com/getlantern/flashlight/logging.logglyToken d730c074-1f0a-415d-8d71-1ebf1d8bd736' -o $ANDROID_APP/libs/armeabi-v7a/libgojni.so *.go
 mv ./bindings/Flashlight.java $ANDROID_APP/src/org/getlantern
 cp AndroidManifest.xml $ANDROID_APP
 cp -r gen $ANDROID_APP

--- a/src/github.com/getlantern/lantern-android/libflashlight/make.bash
+++ b/src/github.com/getlantern/lantern-android/libflashlight/make.bash
@@ -18,9 +18,6 @@ ANDROID_APP=$PWD/../app
 GIT_REVISION=$1
 BUILD_DATE=$2
 LOGGLY_TOKEN=d730c074-1f0a-415d-8d71-1ebf1d8bd736                                                                                                          
-#LDFLAGS="-shared -w -X main.version $GIT_REVISION -X main.buildDate $BUILD_DATE -X github.com/getlantern/flashlight/logging.logglyToken $LOGGLY_TOKEN"
-
-echo $LDFLAGS
 
 mkdir -p gen src
 
@@ -30,7 +27,7 @@ mkdir -p $ANDROID_APP/libs/armeabi-v7a
 
 (cd $GOPATH/src/golang.org/x/mobile && cp $PWD/app/*.java $ANDROID_APP/src/go)
 (cd $GOPATH/src/golang.org/x/mobile && cp $PWD/bind/java/Seq.java $ANDROID_APP/src/go)
-CGO_ENABLED=1 GOOS=android GOARCH=arm GOARM=7 go build -ldflags='-shared -w -X main.version 8c79ebb -X main.buildDate 20150610.173859 -X github.com/getlantern/flashlight/logging.logglyToken d730c074-1f0a-415d-8d71-1ebf1d8bd736' -o $ANDROID_APP/libs/armeabi-v7a/libgojni.so *.go
+CGO_ENABLED=1 GOOS=android GOARCH=arm GOARM=7 go build -ldflags="-shared -w -X main.version $GIT_REVISION -X main.buildDate $BUILD_DATE -X github.com/getlantern/flashlight/logging.logglyToken $LOGGLY_TOKEN" -o $ANDROID_APP/libs/armeabi-v7a/libgojni.so *.go
 mv ./bindings/Flashlight.java $ANDROID_APP/src/org/getlantern
 cp AndroidManifest.xml $ANDROID_APP
 cp -r gen $ANDROID_APP


### PR DESCRIPTION
Some refactoring to use loggly from lantern-android.

Note: We're using a separate customer token for FireTweet in Loggly to delineate messages.