### PR TITLE
idletiming correctly set deadline fix #3866

### DIFF
--- a/src/github.com/getlantern/idletiming/idletiming_conn.go
+++ b/src/github.com/getlantern/idletiming/idletiming_conn.go
@@ -202,11 +202,19 @@ func (c *IdleTimingConn) SetDeadline(t time.Time) error {
 }
 
 func (c *IdleTimingConn) SetReadDeadline(t time.Time) error {
+	// zero value means no time out
+	if t.IsZero() {
+		t = epoch
+	}
 	atomic.StoreInt64(&c.readDeadline, t.UnixNano())
 	return nil
 }
 
 func (c *IdleTimingConn) SetWriteDeadline(t time.Time) error {
+	// zero value means no time out
+	if t.IsZero() {
+		t = epoch
+	}
 	atomic.StoreInt64(&c.writeDeadline, t.UnixNano())
 	return nil
 }


### PR DESCRIPTION
In https://golang.org/pkg/net/#Conn
> // A zero value for t means I/O operations will not time out.