### PR TITLE
run Android tests locally and on testdroid cloud

### DIFF
--- a/src/github.com/getlantern/lantern-mobile/test/.gitignore
+++ b/src/github.com/getlantern/lantern-mobile/test/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+screenshots/
+tmp/
+.ropeproject/
+venv/

--- a/src/github.com/getlantern/lantern-mobile/test/README.md
+++ b/src/github.com/getlantern/lantern-mobile/test/README.md
@@ -16,10 +16,15 @@ virtualenv venv
 pip install -r requirements.txt
 ```
 
-You need to run `. venv/bin/activate` before executing any python scripts.
+## Run tests
 
+Run `. venv/bin/activate` before executing any python scripts.
 
-## Test on Testdroid cloud
+The screenshots took in each run will be in a separate directory under `./screenshots`.
+
+Modify `lib/suite.py` to add more tests.
+
+### Test on Testdroid cloud
 
 Make sure you properly set `TESTDROID_APIKEY` environment variable.
 
@@ -39,12 +44,14 @@ You have two options to run tests on Testdroid cloud.
 
 The script will upload the debug APK before running any test. Supply `--no-upload` option to skip uploading and use the latest uploaded APK.
 
-## Test on locally connected device
+### Test on locally connected device
 
 * Uninstall Lantern from target device.
 
 Selendroid will install the APK with a different signature. Installation will fail if there's an existing APK with different signature is installed.
 
+
+* Connect device and keep screen unlocked.
 
 * Start Selendroid standalone server (will download it at first time).
 
@@ -59,7 +66,3 @@ Selendroid will install the APK with a different signature. Installation will fa
 ```
 
 Check for Selendroid output if the error message is not clear enough.
-
-## Update tests
-
-Modify `lib/suite.py` to add more test functions.

--- a/src/github.com/getlantern/lantern-mobile/test/README.md
+++ b/src/github.com/getlantern/lantern-mobile/test/README.md
@@ -1,0 +1,65 @@
+# Blackbox test on Lantern Android
+
+## Perquisites
+
+* Build the Lantern Android debug APK
+
+```
+(cd ../../../../../; make android-debug)
+```
+
+* Install required python packages
+
+```
+virtualenv venv
+. venv/bin/activate
+pip install -r requirements.txt
+```
+
+You need to run `. venv/bin/activate` before executing any python scripts.
+
+
+## Test on Testdroid cloud
+
+Make sure you properly set `TESTDROID_APIKEY` environment variable.
+
+You have two options to run tests on Testdroid cloud.
+
+* Run on any available free cloud device.
+
+```
+./start_test.py
+```
+
+* Run on all devices in specific device group.
+
+```
+./start_test.py --group 14
+```
+
+The script will upload the debug APK before running any test. Supply `--no-upload` option to skip uploading and use the latest uploaded APK.
+
+## Test on locally connected device
+
+* Uninstall Lantern from target device.
+
+Selendroid will install the APK with a different signature. Installation will fail if there's an existing APK with different signature is installed.
+
+
+* Start Selendroid standalone server (will download it at first time).
+
+```
+./selendroid.sh
+```
+
+* Run test script
+
+```
+./start_test.py --local
+```
+
+Check for Selendroid output if the error message is not clear enough.
+
+## Update tests
+
+Modify `lib/suite.py` to add more test functions.

--- a/src/github.com/getlantern/lantern-mobile/test/README.md
+++ b/src/github.com/getlantern/lantern-mobile/test/README.md
@@ -28,7 +28,7 @@ Modify `lib/suite.py` to add more tests.
 
 Make sure you properly set `TESTDROID_APIKEY` environment variable.
 
-You have two options to run tests on Testdroid cloud.
+You have several options to run tests on Testdroid cloud.
 
 * Run on any available free cloud device.
 
