### PR TITLE
Added TLS ClientSessionCache in a few places to reduce TLS handshaking

### DIFF
--- a/src/github.com/getlantern/fronted/direct.go
+++ b/src/github.com/getlantern/fronted/direct.go
@@ -29,6 +29,9 @@ const (
 var (
 	log       = golog.LoggerFor("fronted")
 	_instance = eventual.NewValue()
+
+	// Shared client session cache for all connections
+	clientSessionCache = tls.NewLRUClientSessionCache(1000)
 )
 
 type direct struct {
@@ -143,6 +146,9 @@ func (d *direct) NewDirect() http.RoundTripper {
 			Dial:                d.Dial,
 			TLSHandshakeTimeout: 40 * time.Second,
 			DisableKeepAlives:   true,
+			TLSClientConfig: &tls.Config{
+				ClientSessionCache: clientSessionCache,
+			},
 		},
 	}
 }


### PR DESCRIPTION
With all these http.Transports that we're creating, we missed a few opportunities to cache TLS sessions, which results in unnecessary handshaking/load to servers.

This probably won't have a huge impact since it's mostly used for our internal polling stuff, but it can't hurt.