### PR TITLE
Fixed data race in eventual

### DIFF
--- a/src/github.com/getlantern/eventual/eventual.go
+++ b/src/github.com/getlantern/eventual/eventual.go
@@ -60,7 +60,7 @@ func (v *value) processUpdates() {
 		if v.gotFirst == FALSE {
 			// Signal to blocking callers that we have the first value
 			v.wg.Done()
-			v.gotFirst = TRUE
+			atomic.StoreInt32(&v.gotFirst, TRUE)
 		}
 	}
 }


### PR DESCRIPTION
closes getlantern/lantern#3551

One can verify this by running `go test -race` in the eventual package.