### PR TITLE
Use content when meta description unavailable

### DIFF
--- a/src/github.com/getlantern/lantern-mobile/app/src/main/res/layout/feed_item.xml
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/res/layout/feed_item.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:autofit="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="120dip"
     android:maxHeight="120dip"
@@ -53,6 +54,7 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:fontFamily="sans-serif"
+            android:maxLines="4"
             android:textColor="#000000"
             android:textSize="10sp"
             android:layout_below="@id/title"  />

--- a/src/github.com/getlantern/lantern-mobile/app/src/main/res/layout/feed_item.xml
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/res/layout/feed_item.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:autofit="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="120dip"
     android:maxHeight="120dip"

--- a/src/github.com/getlantern/lantern/feed.go
+++ b/src/github.com/getlantern/lantern/feed.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"math"
 	"net/http"
 	"strings"
 
@@ -54,6 +53,7 @@ type FeedItem struct {
 	Link        string                 `json:"link"`
 	Image       string                 `json:"image"`
 	Meta        map[string]interface{} `json:"meta,omitempty"`
+	Content     string                 `json:"contentText"`
 	Description string                 `json:"-"`
 }
 
@@ -186,8 +186,12 @@ func processFeed(provider FeedProvider) {
 		if aDesc := entry.Meta["description"]; aDesc != nil {
 			desc = strings.TrimSpace(aDesc.(string))
 		}
-		min := int(math.Min(float64(len(desc)), 150))
-		feed.Entries[i].Description = desc[:min]
+
+		if desc == "" {
+			desc = entry.Content
+		}
+
+		feed.Entries[i].Description = desc
 	}
 
 	for _, s := range feed.Feeds {


### PR DESCRIPTION
Whenever an article is missing a meta description tag, use the content entry instead. This also fixes https://github.com/getlantern/lantern/issues/4049