### PR TITLE
flashlight client call protect package only on Android

### DIFF
--- a/src/github.com/getlantern/flashlight/client/client.go
+++ b/src/github.com/getlantern/flashlight/client/client.go
@@ -15,7 +15,6 @@ import (
 	"github.com/getlantern/detour"
 	"github.com/getlantern/eventual"
 	"github.com/getlantern/golog"
-	"github.com/getlantern/protected"
 )
 
 const (
@@ -234,7 +233,7 @@ func (client *Client) dialCONNECT(addr string, port int) (net.Conn, error) {
 		return d("tcp", addr)
 	}
 	log.Tracef("Port not allowed, bypassing proxy and sending CONNECT request directly to %v", addr)
-	return protected.Dial("tcp", addr, 1*time.Minute)
+	return dialDirect("tcp", addr, 1*time.Minute)
 }
 
 func (client *Client) shouldSendToProxy(port int) bool {

--- a/src/github.com/getlantern/flashlight/client/dial_direct.go
+++ b/src/github.com/getlantern/flashlight/client/dial_direct.go
@@ -1,0 +1,12 @@
+// +build !android
+
+package client
+
+import (
+	"net"
+	"time"
+)
+
+func dialDirect(network, addr string, timeout time.Duration) (net.Conn, error) {
+	return net.DialTimeout(network, addr, timeout)
+}

--- a/src/github.com/getlantern/flashlight/client/dial_direct_android.go
+++ b/src/github.com/getlantern/flashlight/client/dial_direct_android.go
@@ -1,0 +1,13 @@
+package client
+
+import (
+	"net"
+	"time"
+
+	"github.com/getlantern/protected"
+)
+
+// Bypass VPN on Android
+func DialDirect(network, addr string, timeout time.Duration) (net.Conn, error) {
+	return protected.Dial(network, addr, timeout)
+}

--- a/src/github.com/getlantern/protected/protected.go
+++ b/src/github.com/getlantern/protected/protected.go
@@ -132,11 +132,6 @@ func Resolve(addr string) (*net.TCPAddr, error) {
 //   specified system device (this is primarily
 //   used for Android VpnService routing functionality)
 func Dial(network, addr string, timeout time.Duration) (net.Conn, error) {
-	protect, _ := getCurrent()
-	if protect == nil {
-		return net.DialTimeout(network, addr, timeout)
-	}
-
 	host, port, err := SplitHostPort(addr)
 	if err != nil {
 		return nil, err
@@ -164,6 +159,7 @@ func Dial(network, addr string, timeout time.Duration) (net.Conn, error) {
 	defer conn.cleanup()
 
 	// Actually protect the underlying socket here
+	protect, _ := getCurrent()
 	err = protect(conn.socketFd)
 	if err != nil {
 		return nil, fmt.Errorf("Could not bind socket to system device: %v", err)


### PR DESCRIPTION
@oxtoacart It's an attempt to avoid the SOCKS5 change from failing on Windows.