### PR TITLE
Adding -clear-proxy-settings as workaround for #2776

### DIFF
--- a/installer-resources/windows/lantern.nsi
+++ b/installer-resources/windows/lantern.nsi
@@ -83,6 +83,10 @@ Section
     # This is a bad registry entry created by old Lantern versions.
     DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Run\value"
 
+    # Add a registry key to set -clear-proxy-settings. See https://github.com/getlantern/lantern/issues/2776
+    WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Run" \
+                     "Lantern" "$\"$INSTDIR\lantern.exe$\" -clear-proxy-settings"
+
     # Launch Lantern
     ShellExecAsUser::ShellExecAsUser "" "$INSTDIR\lantern.exe"
 

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -45,9 +45,10 @@ var (
 	log = golog.LoggerFor("flashlight")
 
 	// Command-line Flags
-	help     = flag.Bool("help", false, "Get usage help")
-	headless = flag.Bool("headless", false, "if true, lantern will run with no ui")
-	startup  = flag.Bool("startup", false, "if true, Lantern was automatically run on system startup")
+	help               = flag.Bool("help", false, "Get usage help")
+	headless           = flag.Bool("headless", false, "if true, lantern will run with no ui")
+	startup            = flag.Bool("startup", false, "if true, Lantern was automatically run on system startup")
+	clearProxySettings = flag.Bool("clear-proxy-settings", false, "if true, Lantern removes proxy settings from the system.")
 
 	showui = true
 
@@ -84,6 +85,18 @@ func init() {
 
 func main() {
 	parseFlags()
+
+	if *clearProxySettings {
+		// This is a workaround that attempts to fix a Windows-only problem where
+		// Lantern was unable to clean the system's proxy settings before logging
+		// off.
+		//
+		// See: https://github.com/getlantern/lantern/issues/2776
+		setUpPacTool()
+		doPACOff()
+		return
+	}
+
 	showui = !*headless
 
 	if showui {

--- a/src/github.com/getlantern/launcher/launcher_windows.go
+++ b/src/github.com/getlantern/launcher/launcher_windows.go
@@ -25,14 +25,13 @@ func CreateLaunchFile(autoLaunch bool) {
 			log.Errorf("Could not get Lantern directory path: %q", err)
 			return
 		}
-		err = gowin.WriteStringReg("HKCU", runDir, "Lantern", "\""+lanternPath+"\""+" -startup")
+		err = gowin.WriteStringReg("HKCU", runDir, "Lantern", fmt.Sprintf(`"%s" -startup`, lanternPath))
 		if err != nil {
 			log.Errorf("Error inserting Lantern auto-start registry key: %q", err)
 		}
 	} else {
-		// We just set the value to the empty string because the windows registry
-		// library we're using doesn't support RegDeleteValue
-		err = gowin.WriteStringReg("HKCU", runDir, "Lantern", "")
+		// Just remove proxy settings and quit.
+		err = gowin.WriteStringReg("HKCU", runDir, "Lantern", fmt.Sprintf(`"%s" -clear-proxy-settings`, lanternPath))
 		if err != nil {
 			log.Errorf("Error removing Lantern auto-start registry key: %q", err)
 		}

--- a/src/github.com/getlantern/launcher/launcher_windows.go
+++ b/src/github.com/getlantern/launcher/launcher_windows.go
@@ -2,6 +2,7 @@
 package launcher
 
 import (
+	"fmt"
 	"github.com/kardianos/osext"
 	"github.com/luisiturrios/gowin"
 
@@ -17,23 +18,24 @@ var (
 )
 
 func CreateLaunchFile(autoLaunch bool) {
-	var err error
+	var startupCommand string
+
+	lanternPath, err := osext.Executable()
+	if err != nil {
+		log.Errorf("Could not get Lantern directory path: %q", err)
+		return
+	}
 
 	if autoLaunch {
-		lanternPath, err := osext.Executable()
-		if err != nil {
-			log.Errorf("Could not get Lantern directory path: %q", err)
-			return
-		}
-		err = gowin.WriteStringReg("HKCU", runDir, "Lantern", fmt.Sprintf(`"%s" -startup`, lanternPath))
-		if err != nil {
-			log.Errorf("Error inserting Lantern auto-start registry key: %q", err)
-		}
+		// Start Lantern normally.
+		startupCommand = fmt.Sprintf(`"%s" -startup`, lanternPath)
 	} else {
-		// Just remove proxy settings and quit.
-		err = gowin.WriteStringReg("HKCU", runDir, "Lantern", fmt.Sprintf(`"%s" -clear-proxy-settings`, lanternPath))
-		if err != nil {
-			log.Errorf("Error removing Lantern auto-start registry key: %q", err)
-		}
+		// Just clear stored proxy settings and quit.
+		startupCommand = fmt.Sprintf(`"%s" -clear-proxy-settings`, lanternPath)
+	}
+
+	err = gowin.WriteStringReg("HKCU", runDir, "Lantern", startupCommand)
+	if err != nil {
+		log.Errorf("Error setting Lantern auto-start registry key: %q", err)
 	}
 }


### PR DESCRIPTION
This is a workaround that relies on Lantern running at Windows start up with an specific flag that was introduced only to clear system proxy settings.

See #2776 