### PR TITLE
remove deprecated menuZone from systray

### DIFF
--- a/src/github.com/getlantern/systray/systray.go
+++ b/src/github.com/getlantern/systray/systray.go
@@ -39,7 +39,7 @@ var (
 	menuItems     = make(map[int32]*MenuItem)
 	menuItemsLock sync.RWMutex
 
-	currentId int32
+	currentID int32
 )
 
 // Run initializes GUI and starts the event loop, then invokes the onReady
@@ -61,54 +61,59 @@ func Quit() {
 	quit()
 }
 
-// Add menu item with designated title and tooltip, returning a channel that
-// notifies whenever that menu item has been clicked.
+// AddMenuItem adds menu item with designated title and tooltip, returning a channel
+// that notifies whenever that menu item is clicked.
 //
-// Menu items are keyed to an id. If the same id is added twice, the 2nd one
-// overwrites the first.
-//
-// AddMenuItem can be safely invoked from different goroutines.
+// It can be safely invoked from different goroutines.
 func AddMenuItem(title string, tooltip string) *MenuItem {
-	id := atomic.AddInt32(&currentId, 1)
+	id := atomic.AddInt32(&currentID, 1)
 	item := &MenuItem{nil, id, title, tooltip, false, false}
 	item.ClickedCh = make(chan interface{})
 	item.update()
 	return item
 }
 
+// SetTitle set the text to display on a menu item
 func (item *MenuItem) SetTitle(title string) {
 	item.title = title
 	item.update()
 }
 
+// SetTooltip set the tooltip to show when mouse hover
 func (item *MenuItem) SetTooltip(tooltip string) {
 	item.tooltip = tooltip
 	item.update()
 }
 
+// Disabled checkes if the menu item is disabled
 func (item *MenuItem) Disabled() bool {
 	return item.disabled
 }
 
+// Enable a menu item regardless if it's previously enabled or not
 func (item *MenuItem) Enable() {
 	item.disabled = false
 	item.update()
 }
 
+// Disable a menu item regardless if it's previously disabled or not
 func (item *MenuItem) Disable() {
 	item.disabled = true
 	item.update()
 }
 
+// Checked returns if the menu item has a check mark
 func (item *MenuItem) Checked() bool {
 	return item.checked
 }
 
+// Check a menu item regardless if it's previously checked or not
 func (item *MenuItem) Check() {
 	item.checked = true
 	item.update()
 }
 
+// Uncheck a menu item regardless if it's previously unchecked or not
 func (item *MenuItem) Uncheck() {
 	item.checked = false
 	item.update()

--- a/src/github.com/getlantern/systray/systray_darwin.m
+++ b/src/github.com/getlantern/systray/systray_darwin.m
@@ -52,8 +52,7 @@
 - (void)applicationDidFinishLaunching:(NSNotification *)aNotification
 {
   self->statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
-  NSZone *menuZone = [NSMenu menuZone];
-  self->menu = [[NSMenu allocWithZone:menuZone] init];
+  self->menu = [[NSMenu alloc] init];
   [self->menu setAutoenablesItems: FALSE];
   [self->statusItem setMenu:self->menu];
   systray_ready();

--- a/src/github.com/getlantern/systray/systray_nonwindows.go
+++ b/src/github.com/getlantern/systray/systray_nonwindows.go
@@ -36,18 +36,18 @@ func SetTitle(title string) {
 	C.setTitle(C.CString(title))
 }
 
-// SetTitle sets the systray tooltip to display on mouse hover of the tray icon,
+// SetTooltip sets the systray tooltip to display on mouse hover of the tray icon,
 // only available on Mac and Windows.
 func SetTooltip(tooltip string) {
 	C.setTooltip(C.CString(tooltip))
 }
 
 func addOrUpdateMenuItem(item *MenuItem) {
-	var disabled C.short = 0
+	var disabled C.short
 	if item.disabled {
 		disabled = 1
 	}
-	var checked C.short = 0
+	var checked C.short
 	if item.checked {
 		checked = 1
 	}
@@ -66,6 +66,6 @@ func systray_ready() {
 }
 
 //export systray_menu_item_selected
-func systray_menu_item_selected(cId C.int) {
-	systrayMenuItemSelected(int32(cId))
+func systray_menu_item_selected(cID C.int) {
+	systrayMenuItemSelected(int32(cID))
 }


### PR DESCRIPTION
It's a rather quick fix to https://github.com/getlantern/lantern/issues/3246

As per [doc](https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Functions/index.html#//apple_ref/c/func/NSDefaultMallocZone)

> Zones are ignored on iOS and 64-bit runtime on OS X. You should not use zones in current development.

So it's safe to run on any supported OS X versions.

@myleshorton mind take a look?