### PR TITLE
Build/README updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -499,6 +499,20 @@ android-lib: docker-mobile
 		echo "cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) \$$FIRETWEET_MAIN_DIR"; \
 	fi
 
+android-lib-local:
+	@source setenv.bash && \
+	cd $(LANTERN_MOBILE_DIR) && \
+	gomobile bind -target=android -o=$(LANTERN_MOBILE_LIBRARY) -ldflags="$(LDFLAGS)" . && \
+	if [ -d "$(FIRETWEET_MAIN_DIR)" ]; then \
+		cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) $(FIRETWEET_MAIN_DIR)/libs/$(LANTERN_MOBILE_LIBRARY); \
+	else \
+		echo ""; \
+		echo "Either no FIRETWEET_MAIN_DIR variable was passed or the given value is not a";\
+		echo "directory. You'll have to copy the $(LANTERN_MOBILE_LIBRARY) file manually:"; \
+		echo ""; \
+		echo "cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) \$$FIRETWEET_MAIN_DIR"; \
+	fi
+
 android-lib-dist: genconfig android-lib
 
 clean:

--- a/README.md
+++ b/README.md
@@ -362,15 +362,21 @@ Go code in Lantern must pass several tests:
 * Go vet
 * Go test -race
 
-You can find a generic [git-hook](https://github.com/getlantern/lantern/blob/valencia/git-hook)
+You can find a generic [git-hook](https://github.com/getlantern/lantern/blob/valencia/pre-push)
 file, which can be used as a pre-push (or pre-commit) hook to automatically
 ensure these tests are passed before committing any code. Only Go packages in
 `src/github.com/getlantern` will be tested, and only those that have changes in
 them.
 
 Install by copying it into the local `.git/hooks/` directory, with the `pre-push`
-file name if you want to run it before pushing. Alternatively, you can name it
-`pre-commit` to run it before each commit..
+file name if you want to run it before pushing. Alternatively, you can copy
+[pre-commit.hook](https://github.com/getlantern/lantern/blob/valencia/pre-commit)
+to `pre-commit` to run it before each commit.
+
+```bash
+ln -s "$(pwd)/prehook.sh" .git/hooks/prehook.sh
+ln -s "$(pwd)/pre-push" .git/hooks/pre-push
+```
 
 **Important notice**
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,17 @@ You can also override this environment variable if you want to use the
 3. Install NDK(http://developer.android.com/ndk/downloads/index.html)
 4. Install lantern's [fork of gomobile](https://github.com/getlantern/mobile)
 
+##### Installing gomobile
+Because gomobile uses absolute import paths, one has to resort to some trickery
+to install the Lantern fork. In your usual `$GOPATH` (not the gosted one):
+
+```bash
+git clone https://github.com/getlantern/mobile.git $GOPATH/src/golang.org/x/mobile
+cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile
+go get .
+gomobile init -u -noios
+```
+
 Useful environment variables (replace the paths based on wherever you've
 installed the Android SDK and NDK).
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lantern [![Travis CI Status](https://travis-ci.org/getlantern/lantern.svg?branch=valencia)](https://travis-ci.org/getlantern/lantern)&nbsp;[![Coverage Status](https://coveralls.io/repos/getlantern/lantern/badge.png?branch=valencia)](https://coveralls.io/r/getlantern/lantern)&nbsp;[![ProjectTalk](http://www.projecttalk.io/images/gh_badge-3e578a9f437f841de7446bab9a49d103.svg?vsn=d)] (http://www.projecttalk.io/boards/getlantern%2Flantern?utm_campaign=gh-badge&utm_medium=badge&utm_source=github) 
+# lantern [![Travis CI Status](https://travis-ci.org/getlantern/lantern.svg?branch=valencia)](https://travis-ci.org/getlantern/lantern)&nbsp;[![Coverage Status](https://coveralls.io/repos/getlantern/lantern/badge.png?branch=valencia)](https://coveralls.io/r/getlantern/lantern)&nbsp;[![ProjectTalk](http://www.projecttalk.io/images/gh_badge-3e578a9f437f841de7446bab9a49d103.svg?vsn=d)] (http://www.projecttalk.io/boards/getlantern%2Flantern?utm_campaign=gh-badge&utm_medium=badge&utm_source=github)
 
 **If you're looking for Lantern binaries, you can find all of them at the following links:**
 - [Windows XP SP 3 and above](https://raw.githubusercontent.com/getlantern/lantern-binaries/master/lantern-installer-beta.exe)
@@ -23,6 +23,18 @@ We are going to create a Docker image that will take care of compiling Lantern
 for Windows and Linux, in order to compile Lantern for OSX you'll need an OSX
 host, this is a limitation caused by Lantern depending on C code and OSX build
 tools for certain features.
+
+### Docker Installation Instructions
+
+1. Get the [Docker Toolbox](https://www.docker.com/docker-toolbox)
+2. Install docker per [these instructions](https://docs.docker.com/mac/step_one/)
+
+After installation, you'll have a docker machine called `default`, which is what the build script uses. You'll probably want to increase the memory and cpu for the default machine, which will require you to recreate it:
+
+```bash
+docker-machine rm default
+docker-machine create --driver virtualbox --virtualbox-cpu-count 2 --virtualbox-memory 4096 default
+```
 
 ### Building the docker image
 

--- a/README.md
+++ b/README.md
@@ -288,18 +288,7 @@ You can also override this environment variable if you want to use the
 1. Install Java JDK 7 or 8
 2. Install [Android SDK Tools](http://developer.android.com/sdk/index.html#Other)
 3. Install NDK(http://developer.android.com/ndk/downloads/index.html)
-4. Install lantern's [fork of gomobile](https://github.com/getlantern/mobile)
-
-##### Installing gomobile
-Because gomobile uses absolute import paths, one has to resort to some trickery
-to install the Lantern fork. In your usual `$GOPATH` (not the gosted one):
-
-```bash
-git clone https://github.com/getlantern/mobile.git $GOPATH/src/golang.org/x/mobile
-cd $GOPATH/src/golang.org/x/mobile/cmd/gomobile
-go get .
-gomobile init -u -noios
-```
+4. Install [gomobile](https://godoc.org/golang.org/x/mobile/cmd/gomobile)
 
 Useful environment variables (replace the paths based on wherever you've
 installed the Android SDK and NDK).

--- a/README.md
+++ b/README.md
@@ -36,6 +36,15 @@ docker-machine rm default
 docker-machine create --driver virtualbox --virtualbox-cpu-count 2 --virtualbox-memory 4096 default
 ```
 
+### Migrating from boot2docker
+
+If you already have a boot2docker vm that you want to use with the new
+docker-toolbox, you can migrate it with this command:
+
+```bash
+docker-machine create -d virtualbox --virtualbox-import-boot2docker-vm boot2docker-vm default
+```
+
 ### Building the docker image
 
 In order to build the docker image open a terminal, `cd` into the

--- a/README.md
+++ b/README.md
@@ -274,6 +274,29 @@ FIRETWEET_MAIN_DIR=/path/to/firetweet/src/main make android-lib
 You can also override this environment variable if you want to use the
 [Flashlight Android Tester](https://github.com/getlantern/lantern-mobile-single-app-example) app.
 
+#### Creating the Android library without docker
+
+1. Install Java JDK 7 or 8
+2. Install [Android SDK Tools](http://developer.android.com/sdk/index.html#Other)
+3. Install NDK(http://developer.android.com/ndk/downloads/index.html)
+4. Install lantern's [fork of gomobile](https://github.com/getlantern/mobile)
+
+Useful environment variables (replace the paths based on wherever you've
+installed the Android SDK and NDK).
+
+```bash
+export ANDROID_HOME=/opt/adt-bundle-mac-x86_64-20130917/sdk
+export PATH=$ANDROID_HOME/tools:$PATH
+export NDK_HOME=/opt/android-ndk-r10e
+export PATH=$NDK_HOME:$PATH
+```
+)
+
+Then to build the library:
+
+```bash
+make android-lib-local
+```
 
 ### Generating assets
 

--- a/pre-commit
+++ b/pre-commit
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+# Git pre-push hook for the Lantern project
+# Maintainer: Ulysses Aalto <uaalto@getlantern.org>
+#
+# Installation: Copy into .git/hooks/pre-push
+
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Find only modified files/directories
+MODIFIED_DIRS=$(git status --porcelain | \
+                        awk 'match($1, "M") && match($2, "src/github.com/getlantern/*"){print $2}' | \
+                        sed 's+src/github.com/getlantern/++g' | \
+                        sed 's+/.*++' | \
+                        uniq)
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/prehook.sh

--- a/pre-commit
+++ b/pre-commit
@@ -10,7 +10,7 @@
 set -e
 
 # Find only modified files/directories
-MODIFIED_DIRS=$(git status --porcelain | \
+export MODIFIED_DIRS=$(git status --porcelain | \
                         awk 'match($1, "M") && match($2, "src/github.com/getlantern/*"){print $2}' | \
                         sed 's+src/github.com/getlantern/++g' | \
                         sed 's+/.*++' | \

--- a/pre-push
+++ b/pre-push
@@ -11,7 +11,7 @@ set -e
 
 # Find only modified files/directories
 BRANCH=`git rev-parse --abbrev-ref HEAD`
-MODIFIED_DIRS=$(git diff --name-status origin/$BRANCH..$BRANCH | \
+export MODIFIED_DIRS=$(git diff --name-status origin/$BRANCH..$BRANCH | \
                         awk 'match($1, "M") && match($2, "src/github.com/getlantern/*"){print $2}' | \
                         sed 's+src/github.com/getlantern/++g' | \
                         sed 's+/.*++' | \

--- a/pre-push
+++ b/pre-push
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# Git pre-push hook for the Lantern project
+# Maintainer: Ulysses Aalto <uaalto@getlantern.org>
+#
+# Installation: Symlink or copy into .git/hooks/pre-push
+
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Find only modified files/directories
+BRANCH=`git rev-parse --abbrev-ref HEAD`
+MODIFIED_DIRS=$(git diff --name-status origin/$BRANCH..$BRANCH | \
+                        awk 'match($1, "M") && match($2, "src/github.com/getlantern/*"){print $2}' | \
+                        sed 's+src/github.com/getlantern/++g' | \
+                        sed 's+/.*++' | \
+                        uniq)
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+$DIR/prehook.sh

--- a/prehook.sh
+++ b/prehook.sh
@@ -1,25 +1,21 @@
 #!/bin/sh
 
-# Git pre-push hook for the Lantern project
+# Shared pre push/commit hook for the Lantern project
 # Maintainer: Ulysses Aalto <uaalto@getlantern.org>
 #
-# Installation: Copy into .git/hooks/pre-push
+# Installation: Symlink or copy into .git/hooks/prehook.sh
 
-
-# Exit immediately if a command exits with a non-zero status.
-set -e
-
-# Find only modified files/directories
-MODIFIED_DIRS=$(git status --porcelain | \
-                        awk 'match($1, "M") && match($2, "src/github.com/getlantern/*"){print $2}' | \
-                        sed 's+src/github.com/getlantern/++g' | \
-                        sed 's+/.*++' | \
-                        uniq)
 echo "Running hook -- Analyzing modified packages..."
+FOUND_CHANGE=false
 for i in $MODIFIED_DIRS; do
     echo " * $i";
+    FOUND_CHANGE=true;
 done
-echo
+
+if [ "$FOUND_CHANGE" = false ]; then
+    echo "No changes to analyze";
+    exit 0;
+fi
 
 cd src/github.com/getlantern
 

--- a/src/github.com/getlantern/lantern-mobile/Dockerfile
+++ b/src/github.com/getlantern/lantern-mobile/Dockerfile
@@ -5,7 +5,7 @@
 FROM fedora:22
 MAINTAINER "Ulysses Aalto" <uaalto@getlantern.org>
 
-ENV GO_VERSION go1.5.1
+ENV GO_VERSION go1.5.2
 ENV GOROOT_BOOTSTRAP /go1.5
 ENV GOROOT /go
 ENV GOPATH /
@@ -32,15 +32,15 @@ RUN dnf install -y make vim strace tmux && dnf clean all
 # Install Go.
 #   1) 1.5 for bootstrap.
 ENV GOROOT_BOOTSTRAP /go1.5
-RUN (curl -sSL https://golang.org/dl/go1.5.1.linux-amd64.tar.gz | tar -vxz -C /tmp) && \
+RUN (curl -sSL https://golang.org/dl/go1.5.2.linux-amd64.tar.gz | tar -vxz -C /tmp) && \
 	mv /tmp/go $GOROOT_BOOTSTRAP
 
 #   2) Download and cross compile the Go on revision GOREV.
 #
 # GOVERSION string is the output of 'git log -n 1 --format="format: devel +%h %cd" HEAD'
 # like in go tool dist.
-ENV GO_REV go1.5.1
-ENV GO_VERSION go1.5.1
+ENV GO_REV go1.5.2
+ENV GO_VERSION go1.5.2
 
 ENV GOROOT /go
 ENV PATH $GOROOT/bin:$PATH

--- a/src/github.com/getlantern/lantern-mobile/Dockerfile
+++ b/src/github.com/getlantern/lantern-mobile/Dockerfile
@@ -5,7 +5,6 @@
 FROM fedora:22
 MAINTAINER "Ulysses Aalto" <uaalto@getlantern.org>
 
-ENV GO_VERSION go1.5.2
 ENV GOROOT_BOOTSTRAP /go1.5
 ENV GOROOT /go
 ENV GOPATH /


### PR DESCRIPTION
This has a few updates:

1. Support use of newest Docker Tools on Mac.  The script should still work with boot2docker, but it will use the newer docker-machine command if available.

2. Support building mobile locally.

3. Made pre-push hook work on pre-push (as originally written, it didn't seem to work for pre-push because it was using git status which only looks at the working tree, not comparing remote to origin)

4. Added some more details to README