### PR TITLE
Fixing REVISION_DATE on Linux.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ GIT_REVISION_SHORTCODE := $(shell git rev-parse --short HEAD)
 GIT_REVISION := $(shell git describe --abbrev=0 --tags --exact-match 2> /dev/null || git rev-parse --short HEAD)
 GIT_REVISION_DATE := $(shell git show -s --format=%ci $(GIT_REVISION_SHORTCODE))
 
-REVISION_DATE := $(shell date -u -j -f "%F %T %z" "$(GIT_REVISION_DATE)" +"%Y%m%d.%H%M%S" || date -u -d "$(GIT_REVISION_DATE)" +"%Y%m%d.%H%M%S")
+REVISION_DATE := $(shell date -u -j -f "%F %T %z" "$(GIT_REVISION_DATE)" +"%Y%m%d.%H%M%S" 2>/dev/null || date -u -d "$(GIT_REVISION_DATE)" +"%Y%m%d.%H%M%S")
 BUILD_DATE := $(shell date -u +%Y%m%d.%H%M%S)
 
 LOGGLY_TOKEN := 469973d5-6eaf-445a-be71-cf27141316a1


### PR DESCRIPTION
Our Makefile was failing on Linux, see: https://github.com/getlantern/lantern/issues/2760