### PR TITLE
adding getiantem.org closes #3638

### DIFF
--- a/src/github.com/getlantern/flashlight/genconfig/proxiedsites/original.txt
+++ b/src/github.com/getlantern/flashlight/genconfig/proxiedsites/original.txt
@@ -1,3 +1,4 @@
+getiantem.org
 manototv.com
 firetweet.io
 herokuapp.com


### PR DESCRIPTION
About as simple as a changelog itself can be, but it would be useful to review the underlying thinking here. I basically noticed in our logs that detour was dynamically determining what to do with getiantem.org