### PR TITLE
Update build tools revision and Readme (Android)

### DIFF
--- a/MobileSDK/sdk/build.gradle
+++ b/MobileSDK/sdk/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 15

--- a/PubSub/sdk/build.gradle
+++ b/PubSub/sdk/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'android-library'
 
 android {
     compileSdkVersion 23
-    buildToolsVersion "23.0.2"
+    buildToolsVersion "23.0.3"
 
     defaultConfig {
         minSdkVersion 15

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Building the mobile library and app requires the following:
 1. Install Java JDK 7 or 8
 2. Install Go 1.6 or higher
 3. Install [Android SDK Tools](http://developer.android.com/sdk/index.html#Other)
-4. Install NDK(http://developer.android.com/ndk/downloads/index.html)
+4. Install [NDK](http://developer.android.com/ndk/downloads/index.html)
+5. Install [Gradle](http://gradle.org/)
 
 Make sure to set these environment variables before trying to build any Android
 components (replace the paths based on wherever you've installed the Android

--- a/src/github.com/getlantern/lantern-mobile/build.gradle
+++ b/src/github.com/getlantern/lantern-mobile/build.gradle
@@ -22,7 +22,7 @@ ext {
     compileSdkVersion = 23
     targetSdkVersion = 23
     minSdkVersion = 15
-    buildToolsVersion = '23.0.2'
+    buildToolsVersion = '23.0.3'
     buildNumber = 'dev'
 
     lanternDir = projectDir.parentFile.parentFile


### PR DESCRIPTION
In order to be able to compile Lantern for Android, I had to specify the build tools revision to the latest.

Unfortunately I couldn't find a method to wildcard the build tools revision so it doesn't need to be updated manually. I also cannot find revision 2, so I had no other option than to update. In case you had it working already, this steps for updating the revision might be of reference.



`android list sdk -a`

Shows a list:

1- Android SDK Tools, revision 24.0.2
2- Android SDK Platform-tools, revision 21
3- Android SDK Build-tools, revision 21.1.2
...
Select using ID for build-tools 23.0.3

`android update sdk -a -u -t 3`