### PR TITLE
close response body when bad status code fix #3987

### DIFF
--- a/src/github.com/getlantern/flashlight/client/handler.go
+++ b/src/github.com/getlantern/flashlight/client/handler.go
@@ -149,10 +149,11 @@ func pipeData(clientConn net.Conn, connOut net.Conn, closeFunc func()) {
 		closeFunc()
 	}()
 
-	// Then start coyping from proxy to client.
+	// Then start copying from proxy to client.
 	if _, err := io.Copy(clientConn, connOut); err != nil {
 		log.Tracef("Error piping data from proxy to client: %s", err)
 	}
+	closeFunc()
 }
 
 func respondOK(writer io.Writer, req *http.Request) error {

--- a/src/github.com/getlantern/flashlight/logging/useragents.go
+++ b/src/github.com/getlantern/flashlight/logging/useragents.go
@@ -17,8 +17,8 @@ var (
 // AddUserAgentListener registers a listener for user agents.
 func AddUserAgentListener(listener func(string)) {
 	agentsMutex.Lock()
-	listeners = append(listeners, listener)
 	defer agentsMutex.Unlock()
+	listeners = append(listeners, listener)
 }
 
 // RegisterUserAgent tries to find the User-Agent in the HTTP request

--- a/src/github.com/getlantern/flashlight/util/http.go
+++ b/src/github.com/getlantern/flashlight/util/http.go
@@ -180,9 +180,9 @@ func readResponses(finalResponse chan *http.Response, responses chan *http.Respo
 
 			// Just ignore the second response, but still process it.
 			select {
-			case resp := <-responses:
+			case response := <-responses:
 				log.Debug("Closing second response body")
-				_ = resp.Body.Close()
+				_ = response.Body.Close()
 				return
 			case <-errs:
 				log.Debug("Ignoring error on second response")
@@ -203,8 +203,8 @@ func readResponses(finalResponse chan *http.Response, responses chan *http.Respo
 		log.Debugf("Got an error: %v", err)
 		// Just use whatever we get from the second response.
 		select {
-		case resp := <-responses:
-			finalResponse <- resp
+		case response := <-responses:
+			finalResponse <- response
 		case err := <-errs:
 			finalErr <- err
 		}


### PR DESCRIPTION
@myleshorton It should be worth to add to 2.2.0. With this patch, no any `CLOSE` or `CLOSE_WAIT` seen after running for 10min, while previously, at least 2 will be seen in a few seconds.