### PR TITLE
Fixed setting of PackageVersion in production builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -59,16 +59,17 @@ LANTERN_YAML_PATH := installer-resources/lantern.yaml
 
 define build-tags
 	BUILD_TAGS="" && \
+	EXTRA_LDFLAGS="" && \
 	if [[ ! -z "$$VERSION" ]]; then \
-		BUILD_TAGS="prod" && \
-		sed s/'PackageVersion.*'/'PackageVersion = "'$$VERSION'"'/ src/github.com/getlantern/flashlight/flashlight.go | sed s/'!prod'/'prod'/ > src/github.com/getlantern/flashlight/flashlight-prod.go; \
+		EXTRA_LDFLAGS="-X=github.com/getlantern/flashlight.compileTimePackageVersion=$$VERSION"; \
 	else \
-		echo "** VERSION was not set, using git revision instead ($(GIT_REVISION)). This is OK while in development."; \
+		echo "** VERSION was not set, using default version. This is OK while in development."; \
 	fi && \
 	if [[ ! -z "$$HEADLESS" ]]; then \
 		BUILD_TAGS="$$BUILD_TAGS headless"; \
 	fi && \
-	BUILD_TAGS=$$(echo $$BUILD_TAGS | xargs) && echo "Build tags: $$BUILD_TAGS"
+	BUILD_TAGS=$$(echo $$BUILD_TAGS | xargs) && echo "Build tags: $$BUILD_TAGS" && \
+	EXTRA_LDFLAGS=$$(echo $$EXTRA_LDFLAGS | xargs) && echo "Extra ldflags: $$EXTRA_LDFLAGS"
 endef
 
 define docker-up
@@ -162,22 +163,22 @@ docker-genassets: require-npm
 docker-linux-386:
 	@source setenv.bash && \
 	$(call build-tags) && \
-	CGO_ENABLED=1 GOOS=linux GOARCH=386 go build -a -o lantern_linux_386 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) -linkmode internal -extldflags \"-static\"" github.com/getlantern/flashlight/main
+	CGO_ENABLED=1 GOOS=linux GOARCH=386 go build -a -o lantern_linux_386 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) $$EXTRA_LDFLAGS -linkmode internal -extldflags \"-static\"" github.com/getlantern/flashlight/main
 
 docker-linux-amd64:
 	@source setenv.bash && \
 	$(call build-tags) && \
-	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o lantern_linux_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) -linkmode internal -extldflags \"-static\"" github.com/getlantern/flashlight/main
+	CGO_ENABLED=1 GOOS=linux GOARCH=amd64 go build -a -o lantern_linux_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) $$EXTRA_LDFLAGS -linkmode internal -extldflags \"-static\"" github.com/getlantern/flashlight/main
 
 docker-linux-arm:
 	@source setenv.bash && \
 	$(call build-tags) && \
-	CGO_ENABLED=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 go build -a -o lantern_linux_arm -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) -linkmode internal -extldflags \"-static\"" github.com/getlantern/flashlight/main
+	CGO_ENABLED=1 CC=arm-linux-gnueabi-gcc CXX=arm-linux-gnueabi-g++ CGO_ENABLED=1 GOOS=linux GOARCH=arm GOARM=7 go build -a -o lantern_linux_arm -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) $$EXTRA_LDFLAGS -linkmode internal -extldflags \"-static\"" github.com/getlantern/flashlight/main
 
 docker-windows-386:
 	@source setenv.bash && \
 	$(call build-tags) && \
-	CGO_ENABLED=1 GOOS=windows GOARCH=386 go build -a -o lantern_windows_386.exe -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) -H=windowsgui" github.com/getlantern/flashlight/main;
+	CGO_ENABLED=1 GOOS=windows GOARCH=386 go build -a -o lantern_windows_386.exe -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) $$EXTRA_LDFLAGS -H=windowsgui" github.com/getlantern/flashlight/main;
 
 require-assets:
 	@if [ ! -f ./src/github.com/getlantern/flashlight/ui/resources.go ]; then make genassets; fi
@@ -322,7 +323,7 @@ darwin-amd64: require-assets
 			export CGO_LDFLAGS="--sysroot $$OSX_DEV_SDK"; \
 		fi && \
 		MACOSX_DEPLOYMENT_TARGET=$(OSX_MIN_VERSION) \
