### PR TITLE
[important] Workaround for issue #3077

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -113,11 +113,15 @@ func main() {
 	if err != nil {
 		// Something went wrong setting up the panic wrapper. This won't be
 		// captured by panicwrap
+		// At this point, continue execution without panicwrap support. There
+		// are known cases where panicwrap will fail to fork, such as Windows
+		// GUI app
 		log.Errorf("Error setting up panic wrapper: %v", err)
-	}
-	// If exitStatus >= 0, then we're the parent process.
-	if exitStatus >= 0 {
-		os.Exit(exitStatus)
+	} else {
+		// If exitStatus >= 0, then we're the parent process.
+		if exitStatus >= 0 {
+			os.Exit(exitStatus)
+		}
 	}
 
 	parseFlags()


### PR DESCRIPTION
Issue #3077 is confirmed to be triggered by panicwrap trying to fork a GUI app. This seems to offend Windows XP, due to invalid standard file descriptors. Unfortunately we didn't see any log of this because panicwrap fails before logging is configured. Additionally, this bug isn't detected because it doesn't happen if the application is run in console mode (which is generally used for development).

A better solution could be researched further, although I'm not certain it is viable yet, but I wanted to get this ASAP in valencia, since it could potentially affect all Windows XP users.