### PR TITLE
Stop Lantern when user disconnects from WiFi network

### DIFF
--- a/src/github.com/getlantern/lantern-mobile/app/src/main/AndroidManifest.xml
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/AndroidManifest.xml
@@ -27,6 +27,8 @@
 
             <receiver android:name=".LanternReceiver">
                 <intent-filter>
+                    <action android:name="android.net.conn.CONNECTIVITY_CHANGE"/>
+                    <action android:name="android.net.wifi.STATE_CHANGE"/>
                     <action android:name="android.intent.action.ACTION_SHUTDOWN" />
                     <action android:name="android.intent.action.SCREEN_ON" />
                     <action android:name="android.intent.action.SCREEN_OFF" />

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
@@ -130,6 +130,9 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
         }
     }
 
+    // override onKeyDown and onBackPressed default 
+    // behavior to prevent back button from interfering 
+    // with on/off switch
     @Override
     public boolean onKeyDown(int keyCode, KeyEvent event)  {
         if (Integer.parseInt(android.os.Build.VERSION.SDK) > 5
@@ -154,14 +157,15 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
 
     @Override
     protected void onDestroy() {
+        super.onDestroy();
         try {
-            unregisterReceiver(mReceiver);
-            Utils.clearPreferences(this);
+            if (mReceiver != null) {
+                unregisterReceiver(mReceiver);
+            }
             stopLantern();
         } catch (Exception e) {
 
         }
-        super.onDestroy();
     }
 
     // quitLantern is the side menu option and cleanyl exits the app
@@ -170,7 +174,6 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
             Log.d(TAG, "About to exit Lantern...");
 
             stopLantern();
-            Utils.clearPreferences(this);
 
             // sleep for a few ms before exiting
             Thread.sleep(200);
@@ -186,7 +189,7 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
     @Override
     public boolean handleMessage(Message message) {
         if (message != null) {
-            //Toast.makeText(this, message.what, Toast.LENGTH_SHORT).show();
+            Toast.makeText(this, message.what, Toast.LENGTH_SHORT).show();
         }
         return true;
     }
@@ -195,15 +198,6 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
         if (LanternUI != null) {
             LanternUI.sendDesktopVersion(view);
         }
-    }
-
-    // isNetworkAvailable checks whether or not we are connected to
-    // the Internet; if no connection is available, the toggle
-    // switch is inactive
-    public boolean isNetworkAvailable() {
-        final Context context = this;
-        final ConnectivityManager connectivityManager = ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
-        return connectivityManager.getActiveNetworkInfo() != null && connectivityManager.getActiveNetworkInfo().isConnected();
     }
 
     // Make a VPN connection from the client
@@ -323,8 +317,8 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
                 if (LanternUI.useVpn() && 
                     networkInfo.getType() == ConnectivityManager.TYPE_WIFI &&
                     !networkInfo.isConnected()) {
+
                     stopLantern();
-                    Utils.clearPreferences(context);
                 }
             }
         }

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/model/UI.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/model/UI.java
@@ -67,6 +67,7 @@ import java.util.regex.Pattern;
 import org.getlantern.lantern.activity.LanternMainActivity;
 import org.getlantern.lantern.config.LanternConfig;
 import org.getlantern.lantern.model.MailSender;
