### PR TITLE
Removing tlsInfo() to keep logs clean and short.

### DIFF
--- a/src/github.com/getlantern/fronted/masquerade.go
+++ b/src/github.com/getlantern/fronted/masquerade.go
@@ -145,12 +145,6 @@ func (vms *verifiedMasqueradeSet) doVerify(masquerade *Masquerade) bool {
 		resp, err := httpClient.Do(req)
 		if err != nil {
 			errmsg := fmt.Sprintf("HTTP error for masquerade %v: %v", masquerade.Domain, err)
-			// I'm commenting this out because we haven't captured any extended log.
-			// See https://github.com/getlantern/lantern/issues/2398
-			//if _, ok := err.(x509.UnknownAuthorityError); ok {
-			errmsg = fmt.Sprintf("%s, tlsInfo: %s", errmsg, vms.dialer.tlsInfo(masquerade))
-			//}
-
 			errCh <- fmt.Errorf(errmsg)
 			return
 		} else {


### PR DESCRIPTION
I think we don't need `tlsInfo()` anymore.