### PR TITLE
Detour detect ECONNREFUSED to resolve #2638

### DIFF
--- a/src/github.com/getlantern/detour/detect.go
+++ b/src/github.com/getlantern/detour/detect.go
@@ -3,7 +3,6 @@ package detour
 import (
 	"bytes"
 	"net"
-	"runtime"
 	"syscall"
 )
 
@@ -51,7 +50,10 @@ var defaultDetector = Detector{
 			}
 			// TCP RST triggers ECONNREFUSED instead of ECONNRESET on Android
 			// https://github.com/getlantern/lantern/issues/2375
-			if runtime.GOOS == "android" && oe.Err == syscall.ECONNREFUSED {
+			// It's also beneficial to treat all ECONNREFUSED as being blocked
+			// to facilitate testing.
+			// https://github.com/getlantern/lantern/issues/2638#issuecomment-111769428
+			if oe.Err == syscall.ECONNREFUSED {
 				return true
 			}
 		}

--- a/src/github.com/getlantern/detour/detour_test.go
+++ b/src/github.com/getlantern/detour/detour_test.go
@@ -46,6 +46,13 @@ func TestBlockedImmediately(t *testing.T) {
 		assertContent(t, resp, detourMsg, "should detour if dialing times out")
 	}
 
+	client = newClient(proxiedURL, 100*time.Millisecond)
+	resp, err = client.Get("http://127.0.0.1:4325") // hopefully this port didn't open, so connection will be refused
+	if assert.NoError(t, err, "should have no error if connection is refused") {
+		assert.True(t, wlTemporarily("127.0.0.1:4325"), "should be added to whitelist if connection is refused")
+		assertContent(t, resp, detourMsg, "should detour if connection is refused")
+	}
+
 	u, _ := url.Parse(mockURL)
 	resp, err = client.Get(mockURL)
 	if assert.NoError(t, err, "should have no error if reading times out") {


### PR DESCRIPTION
Now if we use fake DNS to point any site to 127.0.0.1, detour will work.

`lantern.log:Jun 18 01:53:41.667 - DEBUG detour: detour.go:136 Dial initially to gmail.com:443 failed, try detour: dial tcp 127.0.0.1:443: connection refused`