### PR TITLE
Don't stick to single masquerade

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -32,7 +32,7 @@ import (
 	"github.com/getlantern/flashlight/statreporter"
 	"github.com/getlantern/flashlight/statserver"
 	"github.com/getlantern/flashlight/ui"
-	"github.com/getlantern/flashlight/util"
+	//"github.com/getlantern/flashlight/util"
 
 	"github.com/mitchellh/panicwrap"
 )
@@ -358,9 +358,9 @@ func applyClientConfig(client *client.Client, cfg *config.Config) {
 	} else {
 		// Give everyone their own *http.Client that uses the highest QOS dialer. Separate
 		// clients for everyone avoids data races configuring those clients.
-		config.Configure(hqfd.NewDirectDomainFronter())
-		geolookup.Configure(hqfd.NewDirectDomainFronter())
-		statserver.Configure(hqfd.NewDirectDomainFronter())
+		config.Configure(hqfd)
+		geolookup.Configure(hqfd)
+		statserver.Configure(hqfd)
 		// Note we don't call Configure on analytics here, as that would
 		// result in an extra analytics call and double counting.
 	}
@@ -425,12 +425,13 @@ func runServerProxy(cfg *config.Config) {
 }
 
 func updateServerSideConfigClient(cfg *config.Config) {
-	client, err := util.HTTPClient(cfg.CloudConfigCA, "")
+	// temporarily comment it as we didn't have fronted dialer on server side
+	/*client, err := util.HTTPClient(cfg.CloudConfigCA, "")
 	if err != nil {
 		log.Errorf("Couldn't create http.Client for fetching the config")
 		return
 	}
-	config.Configure(client)
+	config.Configure(client)*/
 }
 
 func useAllCores() {

--- a/src/github.com/getlantern/flashlight/flashlight_test.go
+++ b/src/github.com/getlantern/flashlight/flashlight_test.go
@@ -196,7 +196,7 @@ func testRequest(testCase string, t *testing.T, requests chan *http.Request, htt
 	} else if requestSuccessful {
 		defer func() {
 			if err := resp.Body.Close(); err != nil {
-				t.Fatalf("Error closing response body", err)
+				t.Fatalf("Error closing response body: %s", err)
 			}
 		}()
 		if resp.StatusCode != expectedStatus {

--- a/src/github.com/getlantern/flashlight/statserver/peer.go
+++ b/src/github.com/getlantern/flashlight/statserver/peer.go
@@ -2,11 +2,11 @@ package statserver
 
 import (
 	"math"
-	"net/http"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/getlantern/fronted"
 	"github.com/getlantern/geolookup"
 )
 
@@ -123,7 +123,8 @@ func (peer *Peer) geolocate() error {
 }
 
 func (peer *Peer) doGeolocate() error {
-	geodata, _, err := geolookup.LookupIPWithClient(peer.IP, geoClient.Load().(*http.Client))
+	d := dialer.Load().(fronted.Dialer)
+	geodata, _, err := geolookup.LookupIPWithClient(peer.IP, d.NewDirectDomainFronter())
 
 	if err != nil {
 		return err

--- a/src/github.com/getlantern/flashlight/statserver/statserver.go
+++ b/src/github.com/getlantern/flashlight/statserver/statserver.go
@@ -1,10 +1,10 @@
 package statserver
 
 import (
-	"net/http"
 	"sync"
 	"sync/atomic"
 
+	"github.com/getlantern/fronted"
 	"github.com/getlantern/golog"
 
 	"github.com/getlantern/flashlight/ui"
@@ -15,15 +15,15 @@ var (
 
 	service    *ui.Service
 	cfgMutex   sync.RWMutex
-	geoClient  atomic.Value
+	dialer     atomic.Value
 	peers      map[string]*Peer
 	peersMutex sync.RWMutex
 )
 
-func Configure(newClient *http.Client) {
+func Configure(d fronted.Dialer) {
 	cfgMutex.Lock()
 	defer cfgMutex.Unlock()
-	geoClient.Store(newClient)
+	dialer.Store(d)
 	if service == nil {
 		err := registerService()
 		if err != nil {

--- a/src/github.com/getlantern/fronted/fronted_test.go
+++ b/src/github.com/getlantern/fronted/fronted_test.go
@@ -51,7 +51,7 @@ func TestHttpClientWithBadEnproxyConn(t *testing.T) {
 		Host: "localhost",
 		Port: 3253,
 	})
-	hc := d.HttpClientUsing(nil)
+	hc := d.HttpClientUsing(&Masquerade{})
 	_, err := hc.Get("http://www.google.com/humans.txt")
 	assert.Error(t, err, "HttpClient using a non-existent host should have failed")
 }

--- a/src/github.com/getlantern/fronted/masquerade.go
+++ b/src/github.com/getlantern/fronted/masquerade.go
@@ -138,7 +138,7 @@ func (vms *verifiedMasqueradeSet) doVerify(masquerade *Masquerade) bool {
 	go func() {
 		start := time.Now()
 		httpClient := vms.dialer.HttpClientUsing(masquerade)
-		req, err := http.NewRequest("GET", "http://geo.getiantem.org/lookup", nil)
+		req, err := http.NewRequest("HEAD", "http://geo.getiantem.org/lookup", nil)
 		if err != nil {
 			errCh <- fmt.Errorf("http.NewRequest Error: %s", err)
 		}

--- a/src/github.com/getlantern/fronted/masquerade.go
+++ b/src/github.com/getlantern/fronted/masquerade.go
@@ -3,9 +3,9 @@ package fronted
 import (
 	//"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	//"io/ioutil"
 	"math/rand"
-	"net/http"
+	//"net/http"
 	"sync"
 	"time"
 )
@@ -136,9 +136,9 @@ func (vms *verifiedMasqueradeSet) doVerify(masquerade *Masquerade) bool {
 		errCh <- fmt.Errorf("Timed out verifying %s", masquerade.Domain)
 	}()
 	go func() {
-		start := time.Now()
+		/*start := time.Now()
 		httpClient := vms.dialer.HttpClientUsing(masquerade)
-		req, err := http.NewRequest("HEAD", "http://www.google.com/humans.txt", nil)
+		req, err := http.NewRequest("GET", "http://geo.getiantem.org/lookup", nil)
 		if err != nil {
 			errCh <- fmt.Errorf("http.NewRequest Error: %s", err)
 		}
@@ -147,21 +147,26 @@ func (vms *verifiedMasqueradeSet) doVerify(masquerade *Masquerade) bool {
 			errmsg := fmt.Sprintf("HTTP error for masquerade %v: %v", masquerade.Domain, err)
 			errCh <- fmt.Errorf(errmsg)
 			return
-		} else {
-			body, err := ioutil.ReadAll(resp.Body)
-			defer func() {
-				if err := resp.Body.Close(); err != nil {
-					log.Debugf("Unable to close response body: %v", err)
-				}
-			}()
-			if err != nil {
-				errCh <- fmt.Errorf("HTTP Body Error: %s", body)
-			} else {
-				delta := time.Now().Sub(start)
-				log.Debugf("Sucessful check for: %s in %s, %s", masquerade.Domain, delta, body)
-				errCh <- nil
-			}
 		}
+		body, err := ioutil.ReadAll(resp.Body)
+		defer func() {
+			if err := resp.Body.Close(); err != nil {
+				log.Debugf("Unable to close response body: %v", err)
+			}
+		}()
+		if err != nil {
+			errCh <- fmt.Errorf("HTTP Body Error: %s", err)
+			return
+		}
+		if resp.StatusCode != 200 {
+			errmsg := fmt.Sprintf("Unexpected HTTP status '%s' for masquerade %s: %s", resp.Status, masquerade.Domain, body)
+			errCh <- fmt.Errorf(errmsg)
+			return
+		}
+		delta := time.Now().Sub(start)
+		log.Debugf("Sucessful check for: %s in %s, %s", masquerade.Domain, delta, body)*/
+		log.Debugf("Sucessful check for: %s", masquerade.Domain)
+		errCh <- nil
 	}()
 	err := <-errCh
 	if err != nil {

--- a/src/github.com/getlantern/fronted/masquerade.go
+++ b/src/github.com/getlantern/fronted/masquerade.go
@@ -3,9 +3,9 @@ package fronted
 import (
 	//"crypto/x509"
 	"fmt"
-	//"io/ioutil"
+	"io/ioutil"
 	"math/rand"
-	//"net/http"
+	"net/http"
 	"sync"
 	"time"
 )
@@ -136,7 +136,7 @@ func (vms *verifiedMasqueradeSet) doVerify(masquerade *Masquerade) bool {
 		errCh <- fmt.Errorf("Timed out verifying %s", masquerade.Domain)
 	}()
 	go func() {
-		/*start := time.Now()
+		start := time.Now()
 		httpClient := vms.dialer.HttpClientUsing(masquerade)
 		req, err := http.NewRequest("GET", "http://geo.getiantem.org/lookup", nil)
 		if err != nil {
@@ -164,8 +164,7 @@ func (vms *verifiedMasqueradeSet) doVerify(masquerade *Masquerade) bool {
 			return
 		}
 		delta := time.Now().Sub(start)
-		log.Debugf("Sucessful check for: %s in %s, %s", masquerade.Domain, delta, body)*/
-		log.Debugf("Sucessful check for: %s", masquerade.Domain)
+		log.Debugf("Sucessful check for masquerade %s in %s", masquerade.Domain, delta)
 		errCh <- nil
 	}()
 	err := <-errCh


### PR DESCRIPTION
Main changes of this PR:

1. Check masquerades using direct domain fronting against http://geo.getiantem.org/lookup, instead of full domain fronting against Google. This prevents the 403 error. Ideally we can setup a static page as test target which is always cached by CF, though for now, geo-server's load is very light.

2. Instead of using fixed http.Client, subcomponents will request a new direct domain fronter each time. This prevents a failed masquerade from keep failing.

fronted_test.go is failed due to 403 errors. I choose to leave it as a indicator to tell us if CF recovered or not.

With this change, Lantern can update config 1 minutes after it starts up. geolookup still not work, as it access `http://nl.fallbacks.getiantem.org` to gain ip and country. We can't move it to `geo.getiantem.org/lookup` unless it add a field of requester ip address in the response.