### PR TITLE
not serving proxied sites to ui

### DIFF
--- a/src/github.com/getlantern/flashlight/proxiedsites/proxiedsites.go
+++ b/src/github.com/getlantern/flashlight/proxiedsites/proxiedsites.go
@@ -1,26 +1,16 @@
 package proxiedsites
 
 import (
-	"encoding/json"
-	"fmt"
 	"sync"
 
 	"github.com/getlantern/detour"
 	"github.com/getlantern/golog"
 	"github.com/getlantern/proxiedsites"
-
-	"github.com/getlantern/flashlight/config"
-	"github.com/getlantern/flashlight/ui"
-)
-
-const (
-	messageType = `proxiedSites`
 )
 
 var (
 	log = golog.LoggerFor("flashlight.proxiedsites")
 
-	service    *ui.Service
 	PACURL     string
 	startMutex sync.Mutex
 )
@@ -34,26 +24,6 @@ func Configure(cfg *proxiedsites.Config) {
 	if delta != nil {
 		updateDetour(delta)
 	}
-	if service == nil {
-		// Initializing service.
-		if err := start(); err != nil {
-			log.Errorf("Unable to register service: %q", err)
-		}
-	} else if delta != nil {
-		// Sending delta.
-		message := ui.Envelope{
-			EnvelopeType: ui.EnvelopeType{messageType},
-			Message:      delta,
-		}
-		b, err := json.Marshal(message)
-
-		if err != nil {
-			log.Errorf("Unable to publish delta to UI: %v", err)
-		} else {
-			service.Out <- b
-		}
-	}
-
 	startMutex.Unlock()
 }
 
@@ -73,38 +43,5 @@ func updateDetour(delta *proxiedsites.Delta) {
 	for _, v := range delta.Additions {
 		detour.AddToWl(v+":80", true)
 		detour.AddToWl(v+":443", true)
-	}
-}
-
-func start() (err error) {
-	newMessage := func() interface{} {
-		return &proxiedsites.Delta{}
-	}
-
-	// Registering a websocket service.
-	helloFn := func(write func(interface{}) error) error {
-		return write(proxiedsites.ActiveDelta())
-	}
-
-	if service, err = ui.Register(messageType, newMessage, helloFn); err != nil {
-		return fmt.Errorf("Unable to register channel: %q", err)
-	}
-
-	// Initializing reader.
-	go read()
-
-	return nil
-}
-
-func read() {
-	for msg := range service.In {
-		err := config.Update(func(updated *config.Config) error {
-			log.Debugf("Applying update from UI")
-			updated.ProxiedSites.Delta.Merge(msg.(*proxiedsites.Delta))
-			return nil
-		})
-		if err != nil {
-			log.Debugf("Error applying update from UI: %v", err)
-		}
 	}
 }


### PR DESCRIPTION
We no longer show or modify proxied sites in UI. Remove relevant code.

It may also helpful for https://github.com/getlantern/lantern/issues/4282. Though we don't exactly know the cause, but inspired by [this SO link](http://stackoverflow.com/questions/31265789/websocket-invalid-frame-header), a large WebSocket frame may trigger "Invalid frame header" error if browser/server has some bug handle it.

@xiam Mind have a look?