### PR TITLE
Disable config updates flag

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -163,7 +163,7 @@ func useGoodOldConfig(configDir, configPath string) bool {
 }
 
 // Init initializes the configuration system.
-func Init(version string) (*Config, error) {
+func Init(version string, disableConfigUpdate bool) (*Config, error) {
 	file := "lantern-" + version + ".yaml"
 	_, configPath, err := InConfigDir(file)
 	if err != nil {
@@ -191,6 +191,9 @@ func Init(version string) (*Config, error) {
 			return cfg.applyFlags()
 		},
 		CustomPoll: func(ycfg yamlconf.Config) (mutate func(yamlconf.Config) error, waitTime time.Duration, err error) {
+			if disableConfigUpdate {
+				return func(yamlconf.Config) error { return nil }, 1 * time.Day, nil
+			}
 			return pollForConfig(ycfg)
 		},
 	}

--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -192,7 +192,7 @@ func Init(version string, disableConfigUpdate bool) (*Config, error) {
 		},
 		CustomPoll: func(ycfg yamlconf.Config) (mutate func(yamlconf.Config) error, waitTime time.Duration, err error) {
 			if disableConfigUpdate {
-				return func(yamlconf.Config) error { return nil }, 1 * time.Day, nil
+				return func(yamlconf.Config) error { return nil }, 24 * time.Hour, nil
 			}
 			return pollForConfig(ycfg)
 		},

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -47,10 +47,11 @@ var (
 	log = golog.LoggerFor("flashlight")
 
 	// Command-line Flags
-	help               = flag.Bool("help", false, "Get usage help")
-	headless           = flag.Bool("headless", false, "if true, lantern will run with no ui")
-	startup            = flag.Bool("startup", false, "if true, Lantern was automatically run on system startup")
-	clearProxySettings = flag.Bool("clear-proxy-settings", false, "if true, Lantern removes proxy settings from the system.")
+	help                = flag.Bool("help", false, "Get usage help")
+	headless            = flag.Bool("headless", false, "if true, lantern will run with no ui")
+	startup             = flag.Bool("startup", false, "if true, Lantern was automatically run on system startup")
+	clearProxySettings  = flag.Bool("clear-proxy-settings", false, "if true, Lantern removes proxy settings from the system.")
+	disableConfigUpdate = flag.Bool("disable-config-update", false, "if true, Lantern will not try to update configuration.")
 
 	showui = true
 
@@ -88,7 +89,7 @@ func init() {
 }
 
 func logPanic(msg string) {
-	_, err := config.Init(packageVersion)
+	_, err := config.Init(packageVersion, false)
 	if err != nil {
 		panic("Error initializing config")
 	}
@@ -176,7 +177,7 @@ func doMain() error {
 	// Run below in separate goroutine as config.Init() can potentially block when Lantern runs
 	// for the first time. User can still quit Lantern through systray menu when it happens.
 	go func() {
-		cfg, err := config.Init(packageVersion)
+		cfg, err := config.Init(packageVersion, *disableConfigUpdate)
 		if err != nil {
 			exit(fmt.Errorf("Unable to initialize configuration: %v", err))
 			return


### PR DESCRIPTION
Very simple change. I'm just wondering if the wait time should be set to a very low number to avoid goroutines waiting for long: if I set the time to 0 I get a lot of messages "trying to update config".