### PR TITLE
use p12 file for package-windows which is already in secrets repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -324,7 +324,7 @@ package-windows: require-version windows
 	if [[ -z "$$SECRETS_DIR" ]]; then echo "SECRETS_DIR environment value is required."; exit 1; fi && \
 	if [[ -z "$$BNS_CERT_PASS" ]]; then echo "BNS_CERT_PASS environment value is required."; exit 1; fi && \
 	$(call docker-up) && \
-	docker run -v $$PWD:/lantern -v $$SECRETS_DIR:/secrets -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && BNS_CERT="/secrets/bns.pfx" BNS_CERT_PASS="'$$BNS_CERT_PASS'" VERSION="'$$VERSION'" MANOTO="'true'" make docker-package-windows' && \
+	docker run -v $$PWD:/lantern -v $$SECRETS_DIR:/secrets -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && BNS_CERT="/secrets/bns_cert.p12" BNS_CERT_PASS="'$$BNS_CERT_PASS'" VERSION="'$$VERSION'" MANOTO="'true'" make docker-package-windows' && \
 	echo "-> lantern-installer.exe and lantern-installer-manoto.exe"
 
 package-darwin-manoto: require-version require-appdmg require-svgexport darwin


### PR DESCRIPTION
The previous one, `bns.pfx`, doesn't exist in secrets folder. Changed to `bns_cert.p12` which is the same format.