### PR TITLE
balancer: not exclude used dialers when retry

### DIFF
--- a/src/github.com/getlantern/balancer/balancer.go
+++ b/src/github.com/getlantern/balancer/balancer.go
@@ -149,6 +149,7 @@ func randomDialer(dialers []*dialer, targetQOS int) (chosen *dialer, others []*d
 		aw += d.Weight
 		if aw > t {
 			log.Tracef("Randomly selected dialer %s with weight %d, QOS %d", d.Label, d.Weight, d.QOS)
+			// Leave at lest one dialer to try in next round
 			if len(dialers) < 2 {
 				return d, dialers
 			} else {
@@ -165,10 +166,12 @@ func dialersMeetingQOS(dialers []*dialer, targetQOS int) ([]*dialer, int) {
 	filtered := make([]*dialer, 0)
 	highestQOS := 0
 	for _, d := range dialers {
+		/* Don't exclude inactive dialer as it's the only one we have
 		if !d.isActive() {
 			log.Trace("Excluding inactive dialer")
 			continue
 		}
+		*/
 
 		highestQOS = d.QOS // don't need to compare since dialers are already sorted by QOS (ascending)
 		if d.QOS >= targetQOS {

--- a/src/github.com/getlantern/balancer/balancer.go
+++ b/src/github.com/getlantern/balancer/balancer.go
@@ -83,7 +83,9 @@ func (b *Balancer) DialQOS(network, addr string, targetQOS int) (net.Conn, error
 		dialers = b.dialers
 	}
 
-	for i := 0; ; i++ {
+	// To prevent dialing infinitely
+	attempts := 3
+	for i := 0; i < attempts; i++ {
 		if len(dialers) == 0 {
 			return nil, fmt.Errorf("No dialers left to try on pass %v", i)
 		}
@@ -103,6 +105,7 @@ func (b *Balancer) DialQOS(network, addr string, targetQOS int) (net.Conn, error
 		log.Debugf("Successfully dialed via %v to %v://%v on pass %v", d.Label, network, addr, i)
 		return conn, nil
 	}
+	return nil, fmt.Errorf("Still unable to dial %s://%s after %d attempts", network, addr, attempts)
 }
 
 // Dial is like DialQOS with a targetQOS of 0.
@@ -146,7 +149,11 @@ func randomDialer(dialers []*dialer, targetQOS int) (chosen *dialer, others []*d
 		aw += d.Weight
 		if aw > t {
 			log.Tracef("Randomly selected dialer %s with weight %d, QOS %d", d.Label, d.Weight, d.QOS)
-			return d, withoutDialer(dialers, d)
+			if len(dialers) < 2 {
+				return d, dialers
+			} else {
+				return d, withoutDialer(dialers, d)
+			}
 		}
 	}
 

--- a/src/github.com/getlantern/balancer/dialer.go
+++ b/src/github.com/getlantern/balancer/dialer.go
@@ -109,8 +109,7 @@ func (d *dialer) start() {
 }
 
 func (d *dialer) isActive() bool {
-	//return atomic.LoadInt32(&d.active) == 1
-	return true
+	return atomic.LoadInt32(&d.active) == 1
 }
 
 func (d *dialer) onError(err error) {


### PR DESCRIPTION
It's another small fix  in addition to yours @myleshorton to prevent "No dialers left to try" error when only 1 dialer available.