### PR TITLE
filter countries by blacklist, not whitelist

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -355,9 +355,9 @@ func runServerProxy(cfg *config.Config) {
 		},
 		AllowedPorts: []int{80, 443, 8080, 8443, 5222, 5223, 5228},
 
-		// We allow all censored countries plus us, es, mx, and gb because we do work
-		// and testing from those countries.
-		AllowedCountries: []string{"US", "ES", "MX", "GB", "CN", "VN", "IN", "IQ", "IR", "CU", "SY", "SA", "BH", "ET", "ER", "UZ", "TM", "PK", "TR", "VE"},
+		// We've observed high resource consumption from these countries for
+		// purposes unrelated to Lantern's mission, so we disallow them.
+		BannedCountries: []string{"PH"},
 	}
 
 	srv.Configure(cfg.Server)


### PR DESCRIPTION
Fixes #2395.  I tested this by deploying a binary built from this to one of our flashlight servers.  I got evidence that some hitherto banned countries were allowed, like Thailand:

    Aug  6 04:25:02 fl-nl-20150226-010 flashlight: Aug 06 04:25:02.809 - 0m54s DEBUG flashlight.statreporter: statreporter.go:252 Reported {"dims":{"country":"TH"},"increments":{"bytesGivenTo":439,"bytesGivenToByFlashlight":439},"multiMembers":{"distinctClients":["180.183.148.247"],"distinctDestHosts":["www.google.com"]}} to statshub

But that PH was still banned:

    Aug  6 04:25:43 fl-nl-20150226-010 flashlight: Aug 06 04:25:43.142 - 1m34s ERROR enproxy: proxy.go:358 Origin country not allowed: Not accepting connections from country PH

