### PR TITLE
Adding version to config file name closes #2731

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -74,8 +74,8 @@ type CA struct {
 }
 
 // Init initializes the configuration system.
-func Init() (*Config, error) {
-	configPath, err := InConfigDir("lantern.yaml")
+func Init(version string) (*Config, error) {
+	configPath, err := InConfigDir("lantern-" + version + ".yaml")
 	if err != nil {
 		return nil, err
 	}

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -117,7 +117,7 @@ func doMain() error {
 
 	parseFlags()
 
-	cfg, err := config.Init(packageVersion)
+	cfg, err := config.Init(version)
 	if err != nil {
 		return fmt.Errorf("Unable to initialize configuration: %v", err)
 	}

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -117,7 +117,7 @@ func doMain() error {
 
 	parseFlags()
 
-	cfg, err := config.Init()
+	cfg, err := config.Init(packageVersion)
 	if err != nil {
 		return fmt.Errorf("Unable to initialize configuration: %v", err)
 	}

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -117,7 +117,7 @@ func doMain() error {
 
 	parseFlags()
 
-	cfg, err := config.Init(version)
+	cfg, err := config.Init(packageVersion)
 	if err != nil {
 		return fmt.Errorf("Unable to initialize configuration: %v", err)
 	}


### PR DESCRIPTION
This just adds the Lantern version to the yaml config file name on disk. That prevents Lantern from ever reading config files from old versions, which I think is exactly what we want.