### PR TITLE
README and Makefile cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -179,17 +179,6 @@ docker-%: system-checks
 	echo docker run `echo $(DOCKER_VOLS) | xargs` -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" BNS_CERT_PASS="'$$BNS_CERT_PASS'" make $*' && \
 	docker run `echo $(DOCKER_VOLS) | xargs` -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" BNS_CERT_PASS="'$$BNS_CERT_PASS'" make $*';
 
-docker-test: system-checks
-	@$(call docker-up) && \
-	echo "Building docker..." && \
-	DOCKER_CONTEXT=.$(DOCKER_IMAGE_TAG)-context && \
-	mkdir -p $$DOCKER_CONTEXT && \
-	cp Dockerfile $$DOCKER_CONTEXT && \
-	echo "Calling docker build..." && \
-	docker build -t $(DOCKER_IMAGE_TAG) $$DOCKER_CONTEXT && \
-	echo docker run `echo $(DOCKER_VOLS) | xargs` -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" BNS_CERT_PASS="'$$BNS_CERT_PASS'" make $*' && \
-	docker run `echo $(DOCKER_VOLS) | xargs` -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" BNS_CERT_PASS="'$$BNS_CERT_PASS'" make $*';
-
 all: binaries
 android-dist: genconfig android
 
@@ -280,17 +269,14 @@ package-windows: $(BNS_CERT) require-version windows
 	rm -f $$INSTALLER_RESOURCES/$(LANTERN_YAML) && \
 	cp installer-resources/$(PACKAGED_YAML) $$INSTALLER_RESOURCES/$(PACKAGED_YAML) && \
 	cp $(LANTERN_YAML_PATH) $$INSTALLER_RESOURCES/$(LANTERN_YAML) && \
-	echo "Signing Lantern Windows binary" && \
 	osslsigncode sign -pkcs12 "$(BNS_CERT)" -pass "$$BNS_CERT_PASS" -n "Lantern" -t http://timestamp.verisign.com/scripts/timstamp.dll -in "lantern_windows_386.exe" -out "$$INSTALLER_RESOURCES/lantern.exe" && \
 	cat $$INSTALLER_RESOURCES/lantern.exe | bzip2 > update_windows_386.bz2 && \
 	ls -l lantern_windows_386.exe update_windows_386.bz2 && \
 	makensis -V1 -DVERSION=$$VERSION installer-resources/windows/lantern.nsi && \
-	echo "Signing Lantern Windows installer" && \
 	osslsigncode sign -pkcs12 "$(BNS_CERT)" -pass "$$BNS_CERT_PASS" -n "Lantern" -t http://timestamp.verisign.com/scripts/timstamp.dll -in "$$INSTALLER_RESOURCES/lantern-installer-unsigned.exe" -out "lantern-installer.exe" && \
 	cp installer-resources/$(MANOTO_YAML) $$INSTALLER_RESOURCES/$(PACKAGED_YAML) && \
 	cp $(LANTERN_YAML_PATH) $$INSTALLER_RESOURCES/$(LANTERN_YAML) && \
 	makensis -V1 -DVERSION=$$VERSION installer-resources/windows/lantern.nsi && \
-	echo "Signing Lantern Windows installer Manoto version" && \
 	osslsigncode sign -pkcs12 "$(BNS_CERT)" -pass "$$BNS_CERT_PASS" -n "Lantern" -t http://timestamp.verisign.com/scripts/timstamp.dll -in "$$INSTALLER_RESOURCES/lantern-installer-unsigned.exe" -out "lantern-installer-manoto.exe" && \
 	echo "-> lantern-installer.exe and lantern-installer-manoto.exe"
 

--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ LANTERN_MOBILE_ANDROID_RELEASE := $(LANTERN_MOBILE_DIR)/app/build/outputs/apk/ap
 LANTERN_YAML := lantern.yaml
 LANTERN_YAML_PATH := installer-resources/lantern.yaml
 
