### PR TITLE
Gets rid of race condition on startup closes #2719

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -208,12 +208,6 @@ func runClientProxy(cfg *config.Config) {
 			exit(fmt.Errorf("Unable to start UI: %v", err))
 			return
 		}
-		/*
-			if showui {
-				// Launch a browser window with Lantern.
-				ui.Show()
-			}
-		*/
 	}
 
 	applyClientConfig(client, cfg)

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -208,10 +208,12 @@ func runClientProxy(cfg *config.Config) {
 			exit(fmt.Errorf("Unable to start UI: %v", err))
 			return
 		}
-		if showui {
-			// Launch a browser window with Lantern.
-			ui.Show()
-		}
+		/*
+			if showui {
+				// Launch a browser window with Lantern.
+				ui.Show()
+			}
+		*/
 	}
 
 	applyClientConfig(client, cfg)
@@ -229,7 +231,16 @@ func runClientProxy(cfg *config.Config) {
 
 	go func() {
 		addExitFunc(pacOff)
-		client.ListenAndServe(pacOn)
+		client.ListenAndServe(func() {
+			pacOn()
+			if showui {
+				// Launch a browser window with Lantern but only after the pac
+				// URL and the proxy server are all up and running to avoid
+				// race conditions where we change the proxy setup while the
+				// UI server and proxy server are still coming up.
+				ui.Show()
+			}
+		})
 	}()
 }
 

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -225,7 +225,7 @@ func runClientProxy(cfg *config.Config) {
 
 	go func() {
 		addExitFunc(pacOff)
-		client.ListenAndServe(func() {
+		err := client.ListenAndServe(func() {
 			pacOn()
 			if showui {
 				// Launch a browser window with Lantern but only after the pac
@@ -235,6 +235,9 @@ func runClientProxy(cfg *config.Config) {
 				ui.Show()
 			}
 		})
+		if err != nil {
+			log.Errorf("Error calling listen and serve: %v", err)
+		}
 	}()
 }
 

--- a/src/github.com/getlantern/flashlight/ui/ui.go
+++ b/src/github.com/getlantern/flashlight/ui/ui.go
@@ -97,15 +97,20 @@ func Show() {
 			log.Errorf("Could not parse url `%v` with error `%v`", uiaddr, er)
 			return
 		}
-
 		if err := waitforserver.WaitForServer("tcp", addr.Host, 10*time.Second); err != nil {
 			log.Errorf("Error waiting for server: %v", err)
 			return
 		}
-		open.Run(uiaddr)
+		err := open.Run(uiaddr)
+		if err != nil {
+			log.Errorf("Error opening page to `%v`: %v", uiaddr, err)
+		}
 		if externalUrl != "NO"+"_URL" && !openedExternal {
 			time.Sleep(4 * time.Second)
-			open.Run(externalUrl)
+			err = open.Run(externalUrl)
+			if err != nil {
+				log.Errorf("Error opening external page to `%v`: %v", uiaddr, err)
+			}
 			openedExternal = true
 		}
 	}()

--- a/src/github.com/getlantern/flashlight/ui/ui.go
+++ b/src/github.com/getlantern/flashlight/ui/ui.go
@@ -87,11 +87,11 @@ func Start(addr string) error {
 	return nil
 }
 
-// Show opens the UI in a browser. It will wait for the UI addr come up for at most 3 seconds
-// Note we know the UI server is *listening* at this point as long as Start is
-// correctly called prior to this method. It may not be reading yet, but
-// since we're the only ones reading from those incoming sockets the fact
-// that reading starts asynchronously is not a problem.
+// Show opens the UI in a browser. Note we know the UI server is
+// *listening* at this point as long as Start is correctly called prior
+// to this method. It may not be reading yet, but since we're the only
+// ones reading from those incoming sockets the fact that reading starts
+// asynchronously is not a problem.
 func Show() {
 	go func() {
 		err := open.Run(uiaddr)

--- a/src/github.com/getlantern/flashlight/ui/ui.go
+++ b/src/github.com/getlantern/flashlight/ui/ui.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"net/url"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -90,18 +89,13 @@ func Start(addr string) error {
 }
 
 // Show opens the UI in a browser. It will wait for the UI addr come up for at most 3 seconds
+// Note we know the UI server is *listening* at this point as long as Start is
+// correctly called prior to this method. It may not be reading yet, but
+// since we're the only ones reading from those incoming sockets the fact
+// that reading starts asynchronously is not a problem.
 func Show() {
 	go func() {
-		addr, err := url.Parse(uiaddr)
-		if err != nil {
-			log.Errorf("Could not parse url `%v` with error `%v`", uiaddr, err)
-			return
-		}
-		if err := waitforserver.WaitForServer("tcp", addr.Host, 10*time.Second); err != nil {
-			log.Errorf("Error waiting for server: %v", err)
-			return
-		}
-		err = open.Run(uiaddr)
+		err := open.Run(uiaddr)
 		if err != nil {
 			log.Errorf("Error opening page to `%v`: %v", uiaddr, err)
 		}

--- a/src/github.com/getlantern/flashlight/ui/ui.go
+++ b/src/github.com/getlantern/flashlight/ui/ui.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/getlantern/golog"
 	"github.com/getlantern/tarfs"
-	"github.com/getlantern/waitforserver"
 	"github.com/skratchdot/open-golang/open"
 )
 

--- a/src/github.com/getlantern/flashlight/ui/ui.go
+++ b/src/github.com/getlantern/flashlight/ui/ui.go
@@ -92,9 +92,14 @@ func Start(addr string) error {
 // Show opens the UI in a browser. It will wait for the UI addr come up for at most 3 seconds
 func Show() {
 	go func() {
-		addr, _ := url.Parse(uiaddr)
-		if err := waitforserver.WaitForServer("tcp", addr.Host, 3*time.Second); err != nil {
-			log.Error(err)
+		addr, er := url.Parse(uiaddr)
+		if er != nil {
+			log.Errorf("Could not parse url `%v` with error `%v`", uiaddr, er)
+			return
+		}
+
+		if err := waitforserver.WaitForServer("tcp", addr.Host, 10*time.Second); err != nil {
+			log.Errorf("Error waiting for server: %v", err)
 			return
 		}
 		open.Run(uiaddr)

--- a/src/github.com/getlantern/flashlight/ui/ui.go
+++ b/src/github.com/getlantern/flashlight/ui/ui.go
@@ -28,7 +28,7 @@ var (
 	server       *http.Server
 	uiaddr       string
 
-	externalUrl    = "https://www.facebook.com/manototv/" // this string is going to be changed by Makefile
+	externalUrl    = "https://www.facebook.com/manototv" // this string is going to be changed by Makefile
 	openedExternal = false
 	r              = http.NewServeMux()
 )

--- a/src/github.com/getlantern/flashlight/ui/ui.go
+++ b/src/github.com/getlantern/flashlight/ui/ui.go
@@ -92,16 +92,16 @@ func Start(addr string) error {
 // Show opens the UI in a browser. It will wait for the UI addr come up for at most 3 seconds
 func Show() {
 	go func() {
-		addr, er := url.Parse(uiaddr)
-		if er != nil {
-			log.Errorf("Could not parse url `%v` with error `%v`", uiaddr, er)
+		addr, err := url.Parse(uiaddr)
+		if err != nil {
+			log.Errorf("Could not parse url `%v` with error `%v`", uiaddr, err)
 			return
 		}
 		if err := waitforserver.WaitForServer("tcp", addr.Host, 10*time.Second); err != nil {
 			log.Errorf("Error waiting for server: %v", err)
 			return
 		}
-		err := open.Run(uiaddr)
+		err = open.Run(uiaddr)
 		if err != nil {
 			log.Errorf("Error opening page to `%v`: %v", uiaddr, err)
 		}


### PR DESCRIPTION
I'm not 100% sure why it seems to fix the issue, but this change removes a race condition on startup that could make the following sequence run in almost any order:

1. Lantern UI server port comes up
1. Lantern opens browser
1. Lantern proxy server comes up
1. Lantern sets the system proxy

My theory is that IE can get confused in some cases depending on the actual order those steps get executed, and in all my testing this change fixes the problem and ensures those steps always proceed as follows:

1. Lantern UI server port comes up
1. Lantern proxy server comes up
1. Lantern sets the system proxy
1. Lantern opens browser