### PR TITLE
When no check function provided for dialer, return true

### DIFF
--- a/src/github.com/getlantern/balancer/dialer.go
+++ b/src/github.com/getlantern/balancer/dialer.go
@@ -165,7 +165,7 @@ func (d *dialer) markFailure() {
 
 func (d *dialer) defaultCheck() bool {
 	log.Errorf("No check function provided for dialer %s", d.Label)
-	return false
+	return true
 }
 
 // adds randomization to make requests less distinguishable on the network.

--- a/src/github.com/getlantern/fdcount/fdcount_test.go
+++ b/src/github.com/getlantern/fdcount/fdcount_test.go
@@ -85,7 +85,7 @@ func TestWaitUntilNoneMatchOK(t *testing.T) {
 		}
 	}()
 
-	err = WaitUntilNoneMatch("TCP", wait*5)
+	err = WaitUntilNoneMatch("TCP", wait*50)
 	elapsed := time.Now().Sub(start)
 	assert.NoError(t, err, "Waiting should have succeeded")
 	assert.True(t, elapsed >= wait, "Should have waited a while")
@@ -102,7 +102,7 @@ func TestWaitUntilNoneMatchTimeout(t *testing.T) {
 		}
 	}()
 
-	wait := 200 * time.Millisecond
+	wait := 1000 * time.Millisecond
 	start := time.Now()
 	go func() {
 		time.Sleep(wait)
@@ -111,7 +111,7 @@ func TestWaitUntilNoneMatchTimeout(t *testing.T) {
 		}
 	}()
 
-	err = WaitUntilNoneMatch("TCP", wait/4)
+	err = WaitUntilNoneMatch("TCP", wait/50)
 	elapsed := time.Now().Sub(start)
 	assert.Error(t, err, "Waiting should have failed")
 	assert.True(t, elapsed < wait, "Should have waited less than time to close conn")


### PR DESCRIPTION
I noticed a lot of log output from the balancer test and saw that the default check function returns false.  That creates unnecessary work since it triggers a recheck, and that recheck can never succeed because the default check function will always return false.