-.PHONY: packages clean docker tun2socks android-lib android-sdk android-testbed android-debug android-release android-install
+.PHONY: packages clean tun2socks android-lib android-sdk android-testbed android-debug android-release android-install
 
 define build-tags
 	BUILD_TAGS="" && \
@@ -164,17 +164,13 @@ define docker-up
 	fi
 endef
 
-docker: docker-
-
 # This implicit rule allows prefix any existing target with "docker-" to make it
 # run in docker.
 docker-%: system-checks
 	@$(call docker-up) && \
-	echo "Building docker..." && \
 	DOCKER_CONTEXT=.$(DOCKER_IMAGE_TAG)-context && \
 	mkdir -p $$DOCKER_CONTEXT && \
 	cp Dockerfile $$DOCKER_CONTEXT && \
-	echo "Calling docker build..." && \
 	docker build -t $(DOCKER_IMAGE_TAG) $$DOCKER_CONTEXT && \
 	echo docker run `echo $(DOCKER_VOLS) | xargs` -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" BNS_CERT_PASS="'$$BNS_CERT_PASS'" make $*' && \
 	docker run `echo $(DOCKER_VOLS) | xargs` -t $(DOCKER_IMAGE_TAG) /bin/bash -c 'cd /lantern && VERSION="'$$VERSION'" HEADLESS="'$$HEADLESS'" BNS_CERT_PASS="'$$BNS_CERT_PASS'" make $*';

