### PR TITLE
show scroll bar only on hover

### DIFF
--- a/src/github.com/getlantern/lantern-ui/app/_css/news.css
+++ b/src/github.com/getlantern/lantern-ui/app/_css/news.css
@@ -44,8 +44,11 @@
   border: 1px solid black;
   margin: 0 auto;
   height: 800px;
+  overflow: hidden;
+}
+
+#news .feeds-container:hover {
   overflow-y: scroll;
-  overflow-x: hidden;
 }
 
 @media (min-width: 780px){


### PR DESCRIPTION
@myleshorton It looks better by not show scroll bar by default. On IE/Edge/Firefox the content will reflow when scroll bar is shown. That doesn't affect user experience too much I think.