### PR TITLE
Add support for simulating autoupdates locally.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,8 @@ LANTERN_MOBILE_ANDROID_RELEASE := $(LANTERN_MOBILE_DIR)/app/build/outputs/apk/ap
 LANTERN_YAML := lantern.yaml
 LANTERN_YAML_PATH := installer-resources/lantern.yaml
 
+BUILD_TAGS ?=
+
 .PHONY: packages clean tun2socks android-lib android-sdk android-testbed android-debug android-release android-install docker-run
 
 define require-node
@@ -118,7 +120,7 @@ define require-npm
 endef
 
 define build-tags
-	BUILD_TAGS="" && \
+	BUILD_TAGS="$(BUILD_TAGS)" && \
 	EXTRA_LDFLAGS="" && \
 	if [[ ! -z "$$VERSION" ]]; then \
 		EXTRA_LDFLAGS="-X github.com/getlantern/flashlight.compileTimePackageVersion=$$VERSION"; \

--- a/src/github.com/getlantern/flashlight/app/autoupdate.go
+++ b/src/github.com/getlantern/flashlight/app/autoupdate.go
@@ -1,3 +1,5 @@
+// +build !mockupdate
+
 package app
 
 // This is the public key of the BNS cert. Incoming updates will be signed to

--- a/src/github.com/getlantern/flashlight/app/mock_autoupdate.go
+++ b/src/github.com/getlantern/flashlight/app/mock_autoupdate.go
@@ -1,0 +1,15 @@
+// +build mockupdate
+
+package app
+
+// This is a public key derived from a private key that is freely available.
+// Don't use in production.
+const packagePublicKey = `-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAzSoibtACnqcp2uTGjCMJ
+tTOLDIMQ4oGPhGHT4Q/epum+H3hcbBNs9jRnMRWgX4z++xxuNJnhmoJw0eUXB7B4
+vj5DYpPajq6gPY8JuraF4ngfP5oxKj2BqpEUR9bx+3SjOSInrirM0JZO+aAW38BQ
+NJB+sS7JvbPjcwdjwKc5IKzc9kxxJNoZoFE9GMnYzaOrAlpCuAKWH8SCXYtCTxsX
+fKexdDxsI5Vzm5lQHJLMeqhLTQTUm9oQofwNAOGOkn6dD4ObMlmFTOsf1G03/Dl9
+sVgjaWaZ9bGjvJ9B85UxNeWwduy+uMrqFytxG6bbq0PbDEVu6ZQCPyiyCA7l945J
+OQIDAQAB
+-----END PUBLIC KEY-----`


### PR DESCRIPTION
This is the client part required to [stage autoupdates](https://github.com/getlantern/autoupdate-server/pull/2).