### PR TITLE
use tip, lastest version of go

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: go
 go:
 - 1.4.2
+- tip
+matrix:
+  allow_failures:
+    - go: tip
 install:
 - sudo apt-get install make libgtk-3-dev libappindicator3-dev -y
 - go get golang.org/x/tools/cmd/cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
 matrix:
   allow_failures:
     - go: tip
+  fast_finish: true
 install:
 - sudo apt-get install make libgtk-3-dev libappindicator3-dev -y
 - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
I have also added allow_failures via matrix for tip, so that failures building on tip are considered allowed failures that way you can still see and anticipate issues, but breaking unstable changes on tip don't mess up other builds