### PR TITLE
Issue 4040

### DIFF
--- a/src/github.com/getlantern/lantern-mobile/app/src/main/res/layout/activity_lantern_main.xml
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/res/layout/activity_lantern_main.xml
@@ -32,14 +32,14 @@
         android:id="@+id/mainView"
         android:gravity="center"
         tools:context=".LanternMainActivity">
+
         <ToggleButton
             android:id="@+id/powerLantern"
             android:layout_height="wrap_content"
             android:layout_width="wrap_content"   
             android:background="@drawable/toggle_switch"
+            android:layout_centerHorizontal="true"
             android:layout_marginTop="20dp"
-            android:layout_marginLeft="105dp"
-            android:layout_gravity="center"
             android:checked="false"
             android:text="ToggleButton"
             android:textOff=""


### PR DESCRIPTION
To resolve https://github.com/getlantern/lantern/issues/4040, a quick fix to center the on/off toggle button inside the parent layout using the ``layout_centerHorizontal`` attribute instead of w/ any left padding.