### PR TITLE
Rewriting the warning message to sound less like an error.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -476,7 +476,7 @@ android-lib: docker-mobile
 	else \
 		echo ""; \
 		echo "Either no FIRETWEET_MAIN_DIR variable was passed or the given value is not a";\
-		echo "directory. You'll have to copy the .arr file manually:"; \
+		echo "directory. You'll have to copy the $(LANTERN_MOBILE_LIBRARY) file manually:"; \
 		echo ""; \
 		echo "cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) \$$FIRETWEET_MAIN_DIR"; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -474,7 +474,11 @@ android-lib: docker-mobile
 	if [ -d "$(FIRETWEET_MAIN_DIR)" ]; then \
 		cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) $(FIRETWEET_MAIN_DIR)/libs/$(LANTERN_MOBILE_LIBRARY); \
 	else \
-		echo "FIRETWEET_MAIN_DIR environment variable: directory does not exist"; \
+		echo ""; \
+		echo "Either no FIRETWEET_MAIN_DIR variable was passed or the given value is not a";\
+		echo "directory. You'll have to copy the .arr file manually:"; \
+		echo ""; \
+		echo "cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) \$$FIRETWEET_MAIN_DIR"; \
 	fi
 
 android-lib-dist: genconfig android-lib


### PR DESCRIPTION
At the end of the `make android-lib` I got this message:

```
FIRETWEET_MAIN_DIR environment variable: directory does not exist
```
Documentation says:

> If you pass the FIRETWEET_MAIN_DIR env variable to make android-lib, the generated bindings and library will be copied into it:

I didn't pass the variable, I just have my `FIRETWEET_MAIN_DIR` in another location.

I think the message is a bit confusing, it *sounds* like an error, but it isn't. @uaalto What do you think of this new message?

```
Either no FIRETWEET_MAIN_DIR variable was passed or the given value is not a
directory. You'll have to copy the .arr file manually:

cp -v src/github.com/getlantern/lantern-mobile/libflashlight.aar $FIRETWEET_MAIN_DIR
```