### PR TITLE
fix #4019

### DIFF
--- a/src/github.com/getlantern/lantern-ui/app/_css/news.css
+++ b/src/github.com/getlantern/lantern-ui/app/_css/news.css
@@ -174,11 +174,13 @@
 
 #news p.feed-date {
   padding-top: 13px;
+  font-size: 10px;
 }
 
 #news h4 {
   font-weight: 700;
-  line-height: 18px;
+  font-size: 14px;
+  line-height: 16px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
@myleshorton It makes feed title smaller to have room for the characters, without overflow. It's size in the original design, I just didn't correctly implement it.