### PR TITLE
set 500ms DelayBeforeDetour by default resolves #3325

### DIFF
--- a/src/github.com/getlantern/detour/detour.go
+++ b/src/github.com/getlantern/detour/detour.go
@@ -43,7 +43,7 @@ var TimeoutToConnect = 30 * time.Second
 
 // To avoid unnecessarily proxy not-blocked url, detour will dial detour connection
 // after this small delay. Set to zero to dial in parallel to not introducing any delay.
-var DelayBeforeDetour = 0 * time.Millisecond
+var DelayBeforeDetour = 500 * time.Millisecond
 
 // If DirectAddrCh is set, when a direct connection is closed without any error,
 // the connection's remote address (in host:port format) will be send to it

--- a/src/github.com/getlantern/detour/detour_test.go
+++ b/src/github.com/getlantern/detour/detour_test.go
@@ -115,6 +115,7 @@ func TestRemoveFromWhitelist(t *testing.T) {
 	AddToWl(u.Host, false)
 	_, err := client.Get(mockURL)
 	if assert.Error(t, err, "should have error if reading times out through detour") {
+		time.Sleep(50 * time.Millisecond)
 		assert.False(t, whitelisted(u.Host), "should be removed from whitelist if reading times out through detour")
 	}
 


### PR DESCRIPTION
Ok this partly resolves https://github.com/getlantern/lantern/issues/3325.

During the ~ 1h test on the China box, with a few exceptions, all non-blocked sites are dialed directly. Those exceptions are much slower sites with ~ 2s to have a connection.

But on Iran box, most Farsi sites took > 1s to connect, the only exceptions were blogfa.com and watchmojo.com. Good news is: Lantern indeed accelerated many sites in test set. www.irna.ir and www.sanjesh.org were 2x faster, www.ut.ac.ir was 7x faster, by running `time curl -vLx localhost:8888 <site>` and `time curl -vL <site>` respectively (in that order).

This workaround seems ok to me. How do you think @myleshorton?


