### PR TITLE
Optional verbose output for checkfallbacks (useful for testing ATS)

### DIFF
--- a/src/github.com/getlantern/checkfallbacks/checkfallbacks.go
+++ b/src/github.com/getlantern/checkfallbacks/checkfallbacks.go
@@ -12,6 +12,7 @@ import (
 	"github.com/getlantern/golog"
 	"io/ioutil"
 	"net/http"
+	"net/http/httputil"
 	"os"
 	"runtime"
 	"strings"
@@ -20,6 +21,7 @@ import (
 
 var (
 	help          = flag.Bool("help", false, "Get usage help")
+	verbose       = flag.Bool("verbose", false, "Be verbose (useful for manual testing)")
 	fallbacksFile = flag.String("fallbacks", "fallbacks.json", "File containing json array of fallback information")
 	numConns      = flag.Int("connections", 1, "Number of simultaneous connections")
 
@@ -43,9 +45,15 @@ func main() {
 	log.Debugf("Using all %d cores on machine", numcores)
 
 	fallbacks := loadFallbacks(*fallbacksFile)
-	for err := range *testAllFallbacks(fallbacks) {
-		if err != nil {
-			fmt.Printf("[failed fallback check] %v\n", err)
+	outputCh := testAllFallbacks(fallbacks)
+	for out := range *outputCh {
+		if out.err != nil {
+			fmt.Printf("[failed fallback check] %v\n", out.err)
+		}
+		if *verbose && len(out.info) > 0 {
+			for _, msg := range out.info {
+				fmt.Printf("[output] %v\n", msg)
+			}
 		}
 	}
 }
@@ -76,10 +84,15 @@ func loadFallbacks(filename string) (fallbacks []client.ChainedServerInfo) {
 	return
 }
 
+type fullOutput struct {
+	err  error
+	info []string
+}
+
 // Test all fallback servers
-func testAllFallbacks(fallbacks []client.ChainedServerInfo) (errors *chan error) {
-	errorsChan := make(chan error)
-	errors = &errorsChan
+func testAllFallbacks(fallbacks []client.ChainedServerInfo) (output *chan fullOutput) {
+	outputChan := make(chan fullOutput)
+	output = &outputChan
 
 	// Make
 	fbChan := make(chan client.ChainedServerInfo)
@@ -103,26 +116,27 @@ func testAllFallbacks(fallbacks []client.ChainedServerInfo) (errors *chan error)
 			// Done() when closed (i.e. range exits)
 			go func(i int) {
 				for fb := range fbChan {
-					*errors <- testFallbackServer(&fb, i)
+					*output <- testFallbackServer(&fb, i)
 				}
 				workersWg.Done()
 			}(i + 1)
 		}
 		workersWg.Wait()
 
-		close(errorsChan)
+		close(outputChan)
 	}()
 
 	return
 }
 
 // Perform the test of an individual server
-func testFallbackServer(fb *client.ChainedServerInfo, workerId int) (err error) {
+func testFallbackServer(fb *client.ChainedServerInfo, workerId int) (output fullOutput) {
 	// Test connectivity
 	fb.Pipelined = true
 	dialer, err := fb.Dialer()
 	if err != nil {
-		return fmt.Errorf("%v: error building dialer: %v", fb.Addr, err)
+		output.err = fmt.Errorf("%v: error building dialer: %v", fb.Addr, err)
+		return
 	}
 	c := &http.Client{
 		Transport: &http.Transport{
@@ -130,9 +144,19 @@ func testFallbackServer(fb *client.ChainedServerInfo, workerId int) (err error) 
 		},
 	}
 	req, err := http.NewRequest("GET", "http://www.google.com/humans.txt", nil)
+	if *verbose {
+		reqStr, _ := httputil.DumpRequestOut(req, true)
+		output.info = []string{"\n" + string(reqStr)}
+	}
+
 	resp, err := c.Do(req)
+	if *verbose {
+		respStr, _ := httputil.DumpResponse(resp, true)
+		output.info = append(output.info, "\n"+string(respStr))
+	}
 	if err != nil {
-		return fmt.Errorf("%v: requesting humans.txt failed: %v", fb.Addr, err)
+		output.err = fmt.Errorf("%v: requesting humans.txt failed: %v", fb.Addr, err)
+		return
 	}
 	defer func() {
 		if err := resp.Body.Close(); err != nil {
@@ -140,17 +164,20 @@ func testFallbackServer(fb *client.ChainedServerInfo, workerId int) (err error) 
 		}
 	}()
 	if resp.StatusCode != 200 {
-		return fmt.Errorf("%v: bad status code: %v", fb.Addr, resp.StatusCode)
+		output.err = fmt.Errorf("%v: bad status code: %v", fb.Addr, resp.StatusCode)
+		return
 	}
 	bytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("%v: error reading response body: %v", fb.Addr, err)
+		output.err = fmt.Errorf("%v: error reading response body: %v", fb.Addr, err)
+		return
 	}
 	body := string(bytes)
 	if body != expectedBody {
-		return fmt.Errorf("%v: wrong body: %s", fb.Addr, body)
+		output.err = fmt.Errorf("%v: wrong body: %s", fb.Addr, body)
+		return
 	}
 
 	log.Debugf("Worker %d: Fallback %v OK.\n", workerId, fb.Addr)
-	return nil
+	return
 }


### PR DESCRIPTION
I did just to be able to use checkfallbacks as a tool for testing ATS. Could you take a look when you have time @fffw or @aranhoide ? (This is definitely not urgent/important).
It's just optionally showing the req/resp in the output, should be harmless.

Also, I've tried several tools (wget, curl, httpie). They all fail because the either don't support TLS connections to the proxy, nor setting headers for the proxy request.