### PR TITLE
[don't merge] add option to detour to skip loopback and LAN address

### DIFF
--- a/src/github.com/getlantern/detour/detour_conn.go
+++ b/src/github.com/getlantern/detour/detour_conn.go
@@ -42,26 +42,20 @@ func (dc *detourConn) FollowupRead(b []byte, ch chan ioResult) {
 }
 
 func (dc *detourConn) doRead(b []byte, ch chan ioResult) {
-	go func() {
-		n, err := dc.Conn.Read(b)
-		atomic.AddUint64(&dc.readBytes, uint64(n))
-		defer func() { ch <- ioResult{n, err, dc} }()
-		if err != nil {
-			if err != io.EOF {
-				atomic.AddUint32(&dc.errorEncountered, 1)
-			}
-			return
+	n, err := dc.Conn.Read(b)
+	atomic.AddUint64(&dc.readBytes, uint64(n))
+	defer func() { ch <- ioResult{n, err, dc} }()
+	if err != nil {
+		if err != io.EOF {
+			atomic.AddUint32(&dc.errorEncountered, 1)
 		}
-	}()
-	return
+		return
+	}
 }
 
 func (dc *detourConn) Write(b []byte, ch chan ioResult) {
-	go func() {
-		n, err := dc.Conn.Write(b)
-		ch <- ioResult{n, err, dc}
-	}()
-	return
+	n, err := dc.Conn.Write(b)
+	ch <- ioResult{n, err, dc}
 }
 
 func (dc *detourConn) Close() (err error) {

--- a/src/github.com/getlantern/detour/detour_conn.go
+++ b/src/github.com/getlantern/detour/detour_conn.go
@@ -19,17 +19,14 @@ type detourConn struct {
 }
 
 func dialDetour(network string, addr string, dialer dialFunc, ch chan conn) {
-	go func() {
-		log.Tracef("Dialing detour connection to %s", addr)
-		conn, err := dialer(network, addr)
-		if err != nil {
-			log.Errorf("Dial detour to %s failed: %s", addr, err)
-			return
-		}
-		log.Tracef("Dial detour to %s succeeded", addr)
-		ch <- &detourConn{Conn: conn, addr: addr, readBytes: 0}
-	}()
-	return
+	log.Tracef("Dialing detour connection to %s", addr)
+	conn, err := dialer(network, addr)
+	if err != nil {
+		log.Errorf("Dial detour to %s failed: %s", addr, err)
+		return
+	}
+	log.Tracef("Dial detour to %s succeeded", addr)
+	ch <- &detourConn{Conn: conn, addr: addr, readBytes: 0}
 }
 
 func (dc *detourConn) ConnType() connType {

--- a/src/github.com/getlantern/detour/detour_test.go
+++ b/src/github.com/getlantern/detour/detour_test.go
@@ -195,11 +195,13 @@ func TestSkipLoopbackAndLAN(t *testing.T) {
 	mockURL, mock := newMockServer(directMsg)
 	SkipLoopbackAndLAN = true
 	client := newClient(proxiedURL, 100*time.Millisecond)
-	_, err := client.Get(mockURL)
-	assert.NoError(t, err, "should time out if skip loopback and LAN")
+	resp, err := client.Get(mockURL)
+	if assert.NoError(t, err, "should have not error if skip loopback and LAN") {
+		assertContent(t, resp, directMsg, "should not detour if skip loopback and LAN")
+	}
 	mock.Timeout(200*time.Millisecond, directMsg)
 	_, err = client.Get(mockURL)
-	assert.Error(t, err, "should time out if skip loopback and LAN")
+	assert.Error(t, err, "should not detour if skip loopback and LAN")
 }
 
 func newClient(proxyURL string, timeout time.Duration) *http.Client {

--- a/src/github.com/getlantern/detour/detour_test.go
+++ b/src/github.com/getlantern/detour/detour_test.go
@@ -186,6 +186,7 @@ func TestGetAddr(t *testing.T) {
 }
 
 func TestSkipLoopbackAndLAN(t *testing.T) {
+	SkipLoopbackAndLAN()
 	assert.True(t, isLoopbackOrLAN("tcp", "172.16.9.1:443"))
 	assert.True(t, isLoopbackOrLAN("tcp", "localhost:443"))
 	assert.False(t, isLoopbackOrLAN("tcp", "10.1.1.1:443"))
@@ -193,7 +194,6 @@ func TestSkipLoopbackAndLAN(t *testing.T) {
 	defer stopMockServers()
 	proxiedURL, _ := newMockServer(detourMsg)
 	mockURL, mock := newMockServer(directMsg)
-	SkipLoopbackAndLAN = true
 	client := newClient(proxiedURL, 100*time.Millisecond)
 	resp, err := client.Get(mockURL)
 	if assert.NoError(t, err, "should have not error if skip loopback and LAN") {

--- a/src/github.com/getlantern/detour/detour_test.go
+++ b/src/github.com/getlantern/detour/detour_test.go
@@ -186,6 +186,10 @@ func TestGetAddr(t *testing.T) {
 }
 
 func TestSkipLoopbackAndLAN(t *testing.T) {
+	assert.True(t, isLoopbackOrLAN("tcp", "172.16.9.1:443"))
+	assert.True(t, isLoopbackOrLAN("tcp", "localhost:443"))
+	assert.False(t, isLoopbackOrLAN("tcp", "10.1.1.1:443"))
+	assert.False(t, isLoopbackOrLAN("tcp", "google.com:443"))
 	defer stopMockServers()
 	proxiedURL, _ := newMockServer(detourMsg)
 	mockURL, mock := newMockServer(directMsg)
@@ -195,7 +199,7 @@ func TestSkipLoopbackAndLAN(t *testing.T) {
 	assert.NoError(t, err, "should time out if skip loopback and LAN")
 	mock.Timeout(200*time.Millisecond, directMsg)
 	_, err = client.Get(mockURL)
-	assert.EqualError(t, err, "Get "+mockURL+": net/http: request canceled (Client.Timeout exceeded while awaiting headers)", "should time out if skip loopback and LAN")
+	assert.Error(t, err, "should time out if skip loopback and LAN")
 }
 
 func newClient(proxyURL string, timeout time.Duration) *http.Client {

--- a/src/github.com/getlantern/detour/direct_conn.go
+++ b/src/github.com/getlantern/detour/direct_conn.go
@@ -103,25 +103,20 @@ func checkFollowupRead(b []byte, n int, err error, addr string) error {
 }
 
 func (dc *directConn) doRead(b []byte, checker readChecker, ch chan ioResult) {
-	go func() {
-		n, err := dc.Conn.Read(b)
-		err = checker(b, n, err, dc.addr)
-		if err != nil {
-			b = nil
-			n = 0
-		} else {
-			atomic.AddUint64(&dc.readBytes, uint64(n))
-		}
-		ch <- ioResult{n, err, dc}
-	}()
-	return
+	n, err := dc.Conn.Read(b)
+	err = checker(b, n, err, dc.addr)
+	if err != nil {
+		b = nil
+		n = 0
+	} else {
+		atomic.AddUint64(&dc.readBytes, uint64(n))
+	}
+	ch <- ioResult{n, err, dc}
 }
 
 func (dc *directConn) Write(b []byte, ch chan ioResult) {
-	go func() {
-		n, err := dc.Conn.Write(b)
-		ch <- ioResult{n, err, dc}
-	}()
+	n, err := dc.Conn.Write(b)
+	ch <- ioResult{n, err, dc}
 }
 
 func (dc *directConn) Close() (err error) {

--- a/src/github.com/getlantern/detour/mock_test.go
+++ b/src/github.com/getlantern/detour/mock_test.go
@@ -55,6 +55,8 @@ func newMockServer(msg string) (string, *mockHandler) {
 }
 
 func stopMockServers() {
+	// To prevent data race during test
+	time.Sleep(200 * time.Millisecond)
 	for _, s := range servers {
 		s.Close()
 	}

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/getlantern/detour"
 	"github.com/getlantern/fronted"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/i18n"
@@ -324,9 +325,10 @@ func runClientProxy(cfg *config.Config) {
 		      }()
 	*/
 
-	// watchDirectAddrs will spawn a goroutine that will add any site that is
+	// watchDirectAddrs will spawn a goroutine to add any site that is
 	// directly accesible to the PAC file.
 	watchDirectAddrs()
+	detour.SkipLoopbackAndLAN = true
 
 	err = client.ListenAndServe(func() {
 		pacOn()

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -328,7 +328,7 @@ func runClientProxy(cfg *config.Config) {
 	// watchDirectAddrs will spawn a goroutine to add any site that is
 	// directly accesible to the PAC file.
 	watchDirectAddrs()
-	detour.SkipLoopbackAndLAN = true
+	detour.SkipLoopbackAndLAN()
 
 	err = client.ListenAndServe(func() {
 		pacOn()

--- a/src/github.com/getlantern/flashlight/flashlight_test.go
+++ b/src/github.com/getlantern/flashlight/flashlight_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -226,7 +225,7 @@ func (srv *MockServer) init() error {
 
 	err := srv.certContext.InitServerCert(HOST)
 	if err != nil {
-		fmt.Errorf("Unable to initialize mock server cert: %s", err)
+		log.Errorf("Unable to initialize mock server cert: %s", err)
 	}
 
 	srv.requests = make(chan *http.Request, 100)
@@ -291,7 +290,7 @@ func (cf *MockCloudFlare) init() error {
 
 	err := cf.certContext.InitServerCert(HOST)
 	if err != nil {
-		fmt.Errorf("Unable to initialize mock CloudFlare server cert: %s", err)
+		log.Errorf("Unable to initialize mock CloudFlare server cert: %s", err)
 	}
 	return nil
 }


### PR DESCRIPTION
It resolves https://github.com/getlantern/lantern/issues/2875 as well as https://github.com/getlantern/lantern/issues/2915 hopefully. Also refactored detour a bit and fixed the randomly failed test.

There's still one minor issue left: if the loopback or LAN address is unable to dial for some reason, `detour.Dialer` will not return immediately, so caller will wait until it times out. Hope I can fix it tomorrow.