### PR TITLE
not proxy traffic to LAN hosts

### DIFF
--- a/src/github.com/getlantern/flashlight/pac.go
+++ b/src/github.com/getlantern/flashlight/pac.go
@@ -80,8 +80,18 @@ func genPACFile() {
 	formatter :=
 		`var bypassDomains = %s;
 		function FindProxyForURL(url, host) {
-			if (host == "localhost" || host == "127.0.0.1") {
+			if (isPlainHostName(host) // including localhost
+			|| shExpMatch(host, "*.local")) {
 				return "DIRECT";
+			}
+			// only checks plain IP addresses to avoid leaking domain name
+			if (/^[0-9.]+$/.test(host)) {
+				if (isInNet(host, "10.0.0.0", "255.0.0.0") ||
+				isInNet(host, "172.16.0.0",  "255.240.0.0") ||
+				isInNet(host, "192.168.0.0",  "255.255.0.0") ||
+				isInNet(host, "127.0.0.0", "255.255.255.0")) {
+					return "DIRECT";
+				}
 			}
 			for (var d in bypassDomains) {
 				if (host == bypassDomains[d]) {


### PR DESCRIPTION
Resolves https://github.com/getlantern/lantern/issues/2780

To exam ports, we have to match url with regex, which is error prone and [never perfect](https://mathiasbynens.be/demo/url-regex). It's rare to access non-standard ports on Internet, so I just skip it.