+import org.getlantern.lantern.sdk.Utils;
 import org.getlantern.lantern.R;
 
 public class UI {
@@ -471,7 +472,7 @@ public class UI {
             public void onClick(View v) {
                 boolean isChecked = powerLantern.isChecked();
 
-                if (!activity.isNetworkAvailable()) {
+                if (!Utils.isNetworkAvailable(activity.getApplicationContext())) {
                     powerLantern.setChecked(false);
                     toggleSwitch(false);
                     showAlertDialog("Lantern", "No Internet connection available!");

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/sdk/Utils.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/sdk/Utils.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.AssetManager;
 import android.content.res.Resources;
+import android.net.ConnectivityManager;
 import android.util.Log;
 
 import java.io.FileInputStream;
@@ -97,4 +98,14 @@ public class Utils {
             mPrefs.edit().remove(PREF_USE_VPN).commit();
         }
     }
+
+    // isNetworkAvailable checks whether or not we are connected to
+    // the Internet; if no connection is available, the toggle
+    // switch is inactive
+    public static boolean isNetworkAvailable(final Context context) {
+        final ConnectivityManager connectivityManager = ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
+        return connectivityManager.getActiveNetworkInfo() != null && connectivityManager.getActiveNetworkInfo().isConnectedOrConnecting();
+    }
+
+
 }

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/sdk/Utils.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/sdk/Utils.java
@@ -103,9 +103,9 @@ public class Utils {
     // the Internet; if no connection is available, the toggle
     // switch is inactive
     public static boolean isNetworkAvailable(final Context context) {
-        final ConnectivityManager connectivityManager = ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
-        return connectivityManager.getActiveNetworkInfo() != null && connectivityManager.getActiveNetworkInfo().isConnectedOrConnecting();
+        final ConnectivityManager connectivityManager = 
+            ((ConnectivityManager) context.getSystemService(Context.CONNECTIVITY_SERVICE));
+        return connectivityManager.getActiveNetworkInfo() != null && 
+            connectivityManager.getActiveNetworkInfo().isConnectedOrConnecting();
     }
-
-
 }

--- a/src/github.com/getlantern/lantern-mobile/lantern/interface.go
+++ b/src/github.com/getlantern/lantern-mobile/lantern/interface.go
@@ -52,44 +52,47 @@ func Configure(provider Provider) error {
 // Start creates a new client at the given address.
 func Start(provider Provider) error {
 
-	log.Debugf("About to configure Lantern")
-
-	if provider.VpnMode() {
-		dnsServer := provider.GetDnsServer()
-		protected.Configure(provider, dnsServer, true)
-	}
-
-	androidProps := map[string]string{
-		"androidDevice":     provider.Device(),
-		"androidModel":      provider.Model(),
-		"androidSdkVersion": provider.Version(),
-	}
-	logging.ConfigureAndroid(androidProps)
-
-	l = lantern.New(appSettings.HttpAddr)
-
 	go func() {
 
-		err := l.Start(false, false, true, nil)
+		log.Debugf("About to configure Lantern")
+
+		if provider.VpnMode() {
+			dnsServer := provider.GetDnsServer()
+			protected.Configure(provider, dnsServer, true)
+		}
+
+		androidProps := map[string]string{
+			"androidDevice":     provider.Device(),
+			"androidModel":      provider.Model(),
+			"androidSdkVersion": provider.Version(),
+		}
+		logging.ConfigureAndroid(androidProps)
+
+		cfgFn := func(cfg *config.Config) {
+
+		}
+
+		l, err := lantern.Start(false, true, false,
+			true, cfgFn)
 
 		if err != nil {
 			log.Fatalf("Could not start Lantern")
 		}
-	}()
 
-	if provider.VpnMode() {
-		i, err = interceptor.Do(l.Client, appSettings.SocksAddr, appSettings.HttpAddr, provider.Notice)
-		if err != nil {
-			log.Errorf("Error starting interceptor: %v", err)
-		} else {
-			l.AddExitFunc(func() {
-				if i != nil {
-					i.Stop()
-				}
-			})
+		if provider.VpnMode() {
+			i, err = interceptor.Do(l.Client, appSettings.SocksAddr, appSettings.HttpAddr, provider.Notice)
+			if err != nil {
+				log.Errorf("Error starting interceptor: %v", err)
+			} else {
+				lantern.AddExitFunc(func() {
+					if i != nil {
+						i.Stop()
+					}
+				})
+			}
 		}
-	}
-	provider.AfterStart(lantern.GetVersion())
+		provider.AfterStart(lantern.GetVersion())
+	}()
 	return nil
 }
 

--- a/src/github.com/getlantern/lantern-mobile/lantern/interface.go
+++ b/src/github.com/getlantern/lantern-mobile/lantern/interface.go
@@ -97,5 +97,5 @@ func Start(provider Provider) error {
 }
 
 func Stop() {
-	go lantern.Exit(nil)
+	lantern.Exit(nil)
 }


### PR DESCRIPTION
This registers a new broadcast receiver that detects changes in network connectivity. If Lantern is running, and we disconnect from Wi-Fi, we automatically turn off the VPN service.