@@ -36,11 +36,19 @@ You have two options to run tests on Testdroid cloud.
 ./start_test.py
 ```
 
-* Run on all devices in specific device group.
+* Run on specific cloud device.
+
+```
+./start_test.py --device "Xiaomi MI 1S"
+```
+
+* Run on all devices in specific device group on cloud.
 
 ```
 ./start_test.py --group 14
 ```
+
+Latter two options can be combined.
 
 The script will upload the debug APK before running any test. Supply `--no-upload` option to skip uploading and use the latest uploaded APK.
 

--- a/src/github.com/getlantern/lantern-mobile/test/lib/device_finder.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/device_finder.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+
+import requests
+
+
+class DeviceFinder:
+    # Cloud URL (not including API path)
+    url = None
+
+    """ Full constructor with username and password
+    """
+    def __init__(self, url="https://cloud.testdroid.com", apiKey=None, download_buffer_size=65536):
+        self.cloud_url = url
+        self.apiKey = apiKey
+        self.download_buffer_size = download_buffer_size
+
+    """ Append dictionary items to header
+    """
+    def _build_headers(self, headers=None):
+        hdrs = {}
+        hdrs["Accept"] = "application/json"
+        if headers is not None:
+            hdrs.update(headers)
+        return hdrs
+
+    """ Returns list of devices
+    """
+    def get_devices(self, limit=0):
+        return self.get("devices?limit=%s" % (limit))
+
+    """ GET from API resource
+    """
+    def get(self, path=None, get_headers=None, auth=None):
+        url = "%s/api/v2/%s" % (self.cloud_url, path)
+        headers = self._build_headers(get_headers)
+        res = requests.get(url, headers=headers, auth=auth)
+        if res.ok:
+            return res.json()
+        else:
+            res.raise_for_status()
+
+    """ Find all devices in a device group
+    """
+    def devices_by_group(self, group_id):
+        if self.apiKey is None:
+            print "API KEY not found"
+            return []
+        resp = self.get("me/device-groups/%d/devices" % (group_id),
+                        auth=(self.apiKey, ''))
+        return map(lambda d: str(d['displayName']), resp['data'])
+
+    """ Find available free Android device
+    """
+    def available_free_android_device(self, limit=0):
+        print "Searching Available Free Android Device..."
+
+        for device in self.get_devices(limit)['data']:
+            if (device['creditsPrice'] == 0
+                    and device['locked'] is False
+                    and device['osType'] == "ANDROID"
+                    and device['softwareVersion']['apiLevel'] > 16):
+                print "Found device '%s'" % device['displayName']
+                return str(device['displayName'])
+
+        print "No available device found"
+        print ""
+        return None
+
+    """ Find available free iOS device
+    """
+    def available_free_ios_device(self, limit=0):
+        print "Searching Available Free iOS Device..."
+
+        for device in self.get_devices(limit)['data']:
+            if (device['creditsPrice'] == 0
+                    and device['locked'] is False
+                    and device['osType'] == "IOS"):
+                print "Found device '%s'" % device['displayName']
+                return str(device['displayName'])
+
+        print "No available device found"
+        return None
+
+    """ Find out the API level of a Device
+    """
+    def device_API_level(self, deviceName):
+        print "Searching for API level of device '%s'" % deviceName
+
+        try:
+            device = self.get(path="devices?search=%s" % deviceName)
+            apiLevel = device['data'][0]['softwareVersion']['apiLevel']
+            print "Found API level: %s" % apiLevel
+            return apiLevel
+        except Exception, e:
+            print "Error: %s" % e
+            return

--- a/src/github.com/getlantern/lantern-mobile/test/lib/device_finder.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/device_finder.py
@@ -4,9 +4,6 @@ import requests
 
 
 class DeviceFinder:
-    # Cloud URL (not including API path)
-    url = None
-
     """ Full constructor with username and password
     """
     def __init__(self, url="https://cloud.testdroid.com", apiKey=None, download_buffer_size=65536):

--- a/src/github.com/getlantern/lantern-mobile/test/lib/local_android.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/local_android.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+
+import time
+import unittest
+from suite import TestLantern
+
+
+def log(msg):
+    print (time.strftime("%H:%M:%S") + ": " + msg)
+
+
+class LocalAndroid(TestLantern):
+    def setUp(self):
+
+        # Ref http://appium.io/slate/en/master/?python#appium-server-capabilities
+        self.desired_caps = {
+            'platformName': 'Android',
+            'aut': 'org.getlantern.lantern',
+            'emulator': False
+        }
+        self.hub_url = 'http://localhost:4444/wd/hub'
+        self.device_name = "local"
+        TestLantern.setUp(self)
+
+
+def test():
+    suite = unittest.TestLoader().loadTestsFromTestCase(LocalAndroid)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/src/github.com/getlantern/lantern-mobile/test/lib/local_android.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/local_android.py
@@ -15,6 +15,7 @@ class LocalAndroid(TestLantern):
         # Ref http://appium.io/slate/en/master/?python#appium-server-capabilities
         self.desired_caps = {
             'platformName': 'Android',
+            'automationName': 'Selendroid',
             'aut': 'org.getlantern.lantern',
             'emulator': False
         }

--- a/src/github.com/getlantern/lantern-mobile/test/lib/suite.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/suite.py
@@ -37,7 +37,7 @@ class TestLantern(ParametrizedTestCase):
     def setUp(self):
         log("Starting Appium test using device '%s'" % self.device_name)
         tm = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
-        self.screenshotDir = os.path.join('./screenshots', self.device_name+'_'+tm)
+        self.screenshotDir = os.path.join('./screenshots', tm + '_' + self.device_name)
         log("Will save screenshots at: " + self.screenshotDir)
         try:
             os.makedirs(self.screenshotDir)
@@ -56,10 +56,12 @@ class TestLantern(ParametrizedTestCase):
         log("Test: start and quit app")
         self.driver.save_screenshot(self.screenshotDir + "/1_appLaunch.png")
 
-        self.by_id('settings_icon').click()
+        # self.by_id('settings_icon').click() # it doesn't work on API 17 or below!
+        elems = self.driver.find_elements_by_class_name('android.widget.ImageView')
+        elems[0].click()
         self.driver.save_screenshot(self.screenshotDir + "/2_showDrawer.png")
 
-        self.elem('Quit').click()
+        self.by_text('Quit').click()
         self.driver.save_screenshot(self.screenshotDir + "/3_quit.png")
 
         # log("  Typing in name")
@@ -106,18 +108,11 @@ class TestLantern(ParametrizedTestCase):
         # self.elem('Answer').click()
 
     def isSelendroid(self):
-        if self._isSelendroid is None:
-            return self._isSelendroid
+        automation = self.driver.capabilities.get('automationName')
+        return automation == 'Selendroid'
 
-        self._isSelendroid = False
-        if 'automationName' in self.driver.capabilities:
-            if self.driver.capabilities['automationName'] == 'selendroid':
-                self._isSelendroid = True
-
-        return self._isSelendroid
-
-    def elem(self, text):
-        if self.isSelendroid:
+    def by_text(self, text):
+        if self.isSelendroid():
             return self.driver.find_element_by_link_text(text)
         else:
             return self.driver.find_element_by_name(text)

--- a/src/github.com/getlantern/lantern-mobile/test/lib/suite.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/suite.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+
+import os
+import time
+import unittest
+from appium import webdriver
+# from time import sleep
+# from selenium.common.exceptions import WebDriverException
+
+
+def log(msg):
+    print (time.strftime("%H:%M:%S") + ": " + msg)
+
+
+class ParametrizedTestCase(unittest.TestCase):
+    """ TestCase classes that want to be parametrized should
+        inherit from this class.
+    """
+    def __init__(self, methodName='runTest', param=None):
+        super(ParametrizedTestCase, self).__init__(methodName)
+        self.param = param
+
+    @staticmethod
+    def parametrize(testcase_klass, param=None):
+        """ Create a suite containing all tests taken from the given
+            subclass, passing them the parameter 'param'.
+        """
+        testloader = unittest.TestLoader()
+        testnames = testloader.getTestCaseNames(testcase_klass)
+        suite = unittest.TestSuite()
+        for name in testnames:
+            suite.addTest(testcase_klass(name, param=param))
+        return suite
+
+
+class TestLantern(ParametrizedTestCase):
+    def setUp(self):
+        log("Starting Appium test using device '%s'" % self.device_name)
+        tm = time.strftime("%Y%m%dT%H%M%S", time.gmtime())
+        self.screenshotDir = os.path.join('./screenshots', self.device_name+'_'+tm)
+        log("Will save screenshots at: " + self.screenshotDir)
+        try:
+            os.makedirs(self.screenshotDir)
+        except OSError, e:
+            log("Fail to create screenshot directory %s: %s", self.screenshotDir, e)
+
+        log("WebDriver request initiated. Waiting for response, this typically takes 2-3 mins")
+        self.driver = webdriver.Remote(self.hub_url, self.desired_caps)
+        log("WebDriver response received")
+
+    def tearDown(self):
+        log("Quitting")
+        self.driver.quit()
+
+    def testStartAndQuit(self):
+        log("Test: start and quit app")
+        self.driver.save_screenshot(self.screenshotDir + "/1_appLaunch.png")
+
+        self.by_id('settings_icon').click()
+        self.driver.save_screenshot(self.screenshotDir + "/2_showDrawer.png")
+
+        self.elem('Quit').click()
+        self.driver.save_screenshot(self.screenshotDir + "/3_quit.png")
+
+        # log("  Typing in name")
+        # elems = self.driver.find_elements_by_class_name('android.widget.EditText')
+        # log("  info: EditText:" + repr("len(elems)"))
+        # log("  Filling in name")
+        # elems[0].send_keys("Testdroid User")
+        # sleep(2)
+        # log("  Taking screenshot: 2_nameTyped.png")
+        # self.driver.save_screenshot(self.screenshotDir + "/2_nameTyped.png")
+
+        # try:
+        #     log("  Hiding keyboard")
+        #     self.driver.hide_keyboard()
+        # except:
+        #     pass  # pass exception, if keyboard isn't visible already
+        # log("  Taking screenshot: 3_nameTypedKeyboardHidden.png")
+        # self.driver.save_screenshot(self.screenshotDir + "/3_nameTypedKeyboardHidden.png")
+
+        # log("  Clicking element 'Buy 101 devices'")
+        # self.elem('Buy 101 devices').click()
+
+        # log("  Taking screenshot: 4_clickedButton1.png")
+        # self.driver.save_screenshot(self.screenshotDir + "/4_clickedButton1.png")
+
+        # log("  Clicking Answer")
+        # self.elem('Answer').click()
+
+        # log("  Taking screenshot: 5_answer.png")
+        # self.driver.save_screenshot(self.screenshotDir + "/5_answer.png")
+
+        # log("Navigating back to Activity-1")
+        # self.driver.back()
+        # log("  Taking screenshot: 6_mainActivity.png")
+        # self.driver.save_screenshot(self.screenshotDir + "/6_mainActivity.png")
+
+        # log("  Clicking element 'Use Testdroid Cloud'")
+        # self.elem('Use Testdroid Cloud').click()
+
+        # log("  Taking screenshot: 7_clickedButton2.png")
+        # self.driver.save_screenshot(self.screenshotDir + "/7_clickedButton2.png")
+
+        # log("  Clicking Answer")
+        # self.elem('Answer').click()
+
+    def isSelendroid(self):
+        if self._isSelendroid is None:
+            return self._isSelendroid
+
+        self._isSelendroid = False
+        if 'automationName' in self.driver.capabilities:
+            if self.driver.capabilities['automationName'] == 'selendroid':
+                self._isSelendroid = True
+
+        return self._isSelendroid
+
+    def elem(self, text):
+        if self.isSelendroid:
+            return self.driver.find_element_by_link_text(text)
+        else:
+            return self.driver.find_element_by_name(text)
+
+    def by_id(self, id):
+        return self.driver.find_element_by_id(id)

--- a/src/github.com/getlantern/lantern-mobile/test/lib/testdroid_android.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/testdroid_android.py
@@ -56,12 +56,15 @@ def available_free_android_device():
             return ret
 
 
-def executeTests(api_key, app, group_id=None):
+def executeTests(api_key, app, group_id=None, device_name=None):
     devices = []
+    if device_name is not None:
+        devices.append(device_name)
     if group_id is None:
-        devices = available_free_android_device()
+        if len(devices) == 0:
+            devices = available_free_android_device()
     else:
-        devices = DeviceFinder(apiKey=api_key).devices_by_group(group_id)
+        devices.extend(DeviceFinder(apiKey=api_key).devices_by_group(group_id))
 
     suite = unittest.TestSuite()
     map(lambda d: suite.addTest(

--- a/src/github.com/getlantern/lantern-mobile/test/lib/testdroid_android.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/testdroid_android.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+#
+# For help on setting up your machine and configuring this TestScript go to
+# http://help.testdroid.com/customer/portal/topics/631129-appium/articles
+#
+
+import time
+import unittest
+from device_finder import DeviceFinder
+from suite import TestLantern, ParametrizedTestCase
+
+appium_url = 'http://appium.testdroid.com/wd/hub'
+
+
+def log(msg):
+    print (time.strftime("%H:%M:%S") + ": " + msg)
+
+
+class TestdroidAndroid(TestLantern):
+    def setUp(self):
+        device = self.param['device']
+        app = self.param['app']
+        api_key = self.param['api_key']
+
+        # Ref http://docs.testdroid.com/appium/testdroid-desired-caps/
+        self.desired_caps = {
+            'testdroid_apiKey': api_key,
+            'testdroid_project': 'Lantern',
+            'testdroid_testrun': 'Lantern test',
+            'testdroid_device': device,
+            'testdroid_app': app,
+            'platformName': 'Android',
+            'deviceName': 'Android Phone',
+            'aut': 'org.getlantern.lantern'
+        }
+
+        apiLevel = DeviceFinder().device_API_level(device)
+        if apiLevel > 16:
+            self.desired_caps['testdroid_target'] = 'Android'
+        else:
+            self.desired_caps['testdroid_target'] = 'Selendroid'
+
+        self.hub_url = appium_url
+        self.device_name = device
+        TestLantern.setUp(self)
+
+
+def available_free_android_device():
+    ret = []
+    # Loop will not exit until free device is found
+    deviceFinder = DeviceFinder()
+    while True:
+        d = deviceFinder.available_free_android_device()
+        if d is not None:
+            ret.append(d)
+            return ret
+
+
+def executeTests(api_key, app, group_id=None):
+    devices = []
+    if group_id is None:
+        devices = available_free_android_device()
+    else:
+        devices = DeviceFinder(apiKey=api_key).devices_by_group(group_id)
+
+    suite = unittest.TestSuite()
+    map(lambda d: suite.addTest(
+        ParametrizedTestCase.parametrize(
+            TestdroidAndroid, param={
+                'api_key': api_key,
+                'device': d,
+                'app': app}
+        )),
+        devices)
+    unittest.TextTestRunner(verbosity=2).run(suite)

--- a/src/github.com/getlantern/lantern-mobile/test/lib/upload.py
+++ b/src/github.com/getlantern/lantern-mobile/test/lib/upload.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+
+import requests
+import os
+import sys
+
+upload_url = 'http://appium.testdroid.com/upload'
+myfile = '../app/build/outputs/apk/lantern-debug.apk'
+
+
+def upload(api_key):
+    print "Uploading %s to %s" % (myfile, upload_url)
+    files = {'file': (os.path.basename(myfile),
+                      open(myfile, 'rb'),
+                      'application/octet-stream')}
+    r = requests.post(upload_url,
+                      files=files,
+                      headers={'Accept': 'application/json'},
+                      auth=(api_key, ''))
+    if "successful" in r.json()['value']['message']:
+        apk_path = r.json()['value']['uploads']['file']
+        print "Filename to use in testdroid capabilities in test: {}".format(apk_path)
+        return apk_path
+    else:
+        print "Upload response: \n{}".format(r.json())
+        sys.exit(-1)

--- a/src/github.com/getlantern/lantern-mobile/test/requirements.txt
+++ b/src/github.com/getlantern/lantern-mobile/test/requirements.txt
@@ -1,0 +1,4 @@
+Appium-Python-Client==0.21
+requests==2.9.1
+selenium==2.52.0
+wsgiref==0.1.2

--- a/src/github.com/getlantern/lantern-mobile/test/selendroid.sh
+++ b/src/github.com/getlantern/lantern-mobile/test/selendroid.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env sh
+
+SELENDROID_VERSION=0.17.0
+SELENDROID_JAR=selendroid-standalone-${SELENDROID_VERSION}-with-dependencies.jar
+APP_PATH=../app/build/outputs/apk/lantern-debug.apk
+
+mkdir -p tmp
+
+if [ ! -f tmp/${SELENDROID_JAR} ]; then
+  URL=https://github.com/selendroid/selendroid/releases/download/${SELENDROID_VERSION}/${SELENDROID_JAR}
+  echo Downloading ${URL}
+  curl -L ${URL} > tmp/${SELENDROID_JAR}
+  if [ $? -ne 0 ]; then
+    exit 1
+  fi
+fi
+
+cp ${APP_PATH} tmp/aut.apk
+if [ $? -ne 0 ]; then
+  exit 1
+fi
+
+java -jar tmp/${SELENDROID_JAR} -app tmp/aut.apk

--- a/src/github.com/getlantern/lantern-mobile/test/start_test.py
+++ b/src/github.com/getlantern/lantern-mobile/test/start_test.py
@@ -17,7 +17,9 @@ if __name__ == '__main__':
     parser.add_argument('--no-upload', action='store_true',
                         help='Not upload APK to testdroid before run test (uses the latest one)')
     parser.add_argument('--group', type=int,
-                        help='The device group to run tests on. If not supplied, will pick whichever free device')
+                        help='The device group to run tests on. If neither group nor device supplied, will pick whichever free device')
+    parser.add_argument('--device', type=str,
+                        help='The specific device to run tests on. If neither group nor device supplied, will pick whichever free device')
 
     args = parser.parse_args()
     if args.local:
@@ -31,4 +33,7 @@ if __name__ == '__main__':
         if args.no_upload is not True:
             testdroid_app = upload(testdroid_api_key)
 
-        testdroid_android.executeTests(testdroid_api_key, testdroid_app, args.group)
+        testdroid_android.executeTests(testdroid_api_key,
+                                       testdroid_app,
+                                       args.group,
+                                       args.device)

--- a/src/github.com/getlantern/lantern-mobile/test/start_test.py
+++ b/src/github.com/getlantern/lantern-mobile/test/start_test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import sys
+sys.path.append('./lib')
+
+import os
+import argparse
+from upload import upload
+import local_android
+import testdroid_android
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Testdroid test script')
+    parser.add_argument('--local', action='store_true',
+                        help='Test from local emulator/device')
+    parser.add_argument('--no-upload', action='store_true',
+                        help='Not upload APK to testdroid before run test (uses the latest one)')
+    parser.add_argument('--group', type=int,
+                        help='The device group to run tests on. If not supplied, will pick whichever free device')
+
+    args = parser.parse_args()
+    if args.local:
+        local_android.test()
+    else:
+        testdroid_api_key = os.environ.get('TESTDROID_APIKEY')
+        if testdroid_api_key is None:
+            print "TESTDROID_APIKEY environment variable is not set!"
+            sys.exit(1)
+        testdroid_app = "latest"
+        if args.no_upload is not True:
+            testdroid_app = upload(testdroid_api_key)
+
+        testdroid_android.executeTests(testdroid_api_key, testdroid_app, args.group)


### PR DESCRIPTION
Added python scripts to run blackbox test. Currently only the "Quit" menu is tested. The value of `TESTDROID_APIKEY` is in `too-many-secrets/testdroid.com`.

@atavism You probably will find this useful.

Resolves https://github.com/getlantern/lantern/issues/3769