-		CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -a -o lantern_darwin_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) -s" github.com/getlantern/flashlight/main; \
+		CGO_ENABLED=1 GOOS=darwin GOARCH=amd64 go build -a -o lantern_darwin_amd64 -tags="$$BUILD_TAGS" -ldflags="$(LDFLAGS) $$EXTRA_LDFLAGS -s" github.com/getlantern/flashlight/main; \
 	else \
 		echo "-> Skipped: Can not compile Lantern for OSX on a non-OSX host."; \
 	fi
@@ -502,7 +503,7 @@ android-lib: docker-mobile
 	@source setenv.bash && \
 	cd $(LANTERN_MOBILE_DIR)
 	@$(call docker-up) && \
-	$(DOCKER) run -v $$PWD/src:/src $(DOCKER_MOBILE_IMAGE_TAG) /bin/bash -c \ "cd /src/github.com/getlantern/lantern-mobile && gomobile bind -target=android -o=$(LANTERN_MOBILE_LIBRARY) -ldflags="$(LDFLAGS)" ." && \
+	$(DOCKER) run -v $$PWD/src:/src $(DOCKER_MOBILE_IMAGE_TAG) /bin/bash -c \ "cd /src/github.com/getlantern/lantern-mobile && gomobile bind -target=android -o=$(LANTERN_MOBILE_LIBRARY) -ldflags="$(LDFLAGS) $$EXTRA_LDFLAGS" ." && \
 	if [ -d "$(FIRETWEET_MAIN_DIR)" ]; then \
 		cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) $(FIRETWEET_MAIN_DIR)/libs/$(LANTERN_MOBILE_LIBRARY); \
 	else \
@@ -516,7 +517,7 @@ android-lib: docker-mobile
 android-lib-local:
 	@source setenv.bash && \
 	cd $(LANTERN_MOBILE_DIR) && \
-	gomobile bind -target=android -o=$(LANTERN_MOBILE_LIBRARY) -ldflags="$(LDFLAGS)" . && \
+	gomobile bind -target=android -o=$(LANTERN_MOBILE_LIBRARY) -ldflags="$(LDFLAGS) $$EXTRA_LDFLAGS" . && \
 	if [ -d "$(FIRETWEET_MAIN_DIR)" ]; then \
 		cp -v $(LANTERN_MOBILE_DIR)/$(LANTERN_MOBILE_LIBRARY) $(FIRETWEET_MAIN_DIR)/libs/$(LANTERN_MOBILE_LIBRARY); \
 	else \

--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -13,17 +13,21 @@ import (
 	"github.com/getlantern/flashlight/logging"
 )
 
-// While in development mode we probably would not want auto-updates to be
-// applied. Using a big number here prevents such auto-updates without
-// disabling the feature completely. The "make package-*" tool will take care
-// of bumping this version number so you don't have to do it by hand.
 const (
+	// While in development mode we probably would not want auto-updates to be
+	// applied. Using a big number here prevents such auto-updates without
+	// disabling the feature completely. The "make package-*" tool will take care
+	// of bumping this version number so you don't have to do it by hand.
 	DefaultPackageVersion = "9999.99.99"
-	PackageVersion        = DefaultPackageVersion
 )
 
 var (
 	log = golog.LoggerFor("flashlight")
+
+	// compileTimePackageVersion is set at compile-time for production builds
+	compileTimePackageVersion string
+
+	PackageVersion = bestPackageVersion()
 
 	Version      string
 	RevisionDate string // The revision date and time that is associated with the version string.
@@ -32,7 +36,16 @@ var (
 	cfgMutex sync.Mutex
 )
 
+func bestPackageVersion() string {
+	if compileTimePackageVersion != "" {
+		return compileTimePackageVersion
+	} else {
+		return DefaultPackageVersion
+	}
+}
+
 func init() {
+	log.Debugf("****************************** Package Version: %v", PackageVersion)
 	if PackageVersion != DefaultPackageVersion {
 		// packageVersion has precedence over GIT revision. This will happen when
 		// packing a version intended for release.

--- a/src/github.com/getlantern/flashlight/main/autoupdate.go
+++ b/src/github.com/getlantern/flashlight/main/autoupdate.go
@@ -1,5 +1,3 @@
-// +build !prod
-
 package main
 
 // This is the public key of the BNS cert. Incoming updates will be signed to


### PR DESCRIPTION
This addresses the issue with production builds not running.  As a bonus, it no longer relies on text substitution and instead uses Go linker flags.