### PR TITLE
Go version bump (security fix) -> 1.4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-- 1.4.2
+- 1.4.3
 install:
 - sudo apt-get install make libgtk-3-dev libappindicator3-dev -y
 - go get golang.org/x/tools/cmd/cover

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 FROM fedora:21
 MAINTAINER "José Carlos Nieto" <xiam@getlantern.org>
 
-ENV GO_VERSION go1.4.2
+ENV GO_VERSION go1.4.3
 ENV GOROOT_BOOTSTRAP /go1.4
 ENV GOROOT /go
 ENV GOPATH /
@@ -15,7 +15,7 @@ ENV PATH $PATH:$GOROOT/bin
 ENV WORKDIR /lantern
 
 # Go binary for bootstrapping.
-ENV GO_PACKAGE_URL https://storage.googleapis.com/golang/go1.4.2.linux-amd64.tar.gz
+ENV GO_PACKAGE_URL https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz
 
 # Updating system.
 RUN yum -y update && yum clean all

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ BUILD_DATE := $(shell date -u +%Y%m%d.%H%M%S)
 
 LOGGLY_TOKEN := 2b68163b-89b6-4196-b878-c1aca4bbdf84 
 
-LDFLAGS := -w -X main.version $(GIT_REVISION) -X main.revisionDate $(REVISION_DATE) -X main.buildDate $(BUILD_DATE) -X github.com/getlantern/flashlight/logging.logglyToken \"$(LOGGLY_TOKEN)\"
+LDFLAGS := -w -X=main.version=$(GIT_REVISION) -X=main.revisionDate=$(REVISION_DATE) -X=main.buildDate=$(BUILD_DATE) -X=github.com/getlantern/flashlight/logging.logglyToken=$(LOGGLY_TOKEN)
 LANTERN_DESCRIPTION := Censorship circumvention tool
 LANTERN_EXTENDED_DESCRIPTION := Lantern allows you to access sites blocked by internet censorship.\nWhen you run it, Lantern reroutes traffic to selected domains through servers located where such domains are uncensored.
 

--- a/src/github.com/getlantern/lantern-mobile/Dockerfile
+++ b/src/github.com/getlantern/lantern-mobile/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:22
 MAINTAINER "Ulysses Aalto" <uaalto@getlantern.org>
 
-ENV GO_VERSION go1.4.2
+ENV GO_VERSION go1.4.3
 ENV GOROOT_BOOTSTRAP /go1.4
 ENV GOROOT /go
 ENV GOPATH /


### PR DESCRIPTION
Closes #3194 

Those changes in the LDFLAGS are due to a deprecation notice and future removal for the old args syntax.