### PR TITLE
Adding more detailed error info in response bodies closes #2822

### DIFF
--- a/src/github.com/getlantern/enproxy/proxy.go
+++ b/src/github.com/getlantern/enproxy/proxy.go
@@ -348,11 +348,15 @@ func clientIpFor(req *http.Request) string {
 }
 
 func badGateway(resp http.ResponseWriter, msg string) {
-	log.Errorf("Responding Bad Gateway: %s", msg)
-	resp.WriteHeader(http.StatusBadGateway)
+	respond(http.StatusBadGateway, resp, fmt.Sprintf("Enproxy server responding Bad Gateway: %s", msg))
 }
 
 func forbidden(resp http.ResponseWriter, msg string) {
-	log.Errorf("Responding Forbidden: %s", msg)
-	resp.WriteHeader(http.StatusForbidden)
+	respond(http.StatusForbidden, resp, fmt.Sprintf("Enproxy server responding Forbidden: %s", msg))
+}
+
+func respond(status int, resp http.ResponseWriter, msg string) {
+	log.Errorf(msg)
+	resp.WriteHeader(status)
+	resp.Write([]byte(msg))
 }


### PR DESCRIPTION
This combined with more detailed client side logging should help narrow down some of these issues.