### PR TITLE
Dynamic bandwidth tracking

### DIFF
--- a/lantern-ui/app/js/services.js
+++ b/lantern-ui/app/js/services.js
@@ -90,6 +90,9 @@ angular.module('app.services', [])
           window.location = settings.redirectTo;
         }
       },
+      'bandwidth': function(bandwidth) {
+        console.log('Got bandwidth data: ', bandwidth);
+      },
       'localDiscovery': function(data) {
         model.localLanterns = data;
       },

--- a/src/github.com/getlantern/bandwidth/bandwidth.go
+++ b/src/github.com/getlantern/bandwidth/bandwidth.go
@@ -36,7 +36,13 @@ func GetQuota() *Quota {
 }
 
 // Track updates the bandwith quota information based on the XBQ header in
-// the given response.
+// the given response. The header is expected to follow this format:
+//
+// <used>/<allowed>/<asof>
+//
+// <used> is the string representation of a 64-bit unsigned integer
+// <allowed> is the string representation of a 64-bit unsigned integer
+// <asof> is the 64-bit signed integer representing nanoseconds since epoch
 func Track(resp *http.Response) {
 	xbq := resp.Header.Get("XBQ")
 	if xbq == "" {

--- a/src/github.com/getlantern/bandwidth/bandwidth.go
+++ b/src/github.com/getlantern/bandwidth/bandwidth.go
@@ -17,7 +17,7 @@ var (
 	mutex sync.RWMutex
 
 	// Updates is a channel on which one can receive updates to the Quota
-	Updates = make(chan *Quota)
+	Updates = make(chan *Quota, 100)
 )
 
 // Quota encapsulates information about the user's bandwidth quota.

--- a/src/github.com/getlantern/bandwidth/bandwidth.go
+++ b/src/github.com/getlantern/bandwidth/bandwidth.go
@@ -1,0 +1,80 @@
+package bandwidth
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/getlantern/golog"
+)
+
+var (
+	log = golog.LoggerFor("bandwidth")
+
+	quota *Quota
+	mutex sync.RWMutex
+
+	// Updates is a channel on which one can receive updates to the Quota
+	Updates = make(chan *Quota)
+)
+
+// Quota encapsulates information about the user's bandwidth quota.
+type Quota struct {
+	MiBAllowed uint64    `json:"mibAllowed"`
+	MiBUsed    uint64    `json:"mibUsed"`
+	AsOf       time.Time `json:"asOf"`
+}
+
+// GetQuota gets the most up to date bandwidth quota information.
+func GetQuota() *Quota {
+	mutex.RLock()
+	result := quota
+	mutex.RUnlock()
+	return result
+}
+
+// Track updates the bandwith quota information based on the XBQ header in
+// the given response.
+func Track(resp *http.Response) {
+	xbq := resp.Header.Get("XBQ")
+	if xbq == "" {
+		log.Debugf("Response missing XBQ header, can't read bandwidth quota")
+		return
+	}
+	// Remove the XBQ header to avoid leaking it to clients
+	resp.Header.Del("XBQ")
+	parts := strings.Split(xbq, "/")
+	if len(parts) != 3 {
+		log.Debugf("Malformed XBQ header %v, can't read bandwidth quota", xbq)
+		return
+	}
+	used, err := strconv.ParseUint(parts[0], 10, 64)
+	if err != nil {
+		log.Debugf("Malformed XBQ header %v, can't parse used MiB: %v", err)
+		return
+	}
+	allowed, err := strconv.ParseUint(parts[1], 10, 64)
+	if err != nil {
+		log.Debugf("Malformed XBQ header %v, can't parse allowed MiB: %v", err)
+		return
+	}
+	asofInt, err := strconv.ParseInt(parts[2], 10, 64)
+	if err != nil {
+		log.Debugf("Malformed XBQ header %v, can't parse as of time: %v", err)
+		return
+	}
+	asof := time.Unix(0, asofInt)
+	mutex.Lock()
+	if quota == nil || quota.AsOf.Before(asof) {
+		quota = &Quota{allowed, used, asof}
+		select {
+		case Updates <- quota:
+			// update submitted
+		default:
+			// channel full, skip it
+		}
+	}
+	mutex.Unlock()
+}

--- a/src/github.com/getlantern/bandwidth/bandwidth_test.go
+++ b/src/github.com/getlantern/bandwidth/bandwidth_test.go
@@ -1,0 +1,46 @@
+package bandwidth
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/getlantern/eventual"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRoundTrip(t *testing.T) {
+	fromChannel := eventual.NewValue()
+	go func() {
+		for q := range Updates {
+			fromChannel.Set(q)
+		}
+	}()
+
+	Track(build(5, 500, 2))
+	Track(build(6, 500, 3))
+	Track(build(4, 500, 1))
+
+	q := GetQuota()
+	time.Sleep(50 * time.Millisecond)
+	_q2, ok := fromChannel.Get(1 * time.Second)
+	if assert.True(t, ok, "Should have gotten quota from channel") {
+		q2 := _q2.(*Quota)
+		assert.EqualValues(t, 500, q.MiBAllowed)
+		assert.EqualValues(t, 500, q2.MiBAllowed)
+		assert.EqualValues(t, 6, q.MiBUsed)
+		assert.EqualValues(t, 6, q2.MiBUsed)
+		assert.EqualValues(t, time.Unix(0, 3), q.AsOf)
+		assert.EqualValues(t, time.Unix(0, 3), q2.AsOf)
+	}
+
+}
+
+func build(used uint64, allowed uint64, asof int64) *http.Response {
+	resp := &http.Response{
+		Header: make(http.Header),
+	}
+	resp.Header.Set("XBQ", fmt.Sprintf("%d/%d/%d", used, allowed, asof))
+	return resp
+}

