### PR TITLE
only render error page to browsers

### DIFF
--- a/src/github.com/getlantern/flashlight/config/config.go
+++ b/src/github.com/getlantern/flashlight/config/config.go
@@ -438,9 +438,9 @@ func fetchCloudConfig(url string) ([]byte, error) {
 		req.Header.Set(ifNoneMatch, lastCloudConfigETag[url])
 	}
 
+	req.Header.Set("Accept", "application/x-gzip")
 	// Prevents intermediate nodes (domain-fronters) from caching the content
 	req.Header.Set("Cache-Control", "no-cache")
-
 	// Set the fronted URL to lookup the config in parallel using chained and domain fronted servers.
 	req.Header.Set("Lantern-Fronted-URL", frontedCloudConfigUrl)
 

--- a/src/github.com/getlantern/flashlight/flashlight_test.go
+++ b/src/github.com/getlantern/flashlight/flashlight_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -226,7 +225,7 @@ func (srv *MockServer) init() error {
 
 	err := srv.certContext.InitServerCert(HOST)
 	if err != nil {
-		fmt.Errorf("Unable to initialize mock server cert: %s", err)
+		log.Errorf("Unable to initialize mock server cert: %s", err)
 	}
 
 	srv.requests = make(chan *http.Request, 100)
@@ -291,7 +290,7 @@ func (cf *MockCloudFlare) init() error {
 
 	err := cf.certContext.InitServerCert(HOST)
 	if err != nil {
-		fmt.Errorf("Unable to initialize mock CloudFlare server cert: %s", err)
+		log.Errorf("Unable to initialize mock CloudFlare server cert: %s", err)
 	}
 	return nil
 }

--- a/src/github.com/getlantern/geolookup/geolookup.go
+++ b/src/github.com/getlantern/geolookup/geolookup.go
@@ -128,6 +128,7 @@ func LookupIPWithEndpoint(endpoint string, ipAddr string, fetcher HTTPFetcher) (
 
 	frontedUrl := fmt.Sprintf(cloudfrontEndpoint, ipAddr)
 
+	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Lantern-Fronted-URL", frontedUrl)
 	log.Debugf("Fetching ip...")
 	if resp, err = fetcher.Do(req); err != nil {


### PR DESCRIPTION
Resolves #3330 to eliminate those weird meaningless Loggly entries.

@xiam mind take a look? It's a slight change to `errorRewritingRoundTripper`. Changes to `flashlight_test.go` are simply making `go vet` happy.

By requesting an inexist port with different user agent via Lantern, we can see the effect.
`curl -vLx localhost:8787 http://twitter.com:8000`
`curl -vLx localhost:8787 http://twitter.com:8000  -H "User-Agent: Mozilla/5.0"`