### PR TITLE
By install deltarpm , boost docker yum update

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ ENV WORKDIR /lantern
 ENV GO_PACKAGE_URL https://storage.googleapis.com/golang/go1.4.3.linux-amd64.tar.gz
 
 # Updating system.
+RUN yum makecache
+RUN yum install -y deltarpm
 RUN yum -y update && yum clean all
 
 # Requisites for building Go.


### PR DESCRIPTION
If installed deltarpm, yum update will faster

Delta RPMs reduced 50 M of updates to 16 M (67% saved)


Signed-off-by: ZhiFeng Hu <hufeng1987@gmail.com>