### PR TITLE
Make fronted servers trusted by default closes #2737

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -280,6 +280,7 @@ func (cfg *Config) applyClientDefaults() {
 				MaxMasquerades: 20,
 				QOS:            10,
 				Weight:         4000,
+				Trusted:        true,
 			},
 		}
 


### PR DESCRIPTION
This allows fronted servers to proxy http traffic if chained servers are blocked.