### PR TITLE
add -verify option to checkfallbacks fix #3179

### DIFF
--- a/src/github.com/getlantern/checkfallbacks/checkfallbacks.go
+++ b/src/github.com/getlantern/checkfallbacks/checkfallbacks.go
@@ -24,6 +24,7 @@ var (
 	verbose       = flag.Bool("verbose", false, "Be verbose (useful for manual testing)")
 	fallbacksFile = flag.String("fallbacks", "fallbacks.json", "File containing json array of fallback information")
 	numConns      = flag.Int("connections", 1, "Number of simultaneous connections")
+	verify        = flag.Bool("verify", false, "Verify the functionality of the fallback")
 
 	expectedBody = "Google is built by a large team of engineers, designers, researchers, robots, and others in many different sites across the globe. It is updated continuously, and built with more tools and technologies than we can shake a stick at. If you'd like to help us out, see google.com/careers.\n"
 )
@@ -149,6 +150,7 @@ func testFallbackServer(fb *client.ChainedServerInfo, workerId int) (output full
 		output.info = []string{"\n" + string(reqStr)}
 	}
 
+	req.Header.Set("X-LANTERN-AUTH-TOKEN", fb.AuthToken)
 	resp, err := c.Do(req)
 	if err != nil {
 		output.err = fmt.Errorf("%v: requesting humans.txt failed: %v", fb.Addr, err)
@@ -180,5 +182,9 @@ func testFallbackServer(fb *client.ChainedServerInfo, workerId int) (output full
 	}
 
 	log.Debugf("Worker %d: Fallback %v OK.\n", workerId, fb.Addr)
+
+	if *verify {
+		verifyFallback(fb, c)
+	}
 	return
 }

