### PR TITLE
check dialers only once after idle

### DIFF
--- a/src/github.com/getlantern/balancer/balancer.go
+++ b/src/github.com/getlantern/balancer/balancer.go
@@ -32,7 +32,7 @@ type Balancer struct {
 	mu           sync.RWMutex
 	dialers      dialerHeap
 	trusted      dialerHeap
-	lastDialTime int64 // Time.Unix()
+	lastDialTime int64 // Time.UnixNano()
 }
 
 // New creates a new Balancer using the supplied Strategy and Dialers.
@@ -72,7 +72,7 @@ func (b *Balancer) OnRequest(req *http.Request) {
 // error.
 func (b *Balancer) Dial(network, addr string) (net.Conn, error) {
 	now := time.Now()
-	lastDialTime := time.Unix(atomic.SwapInt64(&b.lastDialTime, now.Unix()), 0)
+	lastDialTime := time.Unix(0, atomic.SwapInt64(&b.lastDialTime, now.UnixNano()))
 	idlePeriod := now.Sub(lastDialTime)
 	if idlePeriod > recheckAfterIdleFor {
 		log.Debugf("Balancer idle for %s, start checking all dialers", idlePeriod)

--- a/src/github.com/getlantern/balancer/balancer.go
+++ b/src/github.com/getlantern/balancer/balancer.go
@@ -32,7 +32,7 @@ type Balancer struct {
 	mu           sync.RWMutex
 	dialers      dialerHeap
 	trusted      dialerHeap
-	lastDialTime atomic.Value // time.Time
+	lastDialTime int64 // Time.Unix()
 }
 
 // New creates a new Balancer using the supplied Strategy and Dialers.
@@ -53,8 +53,6 @@ func New(st Strategy, dialers ...*Dialer) *Balancer {
 	bal := &Balancer{dialers: st(dls), trusted: st(tdls)}
 	heap.Init(&bal.dialers)
 	heap.Init(&bal.trusted)
-	// Force checking all dialers on first Dial()
-	bal.lastDialTime.Store(time.Time{})
 	return bal
 }
 
@@ -73,13 +71,13 @@ func (b *Balancer) OnRequest(req *http.Request) {
 // either manages to connect, or runs out of dialers in which case it returns an
 // error.
 func (b *Balancer) Dial(network, addr string) (net.Conn, error) {
-	lastDialTime := b.lastDialTime.Load().(time.Time)
-	idled := time.Since(lastDialTime)
-	if idled > recheckAfterIdleFor {
-		log.Debugf("Balancer idled for %s, start checking all dialers", idled)
+	now := time.Now()
+	lastDialTime := time.Unix(atomic.SwapInt64(&b.lastDialTime, now.Unix()), 0)
+	idlePeriod := now.Sub(lastDialTime)
+	if idlePeriod > recheckAfterIdleFor {
+		log.Debugf("Balancer idle for %s, start checking all dialers", idlePeriod)
 		b.checkDialers()
 	}
-	defer b.lastDialTime.Store(time.Now())
 	var dialers dialerHeap
 
 	_, port, _ := net.SplitHostPort(addr)


### PR DESCRIPTION
It uses `SwapInt64` to avoid `checkDialers` from running multiple times when `balancer.Dial` is called simultaneously.

@oxtoacart want to have a look again?