### PR TITLE
Clear shared preferences when Lantern is first run

### DIFF
--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
@@ -61,6 +61,10 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
         mPrefs = Utils.getSharedPrefs(context);
 
         LanternUI = new UI(this, mPrefs);
+        // since onCreate is only called when the main activity
+        // is first created, we clear shared preferences in case
+        // Lantern was forcibly stopped during a previous run
+        LanternUI.clearPreferences();
 
         // the ACTION_SHUTDOWN intent is broadcast when the phone is
         // about to be shutdown. We register a receiver to make sure we

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
@@ -64,7 +64,9 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
         // since onCreate is only called when the main activity
         // is first created, we clear shared preferences in case
         // Lantern was forcibly stopped during a previous run
-        LanternUI.clearPreferences();
+        if (!Service.isRunning(context)) {
+            LanternUI.clearPreferences();
+        }
 
         // the ACTION_SHUTDOWN intent is broadcast when the phone is
         // about to be shutdown. We register a receiver to make sure we
@@ -141,7 +143,6 @@ public class LanternMainActivity extends AppCompatActivity implements Handler.Ca
             if (mReceiver != null) {
                 unregisterReceiver(mReceiver);
             }
-            stopLantern();
         } catch (Exception e) {
 
         }

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/model/UI.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/model/UI.java
@@ -396,6 +396,10 @@ public class UI {
         return mPrefs.getBoolean(LanternConfig.PREF_USE_VPN, false);
     }
 
+    public void clearPreferences() {
+        mPrefs.edit().putBoolean(LanternConfig.PREF_USE_VPN, false).commit();
+    }
+
     // update START/STOP power Lantern button
     // according to our stored preference
     public void setBtnStatus() {

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/vpn/Service.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/vpn/Service.java
@@ -6,6 +6,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
+import org.getlantern.lantern.sdk.Utils;
+
 import go.lantern.Lantern;
 
 public class Service extends VpnBuilder implements Runnable {
@@ -81,6 +83,7 @@ public class Service extends VpnBuilder implements Runnable {
         try {
             super.close();
             Log.d(TAG, "Closing VPN interface..");
+            Utils.clearPreferences(this);
         } catch (Exception e) {
         }
 

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/vpn/Service.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/vpn/Service.java
@@ -1,5 +1,8 @@
 package org.getlantern.lantern.vpn;
 
+import android.app.ActivityManager;
+import android.app.ActivityManager.RunningServiceInfo;
+import android.content.Context;
 import android.content.Intent;
 import android.util.Log;
 
@@ -25,6 +28,18 @@ public class Service extends VpnBuilder implements Runnable {
     public int onStartCommand(Intent intent, int flags, int startId) {
         IsRunning = true;
         return super.onStartCommand(intent, flags, startId);
+    }
+
+    // isRunning checks to see if the VPN service is already running
+    // in the background.
+    public static boolean isRunning(Context c) {
+        ActivityManager manager = (ActivityManager)c.getSystemService(Context.ACTIVITY_SERVICE);
+        for (RunningServiceInfo service : manager.getRunningServices(Integer.MAX_VALUE)) {
+            if (Service.class.getName().equals(service.service.getClassName())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override


### PR DESCRIPTION
This resolves #3708 and https://github.com/getlantern/lantern/issues/3711 ... re-opening since I accidentally merged this in already.

A few test cases: 

- Leave Lantern running, forcibly stop the app from the Application Manager, and verify the button is turned OFF when the app is re-opened. 
- Leave Lantern turned ON, close the app normally, and verify Lantern stays running in the background.