### PR TITLE
Prepend timestamp only on first line of a multiline output

### DIFF
--- a/src/github.com/getlantern/wfilter/wfilter.go
+++ b/src/github.com/getlantern/wfilter/wfilter.go
@@ -9,19 +9,19 @@ import (
 type Prepend func(w io.Writer) (int, error)
 
 // LinePrepender creates an io.Writer that prepends to each line by calling the
-// given prepend function. Perepend can write whatever it wants. It should
+// given prepend function. Prepend can write whatever it wants. It should
 // return the bytes written and any error encountered.
 func LinePrepender(w io.Writer, prepend Prepend) io.Writer {
-	return &lp{w, prepend, true}
+	return &linePrepender{w, prepend, true}
 }
 
-type lp struct {
+type linePrepender struct {
 	io.Writer
 	prepend       Prepend
 	prependNeeded bool
 }
 
-func (w *lp) Write(buf []byte) (int, error) {
+func (w *linePrepender) Write(buf []byte) (int, error) {
 	if w.prependNeeded {
 		_, err := w.prepend(w.Writer)
 		if err != nil {
@@ -65,4 +65,30 @@ func (w *lp) Write(buf []byte) (int, error) {
 	n, err := w.Writer.Write(buf)
 	totalN += n
 	return totalN, err
+}
+
+// SimplePrepender creates an io.Writer that prepends to each line by calling the
+// given prepend function. Prepend can write whatever it wants. It should
+// return the bytes written and any error encountered.
+func SimplePrepender(w io.Writer, prepend Prepend) io.Writer {
+	return &simplePrepender{w, prepend}
+}
+
+type simplePrepender struct {
+	io.Writer
+	prepend Prepend
+}
+
+func (w *simplePrepender) Write(buf []byte) (int, error) {
+	written := 0
+
+	n, err := w.prepend(w.Writer)
+	written = written + n
+	if err != nil {
+		return written, err
+	}
+
+	n, err = w.Writer.Write(buf)
+	written = written + n
+	return written, err
 }

--- a/src/github.com/getlantern/wfilter/wfilter.go
+++ b/src/github.com/getlantern/wfilter/wfilter.go
@@ -67,9 +67,9 @@ func (w *linePrepender) Write(buf []byte) (int, error) {
 	return totalN, err
 }
 
-// SimplePrepender creates an io.Writer that prepends to each line by calling the
-// given prepend function. Prepend can write whatever it wants. It should
-// return the bytes written and any error encountered.
+// SimplePrepender creates an io.Writer that prepends by calling the given
+// prepend function. Prepend can write whatever it wants. It should return
+// the bytes written and any error encountered.
 func SimplePrepender(w io.Writer, prepend Prepend) io.Writer {
 	return &simplePrepender{w, prepend}
 }

--- a/src/github.com/getlantern/wfilter/wfilter_test.go
+++ b/src/github.com/getlantern/wfilter/wfilter_test.go
@@ -10,7 +10,13 @@ import (
 	"github.com/getlantern/testify/assert"
 )
 
-func TestLines(t *testing.T) {
+var expected = `1 A
+2 B
+3 C
+4 D
+`
+
+func TestLinePrepender(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	i := int32(0)
 	w := LinePrepender(buf, func(w io.Writer) (int, error) {
@@ -38,8 +44,62 @@ func TestLines(t *testing.T) {
 	assert.Equal(t, expected, string(buf.Bytes()))
 }
 
-var expected = `1 A
-2 B
-3 C
-4 D
-`
+func TestSimplePrepender(t *testing.T) {
+	buf := bytes.NewBuffer(nil)
+	w := SimplePrepender(buf, func(w io.Writer) (int, error) {
+		return fmt.Fprintf(w, "++ ")
+	})
+
+	n, err := fmt.Fprint(w, "##")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 5, n, "Wrong bytes written for A")
+	}
+
+	n, err = fmt.Fprint(w, "##\n\n")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 7, n, "Wrong bytes written for A")
+	}
+
+	n, err = fmt.Fprint(w, "\n\n##\n\n")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 9, n, "Wrong bytes written for A")
+	}
+
+	w = SimplePrepender(buf, func(w io.Writer) (int, error) {
+		return fmt.Fprintf(w, "")
+	})
+
+	n, err = fmt.Fprint(w, "##")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 2, n, "Wrong bytes written for A")
+	}
+
+	n, err = fmt.Fprint(w, "##\n\n")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 4, n, "Wrong bytes written for A")
+	}
+
+	n, err = fmt.Fprint(w, "\n\n##\n\n")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 6, n, "Wrong bytes written for A")
+	}
+
+	w = SimplePrepender(buf, func(w io.Writer) (int, error) {
+		return fmt.Fprintf(w, "\n\n")
+	})
+
+	n, err = fmt.Fprint(w, "##")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 4, n, "Wrong bytes written for A")
+	}
+
+	n, err = fmt.Fprint(w, "##\n\n")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 6, n, "Wrong bytes written for A")
+	}
+
+	n, err = fmt.Fprint(w, "\n\n##\n\n")
+	if assert.NoError(t, err, "Error writing A") {
+		assert.Equal(t, 8, n, "Wrong bytes written for A")
+	}
+}


### PR DESCRIPTION
Closes #2914 