### PR TITLE
iterate through bootstrap chained servers

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -249,9 +249,9 @@ func Init(version string) (*Config, error) {
 
 func bootstrapConfig(bs *client.BootstrapServers, configs chan []byte, once *sync.Once, url string) {
 	for _, s := range bs.ChainedServers {
-		go func() {
+		go func(s *client.ChainedServerInfo) {
 			bootstrap(s, configs, once, url)
-		}()
+		}(s)
 	}
 }
 


### PR DESCRIPTION
Do you think it's ok to merge to `release-2.0.1`, or `valencia` instead @myleshorton? This fixes the issue of only picking first chained server if more than one available during bootstrap.