### PR TITLE
Add back code for disabling ON/OFF switch temporarily

### DIFF
--- a/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
+++ b/src/github.com/getlantern/lantern-mobile/app/src/main/java/org/getlantern/lantern/activity/LanternMainActivity.java
@@ -18,6 +18,7 @@ import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.TransitionDrawable;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.StrictMode;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
@@ -496,6 +497,10 @@ Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
             return;
         }
 
+        // disable the on/off switch while the VpnService
+        // is updating the connection
+        powerLantern.setEnabled(false);
+
         if (on) {
             // Prompt the user to enable full-device VPN mode
             // Make a VPN connection from the client
@@ -520,6 +525,14 @@ Application.ActivityLifecycleCallbacks, ComponentCallbacks2 {
             Service.IsRunning = false;
             updateStatus(false);
         }
+
+        // after 2000ms, enable the switch again
+        new Handler().postDelayed(new Runnable() {
+            @Override
+            public void run() {
+                powerLantern.setEnabled(true);
+            }
+        }, 2000);
     }
 
     // override onKeyDown and onBackPressed default 


### PR DESCRIPTION
This resolves https://github.com/getlantern/lantern/issues/4226 -- to prevent the on/off switch from being toggled continuously, we disable the switch temporarily while the VpnService updates the connection.