### PR TITLE
Configuring proxiedsites in main instead of flashlight, removes ui as dependency for mobile

### DIFF
--- a/src/github.com/getlantern/flashlight/flashlight.go
+++ b/src/github.com/getlantern/flashlight/flashlight.go
@@ -11,7 +11,6 @@ import (
 	"github.com/getlantern/flashlight/config"
 	"github.com/getlantern/flashlight/geolookup"
 	"github.com/getlantern/flashlight/logging"
-	"github.com/getlantern/flashlight/proxiedsites"
 )
 
 const (
@@ -146,7 +145,6 @@ func applyClientConfig(client *client.Client, cfg *config.Config, proxyAll func(
 		Version, RevisionDate)
 	// Update client configuration
 	client.Configure(cfg.Client, proxyAll)
-	proxiedsites.Configure(cfg.ProxiedSites)
 }
 
 func displayVersion() {

--- a/src/github.com/getlantern/flashlight/main/main.go
+++ b/src/github.com/getlantern/flashlight/main/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/getlantern/golog"
 	"github.com/getlantern/i18n"
 	"github.com/getlantern/profiling"
+	"github.com/getlantern/proxiedsites"
 
 	"github.com/getlantern/flashlight/analytics"
 	"github.com/getlantern/flashlight/autoupdate"
@@ -263,6 +264,7 @@ func afterStart(cfg *config.Config) {
 }
 
 func onConfigUpdate(cfg *config.Config) {
+	proxiedsites.Configure(cfg.ProxiedSites)
 	autoupdate.Configure(cfg)
 }
 


### PR DESCRIPTION
This gets rid of the transitive mobile -> proxied sites -> ui dependency.

@myleshorton This undoes what you did here - https://github.com/getlantern/lantern/commit/e73ca0dd1bbe2f5f376c111a9a5cdb0ec7b96f73#diff-f51f873318b593f0a492e1abb11a57c2R149  What was the reason for that initial change?  Will it cause any problems to go back to just configuring proxiedsites in main?