### PR TITLE
sleep unconditionally on every iteration of register loop

### DIFF
--- a/src/github.com/getlantern/flashlight/server/server.go
+++ b/src/github.com/getlantern/flashlight/server/server.go
@@ -236,9 +236,9 @@ func (server *Server) register(updateConfig func(func(*ServerConfig) error)) {
 				if err == nil {
 					resp.Body.Close()
 				}
-				time.Sleep(registerPeriod)
 			}
 		}
+		time.Sleep(registerPeriod)
 	}
 }
 


### PR DESCRIPTION
Fixes #2539.

If `registerat` flag was empty, this would busy wait forever, hogging one CPU.