### PR TITLE
Reconfigure client when proxyAll option changes fixes #3689

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -61,8 +61,8 @@ func init() {
 	}
 }
 
-// Run runs a client proxy. It blocks as long as the proxy is running.
-func Run(httpProxyAddr string,
+// Start runs a client proxy in separate goroutine.
+func Start(httpProxyAddr string,
 	socksProxyAddr string,
 	configDir string,
 	stickyConfig bool,

--- a/src/github.com/getlantern/flashlight/main/main.go
+++ b/src/github.com/getlantern/flashlight/main/main.go
@@ -165,12 +165,12 @@ func doMain() error {
 		if listenAddr == "" {
 			listenAddr = "localhost:8787"
 		}
-		err := flashlight.Run(
+		proxyAllUpdater, err := flashlight.Run(
 			listenAddr,
 			"localhost:8788",
 			*configdir,
 			*stickyConfig,
-			settings.GetProxyAll,
+			settings.GetProxyAll(),
 			flagsAsMap(),
 			beforeStart,
 			afterStart,
@@ -180,6 +180,7 @@ func doMain() error {
 			exit(err)
 			return
 		}
+		settings.AddBoolNotifier(ProxyAll, proxyAllUpdater)
 	}()
 
 	return waitForExit()

--- a/src/github.com/getlantern/flashlight/main/main.go
+++ b/src/github.com/getlantern/flashlight/main/main.go
@@ -133,8 +133,13 @@ func doMain() error {
 	}
 
 	settings = LoadSettings(flashlight.Version, flashlight.RevisionDate, flashlight.BuildDate)
-
 	settings.AddBoolNotifier(AutoLaunch, launcher.CreateLaunchFile)
+	err := settings.Start()
+	if err != nil {
+		log.Errorf("Unable to register settings service: %q", err)
+	}
+	// toggleSystemProxy will block until proxy is ready, so we put it after
+	// settings.Start to avoid it from being called at this moment.
 	settings.AddBoolNotifier(SystemProxy, toggleSystemProxy)
 
 	// Schedule cleanup actions

--- a/src/github.com/getlantern/flashlight/main/main.go
+++ b/src/github.com/getlantern/flashlight/main/main.go
@@ -165,7 +165,7 @@ func doMain() error {
 		if listenAddr == "" {
 			listenAddr = "localhost:8787"
 		}
-		proxyAllUpdater, err := flashlight.Run(
+		proxyAllUpdater, err := flashlight.Start(
 			listenAddr,
 			"localhost:8788",
 			*configdir,

--- a/src/github.com/getlantern/flashlight/main/settings.go
+++ b/src/github.com/getlantern/flashlight/main/settings.go
@@ -214,13 +214,13 @@ func (s *Settings) Save() {
 // save saves settings to disk without locking.
 func (s *Settings) save() {
 	toBeSaved := s.dump(true, false)
-	log.Tracef("Saving settings: %+v", toBeSaved)
+	log.Tracef("Saving settings:\n %+v", toBeSaved)
 	if bytes, err := yaml.Marshal(toBeSaved); err != nil {
 		log.Errorf("Could not create yaml from settings %v", err)
 	} else if err := ioutil.WriteFile(path, bytes, 0644); err != nil {
 		log.Errorf("Could not write settings file %v", err)
 	} else {
-		log.Debugf("Saved settings to %s with contents %v", path, string(bytes))
+		log.Debugf("Saved settings to %s with contents\n %v", path, string(bytes))
 	}
 }
 

--- a/src/github.com/getlantern/flashlight/main/settings_test.go
+++ b/src/github.com/getlantern/flashlight/main/settings_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,6 +12,30 @@ func TestNotPersistVersion(t *testing.T) {
 	version := "version-not-on-disk"
 	revisionDate := "1970-1-1"
 	buildDate := "1970-1-1"
-	Load(version, revisionDate, buildDate)
-	assert.Equal(t, settings.Version, version, "Should be set to version")
+	LoadSettings(version, revisionDate, buildDate)
+	assert.Equal(t, settings.entries[ProxyAll], true, "Should load from file")
+	assert.Equal(t, settings.entries[Version], version, "Should be set to version")
+}
+
+func TestManipulateentries(t *testing.T) {
+	path = "./TestManipulateentries.yaml"
+	defer os.Remove(path)
+	var prev, cur interface{}
+	testId := id("testId")
+	s := New(entries{}, false)
+	s.AddNotifier(testId, func(p, c interface{}) {
+		prev, cur = p, c
+	})
+
+	s.Set(testId, "abc")
+	assert.Equal(t, s.Get(testId), "abc")
+	assert.Equal(t, s.GetString(testId), "abc")
+	assert.Equal(t, prev, nil, "should call notifier with correct prev value")
+	assert.Equal(t, cur, "abc", "should call notifier with correct cur value")
+
+	s.Set(testId, true)
+	assert.Equal(t, s.Get(testId), true)
+	assert.Equal(t, s.GetBool(testId), true)
+	assert.Equal(t, prev, "abc", "should call notifier with correct prev value")
+	assert.Equal(t, cur, true, "should call notifier with correct cur value")
 }

--- a/src/github.com/getlantern/flashlight/main/test.yaml
+++ b/src/github.com/getlantern/flashlight/main/test.yaml
@@ -1,7 +1,7 @@
 version: test
-builddate: test
-revisiondate: test
-autoreport: false
-autolaunch: false
-proxyall: true
-instanceid: bfc1d4e9-6b3e-4dcb-8376-8e987086c965
+buildDate: test
+revisionDate: test
+autoReport: false
+autoLaunch: false
+proxyAll: true
+instanceId: bfc1d4e9-6b3e-4dcb-8376-8e987086c965

--- a/src/github.com/getlantern/lantern/lantern.go
+++ b/src/github.com/getlantern/lantern/lantern.go
@@ -89,7 +89,7 @@ func run(configDir string) {
 		"localhost:0", // listen for SOCKS on random address
 		configDir,     // place to store lantern configuration
 		false,         // don't make config sticky
-		func() bool { return true },                   // proxy all requests
+		true,          // proxy all requests
 		make(map[string]interface{}),                  // no special configuration flags
 		func(cfg *config.Config) bool { return true }, // beforeStart()
 		func(cfg *config.Config) {},                   // afterStart()

--- a/src/github.com/getlantern/lantern/lantern.go
+++ b/src/github.com/getlantern/lantern/lantern.go
@@ -57,7 +57,7 @@ type StartResult struct {
 // time out.
 func Start(configDir string, timeoutMillis int) (*StartResult, error) {
 	startOnce.Do(func() {
-		go run(configDir)
+		start(configDir)
 	})
 
 	start := time.Now()
@@ -79,13 +79,13 @@ func AddLoggingMetadata(key, value string) {
 	logging.SetExtraLogglyInfo(key, value)
 }
 
-func run(configDir string) {
+func start(configDir string) {
 	err := os.MkdirAll(configDir, 0755)
 	if os.IsExist(err) {
 		log.Errorf("Unable to create configDir at %v: %v", configDir, err)
 		return
 	}
-	flashlight.Run("localhost:0", // listen for HTTP on random address
+	flashlight.Start("localhost:0", // listen for HTTP on random address
 		"localhost:0", // listen for SOCKS on random address
 		configDir,     // place to store lantern configuration
 		false,         // don't make config sticky


### PR DESCRIPTION
Most of the code changes is to use map in settings.go, which makes it easier to add notifiers and entries in the future. We need them because that's how main.go get notified when proxyAll option changes.

The code has plenty of room to improve, but we may leave that for future refactor and fix https://github.com/getlantern/lantern/issues/3689 first.

@oxtoacart want take a look?