### PR TITLE
Reducing timeout for tests: some connections succeed while shouldn't

### DIFF
--- a/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
+++ b/src/github.com/getlantern/tlsdialer/tlsdialer_test.go
@@ -205,11 +205,11 @@ func TestVariableTimeouts(t *testing.T) {
 	}
 
 	for i := 0; i < 500; i++ {
-		// The 5000 microseconds limit is arbitrary. In some systems this may be too high,
+		// The 4000 microseconds limit is arbitrary. In some systems this may be too high,
 		// leading to a successful connection and thus a failed test. On the other hand,
 		// we need to make this limit relatively high, to allow timeouts to happen at different
 		// places
-		doTestTimeout(t, time.Duration(rand.Intn(5000)+1)*time.Microsecond)
+		doTestTimeout(t, time.Duration(rand.Intn(4000)+1)*time.Microsecond)
 	}
 
 	// Wait to give the sockets time to close


### PR DESCRIPTION
[This issue](https://github.com/getlantern/lantern/issues/2858) failed again in an expected way. Fixing.