--- a/README-release.md
+++ b/README-release.md
@@ -1,0 +1,240 @@
+## Building Lantern for Releases
+
+For release builds, you'll want to use Docker:
+
+* [Docker](https://www.docker.com/).
+
+We are going to create a Docker image that will take care of compiling Lantern
+for Windows and Linux, in order to compile Lantern for OSX you'll need an OSX
+host, this is a limitation caused by Lantern depending on C code and OSX build
+tools for certain features.
+
+*Any target can be run on Docker by prefixing it with 'docker-'*, e.g.
+`make windows` runs locally and `make docker-windows` runs in docker.
+
+### Docker Installation Instructions
+
+1. Get the [Docker Toolbox](https://www.docker.com/docker-toolbox)
+2. Install docker per [these instructions](https://docs.docker.com/mac/step_one/)
+
+After installation, you'll have a docker machine called `default`, which is what the build script uses. You'll probably want to increase the memory and cpu for the default machine, which will require you to recreate it:
+
+```bash
+docker-machine rm default
+docker-machine create --driver virtualbox --virtualbox-cpu-count 2 --virtualbox-memory 4096 default
+```
+
+### Migrating from boot2docker
+
+If you already have a boot2docker vm that you want to use with the new
+docker-toolbox, you can migrate it with this command:
+
+```bash
+docker-machine create -d virtualbox --virtualbox-import-boot2docker-vm boot2docker-vm default
+```
+
+### Building the docker image
+
+In order to build the docker image open a terminal, `cd` into the
+`lantern` project and execute `make docker`:
+
+```sh
+cd lantern
+make docker
+```
+
+This will take a while, be patient, you only need to do this once.
+
+## Building Lantern binaries
+
+### Building for Linux
+
+If you want to build for Linux on all supported architectures, use:
+
+```sh
+make linux
+```
+
+You can also build for Linux 386:
+
+```sh
+make linux-386
+file lantern_linux_386
+# lantern_linux_386: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically linked (uses shared libs), not stripped
+```
+
+Or only for amd64:
+
+```sh
+make linux-amd64
+file lantern_linux_amd64
+# lantern_linux_amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked (uses shared libs), not stripped
+```
+
+Or ARM:
+
+```sh
+make linux-arm
+file lantern_linux_arm
+# lantern_linux_arm: ELF 32-bit LSB executable, ARM, version 1 (SYSV), dynamically linked (uses shared libs), not stripped
+```
+
+
+### Building for Windows
+
+Lantern supports the 386 architecture on Windows. In order to build Lantern on
+Windows use:
+
+```sh
+make windows
+file lantern_windows_386.exe
+# lantern_windows_386.exe: PE32 executable for MS Windows (GUI) Intel 80386 32-bit
+```
+
+### Building for OSX
+
+Lantern supports the amd64 architecture on OSX. In order to build Lantern on
+OSX you'll need an OSX host. Run the following command:
+
+```sh
+make darwin
+file lantern_darwin_amd64
+# lantern_darwin_amd64: Mach-O 64-bit executable x86_64
+```
+
+### Building all binaries
+
+If you want to build all supported binaries of Lantern use the `binaries` task:
+
+```sh
+make binaries
+```
+
+### Building headless version
+
+If `HEADLESS` environment variable is set, the generated binaries will be
+headless, that is, it doesn't depend on the systray support libraries, and
+will not show systray or UI.
+
+## Packaging
+
+Packaging requires some special environment variables.
+
+### OSX
+
+Lantern on OS X is packaged as the `Lantern.app` app bundle, distributed inside
+of a drag-and-drop dmg installer. The app bundle and dmg can be created using:
+
+```sh
+VERSION=2.0.0-beta2 make package-darwin
+file Lantern.dmg
+# Lantern.dmg: bzip2 compressed data, block size = 100k
+```
+
+`make package-darwin` signs the Lantern.app using the BNS code signing
+certificate in your KeyChain. The
+[certificate](https://github.com/getlantern/too-many-secrets/blob/master/osx-code-signing-certificate.p12)
+and
+[password](https://github.com/getlantern/too-many-secrets/blob/master/osx-code-signing-certificate.p12.txt)
+can be obtained from
+[too-many-secrets](https://github.com/getlantern/too-many-secrets) and must be
+installed to the system's key chain beforehand.
+
+If signing fails, the script will still build the app bundle and dmg, but the
+app bundle won't be signed. Unsigned app bundles can be used for testing but
+should never be distributed to end users.
+
+The background image for the DMG is
+`installer-resources/darwin/dmgbackground.svg`.
+
+### Packaging for Windows
+
+Lantern on Windows is distributed as an installer built with
+[nsis](http://nsis.sourceforge.net/). The installer is built and signed with
+`make docker-package-windows`.
+
+For `make package-windows` to be able to sign the executable, the environment variables
+`SECRETS_DIR` and `BNS_CERT_PASS` must be set to point to the secrets directory
+and the
+[password](https://github.com/getlantern/too-many-secrets/blob/master/build-installers/env-vars.txt#L3)
+of the BNS certificate.  You can set the environment variables and run the
+script on one line, like this:
+
+```sh
+SECRETS_DIR=$PATH_TO_TOO_MANY_SECRETS BNS_CERT_PASS='***' \
+VERSION=2.0.0-beta1 make package-windows
+```
+
+### Packaging for Ubuntu
+
+Lantern on Ubuntu is distributed as a `.deb` package. You can generate a Debian
+package with:
+
+```sh
+VERSION=2.0.0-beta2 make docker-package-linux
+```
+
+The version string must match the Debian requirements:
+
+https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
+
+This will build both 386 and amd64 packages.
+
+### Generating all packages
+
+Use the `make packages` task combining all the arguments that
+`package-linux`, `package-windows` and `package-darwin` require.
+
+```sh
+SECRETS_DIR=$PATH_TO_TOO_MANY_SECRETS BNS_CERT_PASS='***' \
+VERSION=2.0.0-beta1 make packages
+```
+
+## Creating releases
+
+### Releasing for QA
+
+In order to release for QA, first obtain an [application token][1] from Github
+(`GH_TOKEN`) and then make sure that [s3cmd](https://github.com/s3tools/s3cmd)
+is correctly configured:
+
+```
+s3cmd --config
+```
+
+Then, create all distribution packages:
+
+```
+[...env variables...] make packages
+```
+
+Finally, use `release-qa` to upload the packages that were just generated to
+both AWS S3 and the Github release page:
+
+```
+VERSION=2.0.0-beta5 make release-qa
+```
+
+### Releasing Beta
+
+If you want to release a beta you must have created a package for QA first,
+then use the `release-beta` task:
+
+```
+make release-beta
+```
+
+`release-beta` will promote the QA files that are currently in S3 to beta.
+
+### Releasing for production
+
+After you're satisfied with a beta version, it will be time to promote beta
+packages to production and to publish the packages for auto-updates:
+
+```
+VERSION=2.0.0-beta5 GH_TOKEN=$GITHUB_TOKEN make release
+```
+
+`make release` expects a `lantern-binaries` directory at `../lantern-binaries`.
+You can provide a different directory by passing the `LANTERN_BINARIES_PATH`
+env variable.

--- a/README.md
+++ b/README.md
@@ -24,17 +24,7 @@ To build and run Lantern desktop, just do:
 ```sh
 git clone https://github.com/getlantern/lantern.git
 cd lantern
-make docker
-./lantern
-```
-
-You can alternatively skip make entirely and just do:
-
-```sh
-git clone https://github.com/getlantern/lantern.git
-cd lantern
-source setenv.bash
-go build -o lantern github.com/getlantern/flashlight/main
+make lantern
 ./lantern
 ```
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ make lantern
 ./lantern
 ```
 
+During development, you'll likely want to do a clean build like this:
+
+```sh
+make clean-desktop lantern && ./lantern
+```
+
 ## Building Mobile
 
 ### Mobile Prerequisites

--- a/README.md
+++ b/README.md
@@ -13,259 +13,30 @@
 
 ## Building Lantern
 
-### Requisites
+### Prerequisites
 
-* [Go 1.6rc1 or higher](https://golang.org/dl/).
+* [Git](https://git-scm.com/downloads) - `brew install git`, `apt-get install git`, etc
+* [Go 1.6 or higher](https://golang.org/dl/).
 * [GNU Make](https://www.gnu.org/software/make/)
-* An OSX or Linux host.
 
-For release builds, you'll want to use Docker as well:
-
-* [Docker](https://www.docker.com/).
-
-We are going to create a Docker image that will take care of compiling Lantern
-for Windows and Linux, in order to compile Lantern for OSX you'll need an OSX
-host, this is a limitation caused by Lantern depending on C code and OSX build
-tools for certain features.
-
-Any target can be run on Docker by prefixing it with 'docker-', e.g.
-`make windows` runs locally and `make docker-windows` runs in docker.
-
-### Docker Installation Instructions
-
-1. Get the [Docker Toolbox](https://www.docker.com/docker-toolbox)
-2. Install docker per [these instructions](https://docs.docker.com/mac/step_one/)
-
-After installation, you'll have a docker machine called `default`, which is what the build script uses. You'll probably want to increase the memory and cpu for the default machine, which will require you to recreate it:
-
-```bash
-docker-machine rm default
-docker-machine create --driver virtualbox --virtualbox-cpu-count 2 --virtualbox-memory 4096 default
-```
-
-### Migrating from boot2docker
-
-If you already have a boot2docker vm that you want to use with the new
-docker-toolbox, you can migrate it with this command:
-
-```bash
-docker-machine create -d virtualbox --virtualbox-import-boot2docker-vm boot2docker-vm default
-```
-
-### Building the docker image
-
-In order to build the docker image open a terminal, `cd` into the
-`lantern` project and execute `make docker`:
+Then just run:
 
 ```sh
+git clone https://github.com/getlantern/lantern.git
 cd lantern
 make docker
+./lantern
 ```
 
-This will take a while, be patient, you only need to do this once.
-
-## Building Lantern binaries
-
-### Building for Development
-
-During development, you can build a lantern that includes race detection with
-the below.  Note - this currently only works using Go 1.5 (not 1.6rc1).
+You can alternatively skip make entirely and just do:
 
 ```sh
-make lantern
+git clone https://github.com/getlantern/lantern.git
+cd lantern
+source setenv.bash
+go build -o lantern github.com/getlantern/flashlight/main
+./lantern
 ```
-
-### Building for Linux
-
-If you want to build for Linux on all supported architectures, use:
-
-```sh
-make linux
-```
-
-You can also build for Linux 386:
-
-```sh
-make linux-386
-file lantern_linux_386
-# lantern_linux_386: ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), dynamically linked (uses shared libs), not stripped
-```
-
-Or only for amd64:
-
-```sh
-make linux-amd64
-file lantern_linux_amd64
-# lantern_linux_amd64: ELF 64-bit LSB executable, x86-64, version 1 (SYSV), dynamically linked (uses shared libs), not stripped
-```
-
-Or ARM:
-
-```sh
-make linux-arm
-file lantern_linux_arm
-# lantern_linux_arm: ELF 32-bit LSB executable, ARM, version 1 (SYSV), dynamically linked (uses shared libs), not stripped
-```
-
-
-### Building for Windows
-
-Lantern supports the 386 architecture on Windows. In order to build Lantern on
-Windows use:
-
-```sh
-make windows
-file lantern_windows_386.exe
-# lantern_windows_386.exe: PE32 executable for MS Windows (GUI) Intel 80386 32-bit
-```
-
-### Building for OSX
-
-Lantern supports the amd64 architecture on OSX. In order to build Lantern on
-OSX you'll need an OSX host. Run the following command:
-
-```sh
-make darwin
-file lantern_darwin_amd64
-# lantern_darwin_amd64: Mach-O 64-bit executable x86_64
-```
-
-### Building all binaries
-
-If you want to build all supported binaries of Lantern use the `binaries` task:
-
-```sh
-make binaries
-```
-
-### Building headless version
-
-If `HEADLESS` environment variable is set, the generated binaries will be
-headless, that is, it doesn't depend on the systray support libraries, and
-will not show systray or UI.
-
-## Packaging
-
-Packaging requires some special environment variables.
-
-### OSX
-
-Lantern on OS X is packaged as the `Lantern.app` app bundle, distributed inside
-of a drag-and-drop dmg installer. The app bundle and dmg can be created using:
-
-```sh
-VERSION=2.0.0-beta2 make package-darwin
-file Lantern.dmg
-# Lantern.dmg: bzip2 compressed data, block size = 100k
-```
-
-`make package-darwin` signs the Lantern.app using the BNS code signing
-certificate in your KeyChain. The
-[certificate](https://github.com/getlantern/too-many-secrets/blob/master/osx-code-signing-certificate.p12)
-and
-[password](https://github.com/getlantern/too-many-secrets/blob/master/osx-code-signing-certificate.p12.txt)
-can be obtained from
-[too-many-secrets](https://github.com/getlantern/too-many-secrets) and must be
-installed to the system's key chain beforehand.
-
-If signing fails, the script will still build the app bundle and dmg, but the
-app bundle won't be signed. Unsigned app bundles can be used for testing but
-should never be distributed to end users.
-
-The background image for the DMG is
-`installer-resources/darwin/dmgbackground.svg`.
-
-### Packaging for Windows
-
-Lantern on Windows is distributed as an installer built with
-[nsis](http://nsis.sourceforge.net/). The installer is built and signed with
-`make docker-package-windows`.
-
-For `make package-windows` to be able to sign the executable, the environment variables
-`SECRETS_DIR` and `BNS_CERT_PASS` must be set to point to the secrets directory
-and the
-[password](https://github.com/getlantern/too-many-secrets/blob/master/build-installers/env-vars.txt#L3)
-of the BNS certificate.  You can set the environment variables and run the
-script on one line, like this:
-
-```sh
-SECRETS_DIR=$PATH_TO_TOO_MANY_SECRETS BNS_CERT_PASS='***' \
-VERSION=2.0.0-beta1 make package-windows
-```
-
-### Packaging for Ubuntu
-
-Lantern on Ubuntu is distributed as a `.deb` package. You can generate a Debian
-package with:
-
-```sh
-VERSION=2.0.0-beta2 make docker-package-linux
-```
-
-The version string must match the Debian requirements:
-
-https://www.debian.org/doc/debian-policy/ch-controlfields.html#s-f-Version
-
-This will build both 386 and amd64 packages.
-
-### Generating all packages
-
-Use the `make packages` task combining all the arguments that
-`package-linux`, `package-windows` and `package-darwin` require.
-
-```sh
-SECRETS_DIR=$PATH_TO_TOO_MANY_SECRETS BNS_CERT_PASS='***' \
-VERSION=2.0.0-beta1 make packages
-```
-
-## Creating releases
-
-### Releasing for QA
-
-In order to release for QA, first obtain an [application token][1] from Github
-(`GH_TOKEN`) and then make sure that [s3cmd](https://github.com/s3tools/s3cmd)
-is correctly configured:
-
-```
-s3cmd --config
-```
-
-Then, create all distribution packages:
-
-```
-[...env variables...] make packages
-```
-
-Finally, use `release-qa` to upload the packages that were just generated to
-both AWS S3 and the Github release page:
-
-```
-VERSION=2.0.0-beta5 make release-qa
-```
-
-### Releasing Beta
-
-If you want to release a beta you must have created a package for QA first,
-then use the `release-beta` task:
-
-```
-make release-beta
-```
-
-`release-beta` will promote the QA files that are currently in S3 to beta.
-
-### Releasing for production
-
-After you're satisfied with a beta version, it will be time to promote beta
-packages to production and to publish the packages for auto-updates:
-
-```
-VERSION=2.0.0-beta5 GH_TOKEN=$GITHUB_TOKEN make release
-```
-
-`make release` expects a `lantern-binaries` directory at `../lantern-binaries`.
-You can provide a different directory by passing the `LANTERN_BINARIES_PATH`
-env variable.
 
 ## Mobile
 
@@ -274,7 +45,7 @@ env variable.
 Building the mobile library and app requires the following:
 
 1. Install Java JDK 7 or 8
-2. Install Go 1.6rc1 or higher
+2. Install Go 1.6 or higher
 3. Install [Android SDK Tools](http://developer.android.com/sdk/index.html#Other)
 4. Install NDK(http://developer.android.com/ndk/downloads/index.html)
 
@@ -463,8 +234,11 @@ per the instructions [here](https://docs.travis-ci.com/user/encrypting-files/).
 
 ### Dev README
 
-Please, go to [README-dev](README-dev.md) for an in-depth explanation of the Lantern internals and
-cloud services.
+Please, go to [README-dev](README-dev.md) for an in-depth explanation of the Lantern internals and cloud services.
+
+### Release README
+
+Please visit [README-release](README-release.md) for details on building release versions of Lantern.
 
 ### Contributing changes
 Lantern is a [gost](https://github.com/getlantern/gost) project that

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 * [Go 1.6 or higher](https://golang.org/dl/).
 * [GNU Make](https://www.gnu.org/software/make/)
 
-Then just run:
+To build and run Lantern desktop, just do:
 
 ```sh
 git clone https://github.com/getlantern/lantern.git
@@ -38,7 +38,7 @@ go build -o lantern github.com/getlantern/flashlight/main
 ./lantern
 ```
 
-## Mobile
+## Building Mobile
 
 ### Mobile Prerequisites
 


### PR DESCRIPTION
This breaks out the release details from the README @xiam and @oxtoacart since that only applies to Lantern developers actually creating releases and goes into detail that's unusual for a Makefile. I also added simple instructions for building "the old fashioned way" with just `go build`. Finally, I added back the `make docker` target in the Makefile.