--- a/src/github.com/getlantern/checkfallbacks/verify.go
+++ b/src/github.com/getlantern/checkfallbacks/verify.go
@@ -71,10 +71,6 @@ func doVerifyMimic(addr string, req *http.Request, c *http.Client) {
 	resp, err := c.Do(req)
 	if err != nil {
 		log.Errorf("%v: requesting humans.txt failed: %v", addr, err)
-		if *verbose {
-			reqStr, _ := httputil.DumpRequestOut(req, true)
-			log.Debug(string(reqStr))
-		}
 		return
 	}
 	defer func() {
@@ -84,6 +80,10 @@ func doVerifyMimic(addr string, req *http.Request, c *http.Client) {
 	}()
 	if resp.StatusCode != 404 {
 		log.Errorf("%v: should get 404 if auth failed", addr)
+		if *verbose {
+			respStr, _ := httputil.DumpResponse(resp, true)
+			log.Debug(string(respStr))
+		}
 		return
 	}
 	if resp.Header.Get("Content-Type") != "text/html" ||
@@ -92,6 +92,10 @@ func doVerifyMimic(addr string, req *http.Request, c *http.Client) {
 		resp.Header.Get("Content-Language") != "en" ||
 		resp.Header.Get("Content-Length") != "297" {
 		log.Errorf("%v: should have correct headers present", addr)
+		if *verbose {
+			respStr, _ := httputil.DumpResponse(resp, true)
+			log.Debug(string(respStr))
+		}
 		return
 	}
 	b, err := ioutil.ReadAll(resp.Body)
@@ -111,6 +115,10 @@ func doVerifyMimic(addr string, req *http.Request, c *http.Client) {
 func verifyRedirectSites(fb *client.ChainedServerInfo, c *http.Client, url string) {
 	req, err := http.NewRequest("GET", url, nil)
 	req.Header.Set("X-LANTERN-AUTH-TOKEN", fb.AuthToken)
+	if err != nil {
+		log.Errorf("error make request to %s: %v", url, err)
+		return
+	}
 	resp, err := c.Do(req)
 	if err != nil {
 		log.Errorf("%v: requesting %s failed: %v", fb.Addr, url, err)

--- a/src/github.com/getlantern/checkfallbacks/verify.go
+++ b/src/github.com/getlantern/checkfallbacks/verify.go
@@ -114,11 +114,11 @@ func doVerifyMimic(addr string, req *http.Request, c *http.Client) {
 
 func verifyRedirectSites(fb *client.ChainedServerInfo, c *http.Client, url string) {
 	req, err := http.NewRequest("GET", url, nil)
-	req.Header.Set("X-LANTERN-AUTH-TOKEN", fb.AuthToken)
 	if err != nil {
 		log.Errorf("error make request to %s: %v", url, err)
 		return
 	}
+	req.Header.Set("X-LANTERN-AUTH-TOKEN", fb.AuthToken)
 	resp, err := c.Do(req)
 	if err != nil {
 		log.Errorf("%v: requesting %s failed: %v", fb.Addr, url, err)

--- a/src/github.com/getlantern/checkfallbacks/verify.go
+++ b/src/github.com/getlantern/checkfallbacks/verify.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+
+	"github.com/getlantern/flashlight/client"
+)
+
+var (
+	// https://github.com/getlantern/lantern/issues/3147
+	redirectSites = []string{
+		// sites that redirect to http when accessed through https
+		"http://www.bbc.co.uk",
+		"http://www.speedtest.net",
+		// sites that redirect to itself if the "Host:" HTTP header contains port
+		"http://lowendbox.com",
+		"http://sourceforge.net",
+		"http://krypted.com/mac-security/manage-profiles-from-the-command-line-in-os-x-10-9/",
+	}
+
+	atsDefaultBody = []byte(`<HTML>
+<HEAD>
+<TITLE>Not Found on Accelerator</TITLE>
+</HEAD>
+
+<BODY BGCOLOR="white" FGCOLOR="black">
+<H1>Not Found on Accelerator</H1>
+<HR>
+
+<FONT FACE="Helvetica,Arial"><B>
+Description: Your request on the specified host was not found.
+Check the location and try again.
+</B></FONT>
+<HR>
+</BODY>
+`)
+)
+
+func verifyFallback(fb *client.ChainedServerInfo, c *http.Client) {
+	verifyMimicWhenNoAuthToken(fb, c)
+	verifyMimicWithInvalidAuthToken(fb, c)
+	for _, s := range redirectSites {
+		verifyRedirectSites(fb, c, s)
+	}
+}
+
+func verifyMimicWhenNoAuthToken(fb *client.ChainedServerInfo, c *http.Client) {
+	req, err := http.NewRequest("GET", "http://www.google.com/humans.txt", nil)
+	if err != nil {
+		log.Errorf("%v: NewRequest() error : %v", fb.Addr, err)
+		return
+	}
+	// intentionally not set auth token
+	doVerifyMimic(fb.Addr, req, c)
+}
+
+func verifyMimicWithInvalidAuthToken(fb *client.ChainedServerInfo, c *http.Client) {
+	req, err := http.NewRequest("GET", "http://www.google.com/humans.txt", nil)
+	if err != nil {
+		log.Errorf("%v: NewRequest() error : %v", fb.Addr, err)
+		return
+	}
+	req.Header.Set("X-LANTERN-AUTH-TOKEN", "invalid")
+	doVerifyMimic(fb.Addr, req, c)
+}
+
+func doVerifyMimic(addr string, req *http.Request, c *http.Client) {
+	resp, err := c.Do(req)
+	if err != nil {
+		log.Errorf("%v: requesting humans.txt failed: %v", addr, err)
+		if *verbose {
+			reqStr, _ := httputil.DumpRequestOut(req, true)
+			log.Debug(string(reqStr))
+		}
+		return
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Debugf("Unable to close response body: %v", err)
+		}
+	}()
+	if resp.StatusCode != 404 {
+		log.Errorf("%v: should get 404 if auth failed", addr)
+		return
+	}
+	if resp.Header.Get("Content-Type") != "text/html" ||
+		resp.Header.Get("Cache-Control") != "no-store" ||
+		resp.Header.Get("Connection") != "keep-alive" ||
+		resp.Header.Get("Content-Language") != "en" ||
+		resp.Header.Get("Content-Length") != "297" {
+		log.Errorf("%v: should have correct headers present", addr)
+		return
+	}
+	b, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("%v: error reading response body: %v", addr, err)
+		return
+	}
+	if !bytes.Equal(b, atsDefaultBody) {
+		log.Errorf("%v: response body mismatch for invalid request", addr)
+		log.Debugf("Body expected: %v", string(atsDefaultBody))
+		log.Debugf("Body got: %v", string(b))
+		return
+	}
+	log.Debugf("%v: OK.", addr)
+}
+
+func verifyRedirectSites(fb *client.ChainedServerInfo, c *http.Client, url string) {
+	req, err := http.NewRequest("GET", url, nil)
+	req.Header.Set("X-LANTERN-AUTH-TOKEN", fb.AuthToken)
+	resp, err := c.Do(req)
+	if err != nil {
+		log.Errorf("%v: requesting %s failed: %v", fb.Addr, url, err)
+		if *verbose {
+			reqStr, _ := httputil.DumpRequestOut(req, true)
+			log.Debug(string(reqStr))
+		}
+		return
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Debugf("Unable to close response body: %v", err)
+		}
+	}()
+	if resp.StatusCode != 200 {
+		log.Errorf("%v: bad status code %v for %s", fb.Addr, resp.StatusCode, url)
+		if *verbose {
+			respStr, _ := httputil.DumpResponse(resp, true)
+			log.Debug(string(respStr))
+		}
+		return
+	}
+	log.Debugf("%v via %s: OK.", fb.Addr, url)
+}


### PR DESCRIPTION
Fixes https://github.com/getlantern/lantern/issues/3179

This new option can be used to verify the functionality of ATS based chained server. Currently it only checks https://github.com/getlantern/lantern/issues/3133 and https://github.com/getlantern/lantern/issues/3147, but we can add more checks later.