### PR TITLE
Issue 4109

### DIFF
--- a/src/github.com/getlantern/flashlight/feed/feed.go
+++ b/src/github.com/getlantern/flashlight/feed/feed.go
@@ -60,7 +60,7 @@ type FeedItem struct {
 	Link        string                 `json:"link"`
 	Image       string                 `json:"image"`
 	Meta        map[string]interface{} `json:"meta,omitempty"`
-	Content     string                 `json:"contentText"`
+	Content     string                 `json:"contentSnippetText"`
 	Source      string                 `json:"source"`
 	Description string                 `json:"-"`
 }

--- a/src/github.com/getlantern/flashlight/feed/feed.go
+++ b/src/github.com/getlantern/flashlight/feed/feed.go
@@ -56,14 +56,13 @@ type Source struct {
 }
 
 type FeedItem struct {
-	Title string                 `json:"title"`
-	Link  string                 `json:"link"`
-	Image string                 `json:"image"`
-	Meta  map[string]interface{} `json:"meta,omitempty"`
-
-	Content     string `json:"contentSnippetText"`
-	Source      string `json:"source"`
-	Description string `json:"-"`
+	Title       string                 `json:"title"`
+	Link        string                 `json:"link"`
+	Image       string                 `json:"image"`
+	Meta        map[string]interface{} `json:"meta,omitempty"`
+	Content     string                 `json:"contentSnippetText"`
+	Source      string                 `json:"source"`
+	Description string                 `json:"-"`
 }
 
 type FeedItems []*FeedItem

--- a/src/github.com/getlantern/flashlight/feed/feed.go
+++ b/src/github.com/getlantern/flashlight/feed/feed.go
@@ -56,13 +56,14 @@ type Source struct {
 }
 
 type FeedItem struct {
-	Title       string                 `json:"title"`
-	Link        string                 `json:"link"`
-	Image       string                 `json:"image"`
-	Meta        map[string]interface{} `json:"meta,omitempty"`
-	Content     string                 `json:"contentSnippetText"`
-	Source      string                 `json:"source"`
-	Description string                 `json:"-"`
+	Title string                 `json:"title"`
+	Link  string                 `json:"link"`
+	Image string                 `json:"image"`
+	Meta  map[string]interface{} `json:"meta,omitempty"`
+
+	Content     string `json:"contentSnippetText"`
+	Source      string `json:"source"`
+	Description string `json:"-"`
 }
 
 type FeedItems []*FeedItem


### PR DESCRIPTION
This fixes a tiny discrepancy between desktop and mobile. Whenever an article meta description is missing, we use ``contentSnippetText`` instead of ``contentText`` now. The former field is the one updated by the feed server already to provide article descriptions for sites like Reddit.