### PR TITLE
Simplify golog and errors package by calling PrintStack directly

### DIFF
--- a/src/github.com/getlantern/errors/errors.go
+++ b/src/github.com/getlantern/errors/errors.go
@@ -230,14 +230,14 @@ func (e *structured) PrintStack(w io.Writer) {
 	for {
 		for stackPosition := 0; stackPosition < len(err.callStack); stackPosition++ {
 			call := err.callStack[stackPosition]
-			fmt.Fprintf(w, "  at %+n (%s:%d)\n", call, call, call)
+			fmt.Fprintf(w, "    at %+n (%s:%d)\n", call, call, call)
 		}
 		cause, ok := err.cause.(*structured)
 		if !ok || cause == nil {
 			return
 		}
 		err = cause
-		fmt.Fprintf(w, "Caused by: %v\n", err)
+		fmt.Fprintf(w, "  Caused by: %v\n", err)
 	}
 }
 

--- a/src/github.com/getlantern/errors/errors.go
+++ b/src/github.com/getlantern/errors/errors.go
@@ -108,7 +108,7 @@ type Error interface {
 	// with the cause of this Error (if any), then the stacktrace when the
 	// cause is created, and so on.
 	// The output is an analogy of Java's stacktrace.
-	PrintStack(io.Writer)
+	PrintStack(io.Writer, string)
 
 	// Op attaches a hint of the operation triggers this Error. Many error types
 	// returned by net and os package have Op pre-filled.
@@ -225,19 +225,19 @@ func (e *structured) Error() string {
 	return e.data["error_text"].(string) + e.hiddenID
 }
 
-func (e *structured) PrintStack(w io.Writer) {
+func (e *structured) PrintStack(w io.Writer, linePrefix string) {
 	err := e
 	for {
 		for stackPosition := 0; stackPosition < len(err.callStack); stackPosition++ {
 			call := err.callStack[stackPosition]
-			fmt.Fprintf(w, "  at %+n (%s:%d)\n", call, call, call)
+			fmt.Fprintf(w, "%s  at %+n (%s:%d)\n", linePrefix, call, call, call)
 		}
 		cause, ok := err.cause.(*structured)
 		if !ok || cause == nil {
 			return
 		}
 		err = cause
-		fmt.Fprintf(w, "Caused by: %v\n", err)
+		fmt.Fprintf(w, "%sCaused by: %v\n", linePrefix, err)
 	}
 }
 

--- a/src/github.com/getlantern/errors/errors.go
+++ b/src/github.com/getlantern/errors/errors.go
@@ -230,14 +230,14 @@ func (e *structured) PrintStack(w io.Writer) {
 	for {
 		for stackPosition := 0; stackPosition < len(err.callStack); stackPosition++ {
 			call := err.callStack[stackPosition]
-			fmt.Fprintf(w, "    at %+n (%s:%d)\n", call, call, call)
+			fmt.Fprintf(w, "  at %+n (%s:%d)\n", call, call, call)
 		}
 		cause, ok := err.cause.(*structured)
 		if !ok || cause == nil {
 			return
 		}
 		err = cause
-		fmt.Fprintf(w, "  Caused by: %v\n", err)
+		fmt.Fprintf(w, "Caused by: %v\n", err)
 	}
 }
 

--- a/src/github.com/getlantern/errors/errors.go
+++ b/src/github.com/getlantern/errors/errors.go
@@ -108,7 +108,7 @@ type Error interface {
 	// with the cause of this Error (if any), then the stacktrace when the
 	// cause is created, and so on.
 	// The output is an analogy of Java's stacktrace.
-	PrintStack(io.Writer, string)
+	PrintStack(w io.Writer, linePrefix string)
 
 	// Op attaches a hint of the operation triggers this Error. Many error types
 	// returned by net and os package have Op pre-filled.

--- a/src/github.com/getlantern/errors/errors.go
+++ b/src/github.com/getlantern/errors/errors.go
@@ -59,7 +59,6 @@ package errors
 
 import (
 	"bufio"
-	"bytes"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
@@ -105,8 +104,11 @@ type Error interface {
 	// This can be useful when performing analytics on the error.
 	ErrorClean() string
 
-	// MultiLinePrinter implements the interface golog.MultiLine
-	MultiLinePrinter() func(buf *bytes.Buffer) bool
+	// PrintStack prints the stacktrace when this Error is created, together
+	// with the cause of this Error (if any), then the stacktrace when the
+	// cause is created, and so on.
+	// The output is an analogy of Java's stacktrace.
+	PrintStack(io.Writer)
 
 	// Op attaches a hint of the operation triggers this Error. Many error types
 	// returned by net and os package have Op pre-filled.
@@ -223,53 +225,19 @@ func (e *structured) Error() string {
 	return e.data["error_text"].(string) + e.hiddenID
 }
 
-func (e *structured) MultiLinePrinter() func(buf *bytes.Buffer) bool {
-	first := true
-	indent := false
+func (e *structured) PrintStack(w io.Writer) {
 	err := e
-	stackPosition := 0
-	switchedCause := false
-	return func(buf *bytes.Buffer) bool {
-		if indent {
-			buf.WriteString("  ")
-		}
-		if first {
-			buf.WriteString(e.Error())
-			first = false
-			indent = true
-			return true
-		}
-		if switchedCause {
-			fmt.Fprintf(buf, "Caused by: %v", err)
-			if err.callStack != nil && len(err.callStack) > 0 {
-				switchedCause = false
-				indent = true
-				return true
-			}
-			if err.cause == nil {
-				return false
-			}
-			err = err.cause.(*structured)
-			return true
-		}
-		if stackPosition < len(err.callStack) {
-			buf.WriteString("at ")
+	for {
+		for stackPosition := 0; stackPosition < len(err.callStack); stackPosition++ {
 			call := err.callStack[stackPosition]
-			fmt.Fprintf(buf, "%+n (%s:%d)", call, call, call)
-			stackPosition++
+			fmt.Fprintf(w, "  at %+n (%s:%d)\n", call, call, call)
 		}
-		if stackPosition >= len(err.callStack) {
-			switch cause := err.cause.(type) {
-			case *structured:
-				err = cause
-				indent = false
-				stackPosition = 0
-				switchedCause = true
-			default:
-				return false
-			}
+		cause, ok := err.cause.(*structured)
+		if !ok || cause == nil {
+			return
 		}
-		return err != nil
+		err = cause
+		fmt.Fprintf(w, "Caused by: %v\n", err)
 	}
 }
 

--- a/src/github.com/getlantern/errors/errors_test.go
+++ b/src/github.com/getlantern/errors/errors_test.go
@@ -62,14 +62,9 @@ func TestNewWithCause(t *testing.T) {
 
 	// Make sure that stacktrace prints out okay
 	buf := &bytes.Buffer{}
-	print := outer.MultiLinePrinter()
-	for {
-		more := print(buf)
-		buf.WriteByte('\n')
-		if !more {
-			break
-		}
-	}
+	buf.WriteString(outer.Error())
+	buf.WriteByte('\n')
+	outer.PrintStack(buf)
 	expected := `Hello World
   at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
   at testing.tRunner (testing.go:999)

--- a/src/github.com/getlantern/errors/errors_test.go
+++ b/src/github.com/getlantern/errors/errors_test.go
@@ -66,23 +66,23 @@ func TestNewWithCause(t *testing.T) {
 	buf.WriteByte('\n')
 	outer.PrintStack(buf)
 	expected := `Hello World
-  at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
-Caused by: World
-  at github.com/getlantern/errors.buildCause (errors_test.go:999)
-  at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
-Caused by: orld
-Caused by: ld
-  at github.com/getlantern/errors.buildSubSubCause (errors_test.go:999)
-  at github.com/getlantern/errors.buildSubCause (errors_test.go:999)
-  at github.com/getlantern/errors.buildCause (errors_test.go:999)
-  at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
-Caused by: d
+    at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
+    at testing.tRunner (testing.go:999)
+    at runtime.goexit (asm_amd999.s:999)
+  Caused by: World
+    at github.com/getlantern/errors.buildCause (errors_test.go:999)
+    at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
+    at testing.tRunner (testing.go:999)
+    at runtime.goexit (asm_amd999.s:999)
+  Caused by: orld
+  Caused by: ld
+    at github.com/getlantern/errors.buildSubSubCause (errors_test.go:999)
+    at github.com/getlantern/errors.buildSubCause (errors_test.go:999)
+    at github.com/getlantern/errors.buildCause (errors_test.go:999)
+    at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
+    at testing.tRunner (testing.go:999)
+    at runtime.goexit (asm_amd999.s:999)
+  Caused by: d
 `
 
 	assert.Equal(t, expected, replaceNumbers.ReplaceAllString(hidden.Clean(buf.String()), "999"))

--- a/src/github.com/getlantern/errors/errors_test.go
+++ b/src/github.com/getlantern/errors/errors_test.go
@@ -64,7 +64,7 @@ func TestNewWithCause(t *testing.T) {
 	buf := &bytes.Buffer{}
 	buf.WriteString(outer.Error())
 	buf.WriteByte('\n')
-	outer.PrintStack(buf)
+	outer.PrintStack(buf, "")
 	expected := `Hello World
   at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
   at testing.tRunner (testing.go:999)

--- a/src/github.com/getlantern/errors/errors_test.go
+++ b/src/github.com/getlantern/errors/errors_test.go
@@ -66,23 +66,23 @@ func TestNewWithCause(t *testing.T) {
 	buf.WriteByte('\n')
 	outer.PrintStack(buf)
 	expected := `Hello World
-    at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
-    at testing.tRunner (testing.go:999)
-    at runtime.goexit (asm_amd999.s:999)
-  Caused by: World
-    at github.com/getlantern/errors.buildCause (errors_test.go:999)
-    at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
-    at testing.tRunner (testing.go:999)
-    at runtime.goexit (asm_amd999.s:999)
-  Caused by: orld
-  Caused by: ld
-    at github.com/getlantern/errors.buildSubSubCause (errors_test.go:999)
-    at github.com/getlantern/errors.buildSubCause (errors_test.go:999)
-    at github.com/getlantern/errors.buildCause (errors_test.go:999)
-    at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
-    at testing.tRunner (testing.go:999)
-    at runtime.goexit (asm_amd999.s:999)
-  Caused by: d
+  at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
+Caused by: World
+  at github.com/getlantern/errors.buildCause (errors_test.go:999)
+  at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
+Caused by: orld
+Caused by: ld
+  at github.com/getlantern/errors.buildSubSubCause (errors_test.go:999)
+  at github.com/getlantern/errors.buildSubCause (errors_test.go:999)
+  at github.com/getlantern/errors.buildCause (errors_test.go:999)
+  at github.com/getlantern/errors.TestNewWithCause (errors_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
+Caused by: d
 `
 
 	assert.Equal(t, expected, replaceNumbers.ReplaceAllString(hidden.Clean(buf.String()), "999"))

--- a/src/github.com/getlantern/golog/golog.go
+++ b/src/github.com/getlantern/golog/golog.go
@@ -159,16 +159,15 @@ func (l *logger) print(out io.Writer, skipFrames int, severity string, arg inter
 	defer bufferPool.Put(buf)
 
 	linePrefix := l.linePrefix(skipFrames)
-	buf.WriteString(severity)
-	buf.WriteString(" ")
-	buf.WriteString(linePrefix)
+	sp := severity + " " + linePrefix
+	buf.WriteString(sp)
 	if arg != nil {
 		if err, isError := arg.(errors.Error); isError && err != nil {
 			buf.WriteString(err.Error())
 			printContext(buf, arg)
 			buf.WriteByte('\n')
 			if severity == "FATAL" || severity == "ERROR" {
-				err.PrintStack(buf)
+				err.PrintStack(buf, sp)
 			}
 		} else {
 			fmt.Fprintf(buf, "%v", arg)

--- a/src/github.com/getlantern/golog/golog.go
+++ b/src/github.com/getlantern/golog/golog.go
@@ -159,20 +159,16 @@ func (l *logger) print(out io.Writer, skipFrames int, severity string, arg inter
 	defer bufferPool.Put(buf)
 
 	linePrefix := l.linePrefix(skipFrames)
-	writeHeader := func() {
-		buf.WriteString(severity)
-		buf.WriteString(" ")
-		buf.WriteString(linePrefix)
-	}
+	buf.WriteString(severity)
+	buf.WriteString(" ")
+	buf.WriteString(linePrefix)
 	if arg != nil {
 		err, isError := arg.(errors.Error)
 		if !isError {
-			writeHeader()
 			fmt.Fprintf(buf, "%v", arg)
 			printContext(buf, arg)
 			buf.WriteByte('\n')
 		} else {
-			writeHeader()
 			buf.WriteString(err.Error())
 			printContext(buf, arg)
 			buf.WriteByte('\n')

--- a/src/github.com/getlantern/golog/golog.go
+++ b/src/github.com/getlantern/golog/golog.go
@@ -163,16 +163,17 @@ func (l *logger) print(out io.Writer, skipFrames int, severity string, arg inter
 	buf.WriteString(" ")
 	buf.WriteString(linePrefix)
 	if arg != nil {
-		err, isError := arg.(errors.Error)
-		if !isError {
-			fmt.Fprintf(buf, "%v", arg)
-			printContext(buf, arg)
-			buf.WriteByte('\n')
-		} else {
+		if err, isError := arg.(errors.Error); isError && err != nil {
 			buf.WriteString(err.Error())
 			printContext(buf, arg)
 			buf.WriteByte('\n')
-			err.PrintStack(buf)
+			if severity == "FATAL" || severity == "ERROR" {
+				err.PrintStack(buf)
+			}
+		} else {
+			fmt.Fprintf(buf, "%v", arg)
+			printContext(buf, arg)
+			buf.WriteByte('\n')
 		}
 	}
 	b := []byte(hidden.Clean(buf.String()))

--- a/src/github.com/getlantern/golog/golog.go
+++ b/src/github.com/getlantern/golog/golog.go
@@ -2,7 +2,6 @@
 // debug messages to stdout. Trace logging is also supported.
 // Trace logs go to stdout as well, but they are only written if the program
 // is run with environment variable "TRACE=true".
-// A stack dump will be printed after the message if "PRINT_STACK=true".
 package golog
 
 import (
@@ -135,20 +134,15 @@ func LoggerFor(prefix string) Logger {
 		l.traceOut = ioutil.Discard
 	}
 
-	printStack := os.Getenv("PRINT_STACK")
-	l.printStack, _ = strconv.ParseBool(printStack)
-
 	return l
 }
 
 type logger struct {
-	prefix     string
-	traceOn    bool
-	traceOut   io.Writer
-	printStack bool
-	outs       atomic.Value
-	pc         []uintptr
-	funcForPc  *runtime.Func
+	prefix   string
+	traceOn  bool
+	traceOut io.Writer
+	outs     atomic.Value
+	pc       []uintptr
 }
 
 // attaches the file and line number corresponding to
@@ -190,10 +184,6 @@ func (l *logger) print(out io.Writer, skipFrames int, severity string, arg inter
 	if err != nil {
 		errorOnLogging(err)
 	}
-	if l.printStack {
-		l.doPrintStack()
-	}
-
 	return linePrefix
 }
 
@@ -212,9 +202,6 @@ func (l *logger) printf(out io.Writer, skipFrames int, severity string, err erro
 	_, err2 := out.Write(b)
 	if err2 != nil {
 		errorOnLogging(err)
-	}
-	if l.printStack {
-		l.doPrintStack()
 	}
 	return linePrefix
 }
@@ -328,26 +315,6 @@ func (w *errorWriter) Write(p []byte) (n int, err error) {
 
 func (l *logger) AsStdLogger() *log.Logger {
 	return log.New(&errorWriter{l}, "", 0)
-}
-
-func (l *logger) doPrintStack() {
-	var b []byte
-	buf := bytes.NewBuffer(b)
-	for _, pc := range l.pc {
-		funcForPc := runtime.FuncForPC(pc)
-		if funcForPc == nil {
-			break
-		}
-		name := funcForPc.Name()
-		if strings.HasPrefix(name, "runtime.") {
-			break
-		}
-		file, line := funcForPc.FileLine(pc)
-		fmt.Fprintf(buf, "\t%s\t%s: %d\n", name, file, line)
-	}
-	if _, err := buf.WriteTo(os.Stderr); err != nil {
-		errorOnLogging(err)
-	}
 }
 
 func errorOnLogging(err error) {

--- a/src/github.com/getlantern/golog/golog_test.go
+++ b/src/github.com/getlantern/golog/golog_test.go
@@ -20,22 +20,22 @@ import (
 var (
 	expectedLog      = "SEVERITY myprefix: golog_test.go:999 Hello world\nSEVERITY myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b op=name root_op=name]\n"
 	expectedErrorLog = `ERROR myprefix: golog_test.go:999 Hello world [cvarC=c cvarD=d error=Hello %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello world error_type=errors.Error op=name root_op=name]
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
-Caused by: world
-  at github.com/getlantern/golog.errorReturner (golog_test.go:999)
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
+ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
+ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
+ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
+ERROR myprefix: golog_test.go:999 Caused by: world
+ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.errorReturner (golog_test.go:999)
+ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
+ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
+ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
 ERROR myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b cvarC=c error=%v %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello true error_type=errors.Error op=name999 root_op=name999]
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
-Caused by: Hello
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
+ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
+ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
+ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
+ERROR myprefix: golog_test.go:999 Caused by: Hello
+ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
+ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
+ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
 `
 	expectedTraceLog = "TRACE myprefix: golog_test.go:999 Hello world\nTRACE myprefix: golog_test.go:999 Hello true\nTRACE myprefix: golog_test.go:999 Gravy\nTRACE myprefix: golog_test.go:999 TraceWriter closed due to unexpected error: EOF\n"
 	expectedStdLog   = expectedLog

--- a/src/github.com/getlantern/golog/golog_test.go
+++ b/src/github.com/getlantern/golog/golog_test.go
@@ -20,22 +20,22 @@ import (
 var (
 	expectedLog      = "SEVERITY myprefix: golog_test.go:999 Hello world\nSEVERITY myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b op=name root_op=name]\n"
 	expectedErrorLog = `ERROR myprefix: golog_test.go:999 Hello world [cvarC=c cvarD=d error=Hello %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello world error_type=errors.Error op=name root_op=name]
-ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
-ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
-ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
-ERROR myprefix: golog_test.go:999 Caused by: world
-ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.errorReturner (golog_test.go:999)
-ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
-ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
-ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
+Caused by: world
+  at github.com/getlantern/golog.errorReturner (golog_test.go:999)
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
 ERROR myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b cvarC=c error=%v %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello true error_type=errors.Error op=name999 root_op=name999]
-ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
-ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
-ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
-ERROR myprefix: golog_test.go:999 Caused by: Hello
-ERROR myprefix: golog_test.go:999   at github.com/getlantern/golog.TestError (golog_test.go:999)
-ERROR myprefix: golog_test.go:999   at testing.tRunner (testing.go:999)
-ERROR myprefix: golog_test.go:999   at runtime.goexit (asm_amd999.s:999)
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
+Caused by: Hello
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
 `
 	expectedTraceLog = "TRACE myprefix: golog_test.go:999 Hello world\nTRACE myprefix: golog_test.go:999 Hello true\nTRACE myprefix: golog_test.go:999 Gravy\nTRACE myprefix: golog_test.go:999 TraceWriter closed due to unexpected error: EOF\n"
 	expectedStdLog   = expectedLog

--- a/src/github.com/getlantern/golog/golog_test.go
+++ b/src/github.com/getlantern/golog/golog_test.go
@@ -20,22 +20,22 @@ import (
 var (
 	expectedLog      = "SEVERITY myprefix: golog_test.go:999 Hello world\nSEVERITY myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b op=name root_op=name]\n"
 	expectedErrorLog = `ERROR myprefix: golog_test.go:999 Hello world [cvarC=c cvarD=d error=Hello %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello world error_type=errors.Error op=name root_op=name]
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
-Caused by: world
-  at github.com/getlantern/golog.errorReturner (golog_test.go:999)
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
+    at github.com/getlantern/golog.TestError (golog_test.go:999)
+    at testing.tRunner (testing.go:999)
+    at runtime.goexit (asm_amd999.s:999)
+  Caused by: world
+    at github.com/getlantern/golog.errorReturner (golog_test.go:999)
+    at github.com/getlantern/golog.TestError (golog_test.go:999)
+    at testing.tRunner (testing.go:999)
+    at runtime.goexit (asm_amd999.s:999)
 ERROR myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b cvarC=c error=%v %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello true error_type=errors.Error op=name999 root_op=name999]
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
-Caused by: Hello
-  at github.com/getlantern/golog.TestError (golog_test.go:999)
-  at testing.tRunner (testing.go:999)
-  at runtime.goexit (asm_amd999.s:999)
+    at github.com/getlantern/golog.TestError (golog_test.go:999)
+    at testing.tRunner (testing.go:999)
+    at runtime.goexit (asm_amd999.s:999)
+  Caused by: Hello
+    at github.com/getlantern/golog.TestError (golog_test.go:999)
+    at testing.tRunner (testing.go:999)
+    at runtime.goexit (asm_amd999.s:999)
 `
 	expectedTraceLog = "TRACE myprefix: golog_test.go:999 Hello world\nTRACE myprefix: golog_test.go:999 Hello true\nTRACE myprefix: golog_test.go:999 Gravy\nTRACE myprefix: golog_test.go:999 TraceWriter closed due to unexpected error: EOF\n"
 	expectedStdLog   = expectedLog

--- a/src/github.com/getlantern/golog/golog_test.go
+++ b/src/github.com/getlantern/golog/golog_test.go
@@ -20,22 +20,22 @@ import (
 var (
 	expectedLog      = "SEVERITY myprefix: golog_test.go:999 Hello world\nSEVERITY myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b op=name root_op=name]\n"
 	expectedErrorLog = `ERROR myprefix: golog_test.go:999 Hello world [cvarC=c cvarD=d error=Hello %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello world error_type=errors.Error op=name root_op=name]
-    at github.com/getlantern/golog.TestError (golog_test.go:999)
-    at testing.tRunner (testing.go:999)
-    at runtime.goexit (asm_amd999.s:999)
-  Caused by: world
-    at github.com/getlantern/golog.errorReturner (golog_test.go:999)
-    at github.com/getlantern/golog.TestError (golog_test.go:999)
-    at testing.tRunner (testing.go:999)
-    at runtime.goexit (asm_amd999.s:999)
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
+Caused by: world
+  at github.com/getlantern/golog.errorReturner (golog_test.go:999)
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
 ERROR myprefix: golog_test.go:999 Hello true [cvarA=a cvarB=b cvarC=c error=%v %v error_location=github.com/getlantern/golog.TestError (golog_test.go:999) error_text=Hello true error_type=errors.Error op=name999 root_op=name999]
-    at github.com/getlantern/golog.TestError (golog_test.go:999)
-    at testing.tRunner (testing.go:999)
-    at runtime.goexit (asm_amd999.s:999)
-  Caused by: Hello
-    at github.com/getlantern/golog.TestError (golog_test.go:999)
-    at testing.tRunner (testing.go:999)
-    at runtime.goexit (asm_amd999.s:999)
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
+Caused by: Hello
+  at github.com/getlantern/golog.TestError (golog_test.go:999)
+  at testing.tRunner (testing.go:999)
+  at runtime.goexit (asm_amd999.s:999)
 `
 	expectedTraceLog = "TRACE myprefix: golog_test.go:999 Hello world\nTRACE myprefix: golog_test.go:999 Hello true\nTRACE myprefix: golog_test.go:999 Gravy\nTRACE myprefix: golog_test.go:999 TraceWriter closed due to unexpected error: EOF\n"
 	expectedStdLog   = expectedLog


### PR DESCRIPTION
It intends to fix https://github.com/getlantern/lantern/issues/4803 indirectly by replacing `MultiLine` with a more direct one pass `PrintStack`.

There's one slight difference of `golog` output: The file/line number prepended to each line of stacktrace is removed. Actually, it's what I wanted to remove!

I do want to solve the interleaving of log lines in this PR.