### PR TITLE
hide error page when showing mobile ad fix #4108

### DIFF
--- a/src/github.com/getlantern/lantern-ui/app/partials/error.html
+++ b/src/github.com/getlantern/lantern-ui/app/partials/error.html
@@ -1,4 +1,4 @@
-<div id="error" ng-controller="ErrorCtrl" ng-show="showError">
+<div id="error" ng-controller="ErrorCtrl" ng-show="showError && !showMobileAd">
   <div id="oops">
     {{ 'ERROR_OOPS' | translate }}
   </div>


### PR DESCRIPTION
@myleshorton Simple change to fix https://github.com/getlantern/lantern/issues/4108
