### PR TITLE
support minimum OSX 10.7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 SHELL := /bin/bash
 
+MIN_OS_VERSION_MAC := 10.7
+
 DOCKER := $(shell which docker 2> /dev/null)
 GO := $(shell which go 2> /dev/null)
 NODE := $(shell which node 2> /dev/null)
@@ -298,7 +300,7 @@ darwin-amd64: require-assets
 	if [[ "$$(uname -s)" == "Darwin" ]]; then \
 		source setenv.bash && \
 		$(call build-tags) && \
-		MACOSX_DEPLOYMENT_TARGET=10.7 CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -a -o lantern_darwin_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS)" github.com/getlantern/flashlight; \
+		MACOSX_DEPLOYMENT_TARGET=$(MIN_OS_VERSION_MAC) CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -a -o lantern_darwin_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS)" github.com/getlantern/flashlight; \
 	else \
 		echo "-> Skipped: Can not compile Lantern for OSX on a non-OSX host."; \
 	fi

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,7 @@ darwin-amd64: require-assets
 	if [[ "$$(uname -s)" == "Darwin" ]]; then \
 		source setenv.bash && \
 		$(call build-tags) && \
-		CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -a -o lantern_darwin_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS)" github.com/getlantern/flashlight; \
+		MACOSX_DEPLOYMENT_TARGET=10.7 CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -a -o lantern_darwin_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS)" github.com/getlantern/flashlight; \
 	else \
 		echo "-> Skipped: Can not compile Lantern for OSX on a non-OSX host."; \
 	fi


### PR DESCRIPTION
Hey @xiam this change should work.
```
> otool -l ./lantern_darwin_amd64  | grep -A 3 LC_VERSION_MIN_MACOSX
      cmd LC_VERSION_MIN_MACOSX
  cmdsize 16
  version 10.7
      sdk 10.11
```

`man clang` gives me the clue. golang doesn't recognize `-mmacosx-version-min` as CGO hint. Fortunately environment variable works.
```
MACOSX_DEPLOYMENT_TARGET
           If -mmacosx-version-min is unspecified, the default deployment target is read from this environment variable.  This option only affects darwin
           targets.
```