### PR TITLE
Changing no-cache argument everytime we set the PAC URL.

### DIFF
--- a/src/github.com/getlantern/flashlight/main/pac.go
+++ b/src/github.com/getlantern/flashlight/main/pac.go
@@ -21,11 +21,11 @@ import (
 )
 
 var (
-	isPacOn     = int32(0)
-	pacURL      string
+	isPacOn       = int32(0)
+	pacURL        string
 	pacURLNoCache string
-	directHosts = make(map[string]bool)
-	cfgMutex    sync.RWMutex
+	directHosts   = make(map[string]bool)
+	cfgMutex      sync.RWMutex
 )
 
 func ServePACFile() {

--- a/src/github.com/getlantern/flashlight/main/pac.go
+++ b/src/github.com/getlantern/flashlight/main/pac.go
@@ -23,6 +23,7 @@ import (
 var (
 	isPacOn     = int32(0)
 	pacURL      string
+	pacURLNoCache string
 	directHosts = make(map[string]bool)
 	cfgMutex    sync.RWMutex
 )
@@ -32,31 +33,6 @@ func ServePACFile() {
 	defer cfgMutex.Unlock()
 	if pacURL == "" {
 		pacURL = ui.Handle("/proxy_on.pac", http.HandlerFunc(servePACFile))
-
-		// Trying to bypass Windows' PAC file cache.
-		// This is a workaround for Windows 10 and Edge.
-		//
-		// Lantern changes the system's proxy settings a sets an URL like:
-		//
-		//   http://127.0.0.1:16823/proxy_on.pac
-		//
-		// This URL is verified by Windows, and if it works then the system sets it
-		// as system proxy.
-		//
-		// The problem here was that, after rebooting, this URL was checked before
-		// Lantern started, so it failed and was marked as invalid by the OS.
-		//
-		// After Lantern finally started and called pacOn() the URL was not being
-		// verified again, because it was the same URL the system tried to reach a
-		// few seconds before.
-		//
-		// Some browsers like Chrome or Firefox use the URL later in the game
-		// anyway when Lantern is running, but some others like Edge do not even
-		// try.
-		//
-		// By changing the URL here we are forcing the OS to check the URL whenever
-		// Lantern starts.
-		pacURL = pacURL + fmt.Sprintf("?%d", time.Now().UnixNano())
 	}
 }
 
@@ -199,14 +175,39 @@ func cyclePAC() {
 }
 
 func doPACOn(pacURL string) {
-	err := pac.On(pacURL)
+	// Trying to bypass Windows' PAC file cache.
+	// This is a workaround for Windows 10 and Edge.
+	//
+	// Lantern changes the system's proxy settings a sets an URL like:
+	//
+	//   http://127.0.0.1:16823/proxy_on.pac
+	//
+	// This URL is verified by Windows, and if it works then the system sets it
+	// as system proxy.
+	//
+	// The problem here was that, after rebooting, this URL was checked before
+	// Lantern started, so it failed and was marked as invalid by the OS.
+	//
+	// After Lantern finally started and called pacOn() the URL was not being
+	// verified again, because it was the same URL the system tried to reach a
+	// few seconds before.
+	//
+	// Some browsers like Chrome or Firefox use the URL later in the game
+	// anyway when Lantern is running, but some others like Edge do not even
+	// try.
+	//
+	// By changing the URL here we are forcing the OS to check the URL whenever
+	// Lantern starts.
+	pacURLNoCache = fmt.Sprintf("?%d", time.Now().UnixNano())
+
+	err := pac.On(pacURL + pacURLNoCache)
 	if err != nil {
 		log.Errorf("Unable to set lantern as system proxy: %v", err)
 	}
 }
 
 func doPACOff(pacURL string) {
-	err := pac.Off(pacURL)
+	err := pac.Off(pacURL + pacURLNoCache)
 	if err != nil {
 		log.Errorf("Unable to unset lantern as system proxy: %v", err)
 	}


### PR DESCRIPTION
Hey @myleshorton, this implements your suggestion of changing the pac URL everytime it is set, this effectively forces a reset, even on Windows. It looks like problems with Xunlei get somewhat _fixed_ after  resetting the pac file, users may trigger a reset by themselves with checking/unchecking the proxy all feature. On my experience, though, I had no problems with Xunlei 7.9 and latest QA version, only with [Xunlei 5 + IE](https://support.microsoft.com/en-us/kb/2520403) and current public beta.