### PR TITLE
align balancer.lastDialTime in 64bit boundary

### DIFF
--- a/src/github.com/getlantern/balancer/balancer.go
+++ b/src/github.com/getlantern/balancer/balancer.go
@@ -30,11 +30,12 @@ var (
 
 // Balancer balances connections among multiple Dialers.
 type Balancer struct {
+	// make sure to align on 64bit boundary
+	lastDialTime int64 // Time.UnixNano()
 	st           Strategy
 	mu           sync.RWMutex
 	dialers      dialerHeap
 	trusted      dialerHeap
-	lastDialTime int64 // Time.UnixNano()
 }
 
 // New creates a new Balancer using the supplied Strategy and Dialers.


### PR DESCRIPTION
It cherry-picks the commit in https://github.com/getlantern/lantern-pro/pull/73. That PR was created to wrong repo.