### PR TITLE
When the system's Lantern binary is changed (on Linux) use it instead of the copy

### DIFF
--- a/installer-resources/linux/lantern.sh
+++ b/installer-resources/linux/lantern.sh
@@ -13,14 +13,26 @@ LANTERN_WRAPPER_DIR=$(dirname "$LANTERN_WRAPPER")
 LANTERN_SOURCE_BINARY=$LANTERN_WRAPPER_DIR/lantern-binary
 
 LANTERN_USER_DIRECTORY=$HOME/.lantern
+LANTERN_SOURCE_BINARY_HASH=$LANTERN_USER_DIRECTORY/bin/lantern.sha1
 LANTERN_USER_BINARY=$LANTERN_USER_DIRECTORY/bin/lantern
 
-# A local copy of the Lantern binary is preferred since it can update by
-# itself.
+# Checking if the source Lantern binary had any change.
+if [ -f $LANTERN_SOURCE_BINARY_HASH ]; then
+  # If the checksum does not match then it probably means that the source
+  # binary got updated. See https://github.com/getlantern/lantern/issues/2670.
+  sha1sum -c $LANTERN_SOURCE_BINARY_HASH || rm -f $LANTERN_USER_BINARY;
+else
+  # This was an old version that didn't saved verification sums.
+  rm -f $LANTERN_USER_BINARY;
+fi
+
+# A local copy of the Lantern binary is preferred since it has the current
+# user's writing permissions and it can be updated.
 if [ ! -f $LANTERN_USER_BINARY ]; then
   # If there is no local copy, we use the original Lantern binary.
   mkdir -p $LANTERN_USER_DIRECTORY/bin
   cp $LANTERN_SOURCE_BINARY $LANTERN_USER_BINARY
+  sha1sum $LANTERN_SOURCE_BINARY > $LANTERN_SOURCE_BINARY_HASH
   chmod +x $LANTERN_USER_BINARY
 fi
 


### PR DESCRIPTION
Added a verification that checks whether the system's Lantern binary got changed and replaces the user's copy of the binary in such case. 

See #2670.