### PR TITLE
Adds a parameter to prevent the PAC URL from being cached by Windows

### DIFF
--- a/src/github.com/getlantern/flashlight/app/pac.go
+++ b/src/github.com/getlantern/flashlight/app/pac.go
@@ -33,7 +33,29 @@ func servePACFile() {
 	defer cfgMutex.Unlock()
 	if pacURL == "" {
 		pacURL = ui.Handle("/proxy_on.pac", http.HandlerFunc(pacFileHandler))
-		// Trying to bypass Windows' PAC file cache.
+
+		// This is a workaround for Windows 10 and Edge.
+		//
+		// Lantern changes the system's proxy settings a sets an URL like:
+		//
+		//   http://127.0.0.1:16823/proxy_on.pac
+		//
+		// This URL is verified by Windows, and if it works then the system sets it
+		// as system proxy.
+		//
+		// The problem here was that, after rebooting, this URL was checked before
+		// Lantern started, so it failed and was marked as invalid by the OS.
+		//
+		// After Lantern finally started and called pacOn() the URL was not being
+		// verified again, because it was the same URL the system tried to reach a
+		// few seconds before.
+		//
+		// Some browsers like Chrome or Firefox use the URL later in the game
+		// anyway when Lantern is running, but some others like Edge do not even
+		// try.
+		//
+		// By changing the URL here we are forcing the OS to check the URL whenever
+		// Lantern starts.
 		pacURL = pacURL + fmt.Sprintf("?%d", time.Now().UnixNano())
 	}
 }

--- a/src/github.com/getlantern/flashlight/app/pac.go
+++ b/src/github.com/getlantern/flashlight/app/pac.go
@@ -33,6 +33,8 @@ func servePACFile() {
 	defer cfgMutex.Unlock()
 	if pacURL == "" {
 		pacURL = ui.Handle("/proxy_on.pac", http.HandlerFunc(pacFileHandler))
+		// Trying to bypass Windows' PAC file cache.
+		pacURL = fmt.Sprintf("%s?_t=%d", pacURL, time.Now().UnixNano)
 	}
 }
 
@@ -71,6 +73,8 @@ func setUpPacTool() error {
 }
 
 func genPACFile(w io.Writer) (int, error) {
+	// TODO: we don't need to generate this thing everytime.
+
 	hostsString := "[]"
 	// only bypass sites if proxy all option is unset
 	if !settings.GetProxyAll() {

--- a/src/github.com/getlantern/flashlight/app/pac.go
+++ b/src/github.com/getlantern/flashlight/app/pac.go
@@ -34,7 +34,7 @@ func servePACFile() {
 	if pacURL == "" {
 		pacURL = ui.Handle("/proxy_on.pac", http.HandlerFunc(pacFileHandler))
 		// Trying to bypass Windows' PAC file cache.
-		pacURL = fmt.Sprintf("%s?_t=%d", pacURL, time.Now().UnixNano)
+		pacURL = pacURL + fmt.Sprintf("?%d", time.Now().UnixNano())
 	}
 }
 


### PR DESCRIPTION
Should fixes a number of issues, specially this one

* https://github.com/getlantern/lantern/issues/4175

And others that claimed that Lantern was not working after reboot or not working on Edge. 