### PR TITLE
Provide TLS Config to failing tests that randomly reach handshaking and fail unproperly

### DIFF
--- a/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
+++ b/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
@@ -206,7 +206,7 @@ func TestVariableTimeouts(t *testing.T) {
 		// leading to a successful connection and thus a failed test. On the other hand,
 		// we need to make this limit relatively high, to allow timeouts to happen at different
 		// places
-		doTestTimeout(t, time.Duration(rand.Intn(4000)+1)*time.Microsecond)
+		doTestTimeout(t, time.Duration(rand.Intn(5000)+1)*time.Microsecond)
 	}
 
 	// Wait to give the sockets time to close

--- a/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
+++ b/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
@@ -202,7 +202,11 @@ func TestVariableTimeouts(t *testing.T) {
 	}
 
 	for i := 0; i < 500; i++ {
-		doTestTimeout(t, time.Duration(rand.Intn(5000)+1)*time.Microsecond)
+		// The 5000 microseconds limit is arbitrary. In some systems this may be too high,
+		// leading to a successful connection and thus a failed test. On the other hand,
+		// we need to make this limit relatively high, to allow timeouts to happen at different
+		// places
+		doTestTimeout(t, time.Duration(rand.Intn(4000)+1)*time.Microsecond)
 	}
 
 	// Wait to give the sockets time to close

--- a/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
+++ b/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
@@ -213,7 +213,9 @@ func TestVariableTimeouts(t *testing.T) {
 func doTestTimeout(t *testing.T, timeout time.Duration) {
 	_, err := DialWithDialer(&net.Dialer{
 		Timeout: timeout,
-	}, "tcp", ADDR, false, nil)
+	}, "tcp", ADDR, false, &tls.Config{
+		RootCAs: cert.PoolContainingCert(),
+	})
 
 	assert.Error(t, err, "There should have been a problem dialing", timeout)
 


### PR DESCRIPTION
Closes #2858 
I've run the tests on Travis 5 times. This error is not easily reproducible, it is a matter of times run. In case it fails again, we will reduce the timeout from 5000 microseconds to something like 3000-4000. But if it works with this tweak, is best to keep it at 5000.