--- a/src/github.com/getlantern/chained/dialer.go
+++ b/src/github.com/getlantern/chained/dialer.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"net/http"
 	"strings"
+
+	"github.com/getlantern/bandwidth"
 )
 
 // Config is a configuration for a Dialer.
@@ -95,6 +97,7 @@ func checkCONNECTResponse(r *bufio.Reader, req *http.Request) error {
 	if !sameStatusCodeClass(http.StatusOK, resp.StatusCode) {
 		return fmt.Errorf("Bad status code on CONNECT response: %d", resp.StatusCode)
 	}
+	bandwidth.Track(resp)
 	return nil
 }
 

--- a/src/github.com/getlantern/flashlight/app/app.go
+++ b/src/github.com/getlantern/flashlight/app/app.go
@@ -155,6 +155,11 @@ func (app *App) beforeStart(cfg *config.Config) bool {
 	}
 	client.UIAddr = actualUIAddr
 
+	err = serveBandwidth()
+	if err != nil {
+		log.Errorf("Unable to serve bandwidth to UI: %v", err)
+	}
+
 	// Only run analytics once on startup.
 	if settings.IsAutoReport() {
 		stopAnalytics := analytics.Start(settings.GetDeviceID(), flashlight.Version)

--- a/src/github.com/getlantern/flashlight/app/bandwidth.go
+++ b/src/github.com/getlantern/flashlight/app/bandwidth.go
@@ -1,0 +1,25 @@
+package app
+
+import (
+	"github.com/getlantern/bandwidth"
+
+	"github.com/getlantern/flashlight/ui"
+)
+
+func serveBandwidth() error {
+	helloFn := func(write func(interface{}) error) error {
+		log.Debugf("Sending current bandwidth quota to new client")
+		return write(bandwidth.GetQuota())
+	}
+
+	service, err := ui.Register("bandwidth", helloFn)
+	if err == nil {
+		go func() {
+			for quota := range bandwidth.Updates {
+				service.Out <- quota
+			}
+		}()
+	}
+
+	return err
+}

--- a/src/github.com/getlantern/flashlight/app/settings.go
+++ b/src/github.com/getlantern/flashlight/app/settings.go
@@ -110,7 +110,7 @@ func (s *Settings) start() error {
 		defer s.Unlock()
 		return write(s)
 	}
-	service, err = ui.Register(messageType, nil, helloFn)
+	service, err = ui.Register(messageType, helloFn)
 	return err
 }
 

--- a/src/github.com/getlantern/flashlight/client/client.go
+++ b/src/github.com/getlantern/flashlight/client/client.go
@@ -30,8 +30,7 @@ var (
 	// UIAddr is the address at which UI is to be found
 	UIAddr string
 
-	addr = eventual.NewValue()
-
+	addr      = eventual.NewValue()
 	socksAddr = eventual.NewValue()
 )
 

--- a/src/github.com/getlantern/flashlight/ui/service.go
+++ b/src/github.com/getlantern/flashlight/ui/service.go
@@ -10,14 +10,13 @@ import (
 type helloFnType func(func(interface{}) error) error
 
 type Service struct {
-	Type       string
-	In         <-chan interface{}
-	Out        chan<- interface{}
-	in         chan interface{}
-	out        chan interface{}
-	stopCh     chan bool
-	newMessage func() interface{}
-	helloFn    helloFnType
+	Type    string
+	In      <-chan interface{}
+	Out     chan<- interface{}
+	in      chan interface{}
+	out     chan interface{}
+	stopCh  chan bool
+	helloFn helloFnType
 }
 
 var (
@@ -46,7 +45,7 @@ func (s *Service) write() {
 	}
 }
 
-func Register(t string, newMessage func() interface{}, helloFn helloFnType) (*Service, error) {
+func Register(t string, helloFn helloFnType) (*Service, error) {
 	log.Tracef("Registering UI service %s", t)
 	mu.Lock()
 
@@ -62,12 +61,11 @@ func Register(t string, newMessage func() interface{}, helloFn helloFnType) (*Se
 	}
 
 	s := &Service{
-		Type:       t,
-		in:         make(chan interface{}, 100),
-		out:        make(chan interface{}, 100),
-		stopCh:     make(chan bool),
-		newMessage: newMessage,
-		helloFn:    helloFn,
+		Type:    t,
+		in:      make(chan interface{}, 100),
+		out:     make(chan interface{}, 100),
+		stopCh:  make(chan bool),
+		helloFn: helloFn,
 	}
 	s.In, s.Out = s.in, s.out
 

--- a/testpackages.txt
+++ b/testpackages.txt
@@ -1,5 +1,6 @@
 github.com/getlantern/appdir
 github.com/getlantern/balancer
+github.com/getlantern/bandwidth
 github.com/getlantern/buuid
 github.com/getlantern/bytecounting
 github.com/getlantern/byteexec


### PR DESCRIPTION
In order to test this, you can locally run a proxy that spits out fake bandwidth tracking stats by building from https://github.com/getlantern/http-proxy-lantern/tree/throttling-ox