### PR TITLE
Use lantern instead of lantern-outline repo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/getlantern/lantern-outline
+module github.com/getlantern/lantern
 
 go 1.25.4
 

--- a/lantern-core/cmd/lanternsvc/main.go
+++ b/lantern-core/cmd/lanternsvc/main.go
@@ -16,8 +16,8 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/getlantern/lantern-outline/lantern-core/common"
-	"github.com/getlantern/lantern-outline/lantern-core/wintunmgr"
+	"github.com/getlantern/lantern/lantern-core/common"
+	"github.com/getlantern/lantern/lantern-core/wintunmgr"
 	"golang.org/x/sys/windows"
 	"golang.org/x/sys/windows/svc"
 

--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -24,9 +24,9 @@ import (
 	"github.com/getlantern/radiance/vpn"
 	"google.golang.org/protobuf/proto"
 
-	"github.com/getlantern/lantern-outline/lantern-core/apps"
-	privateserver "github.com/getlantern/lantern-outline/lantern-core/private-server"
-	"github.com/getlantern/lantern-outline/lantern-core/utils"
+	"github.com/getlantern/lantern/lantern-core/apps"
+	privateserver "github.com/getlantern/lantern/lantern-core/private-server"
+	"github.com/getlantern/lantern/lantern-core/utils"
 )
 
 type EventType = string

--- a/lantern-core/ffi/ffi.go
+++ b/lantern-core/ffi/ffi.go
@@ -17,12 +17,12 @@ import (
 	"sync/atomic"
 	"unsafe"
 
-	lanterncore "github.com/getlantern/lantern-outline/lantern-core"
-	"github.com/getlantern/lantern-outline/lantern-core/apps"
-	"github.com/getlantern/lantern-outline/lantern-core/dart_api_dl"
-	privateserver "github.com/getlantern/lantern-outline/lantern-core/private-server"
-	"github.com/getlantern/lantern-outline/lantern-core/utils"
-	"github.com/getlantern/lantern-outline/lantern-core/vpn_tunnel"
+	lanterncore "github.com/getlantern/lantern/lantern-core"
+	"github.com/getlantern/lantern/lantern-core/apps"
+	"github.com/getlantern/lantern/lantern-core/dart_api_dl"
+	privateserver "github.com/getlantern/lantern/lantern-core/private-server"
+	"github.com/getlantern/lantern/lantern-core/utils"
+	"github.com/getlantern/lantern/lantern-core/vpn_tunnel"
 )
 
 type VPNStatus string

--- a/lantern-core/logging/logging.go
+++ b/lantern-core/logging/logging.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/fsnotify/fsnotify"
-	"github.com/getlantern/lantern-outline/lantern-core/dart_api_dl"
+	"github.com/getlantern/lantern/lantern-core/dart_api_dl"
 )
 
 // LogHandler is a function that handles new log messages.

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -10,9 +10,9 @@ import (
 	"github.com/sagernet/sing-box/experimental/libbox"
 	_ "golang.org/x/mobile/bind"
 
-	lanterncore "github.com/getlantern/lantern-outline/lantern-core"
-	"github.com/getlantern/lantern-outline/lantern-core/utils"
-	"github.com/getlantern/lantern-outline/lantern-core/vpn_tunnel"
+	lanterncore "github.com/getlantern/lantern/lantern-core"
+	"github.com/getlantern/lantern/lantern-core/utils"
+	"github.com/getlantern/lantern/lantern-core/vpn_tunnel"
 	"github.com/getlantern/radiance/common"
 )
 

--- a/lantern-core/private-server/server.go
+++ b/lantern-core/private-server/server.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/getlantern/golog"
-	"github.com/getlantern/lantern-outline/lantern-core/utils"
+	"github.com/getlantern/lantern/lantern-core/utils"
 	pcommon "github.com/getlantern/lantern-server-provisioner/common"
 	"github.com/getlantern/lantern-server-provisioner/digitalocean"
 	gcp "github.com/getlantern/lantern-server-provisioner/gcp"

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -10,7 +10,7 @@ import (
 	"github.com/getlantern/radiance/vpn"
 	"github.com/sagernet/sing-box/experimental/libbox"
 
-	"github.com/getlantern/lantern-outline/lantern-core/utils"
+	"github.com/getlantern/lantern/lantern-core/utils"
 )
 
 type InternalTag string

--- a/lantern-core/wintunmgr/ipc.go
+++ b/lantern-core/wintunmgr/ipc.go
@@ -3,7 +3,7 @@ package wintunmgr
 import (
 	"encoding/json"
 
-	"github.com/getlantern/lantern-outline/lantern-core/common"
+	"github.com/getlantern/lantern/lantern-core/common"
 )
 
 // IPC structs

--- a/lantern-core/wintunmgr/service_windows.go
+++ b/lantern-core/wintunmgr/service_windows.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/Microsoft/go-winio"
-	"github.com/getlantern/lantern-outline/lantern-core/common"
-	"github.com/getlantern/lantern-outline/lantern-core/utils"
-	"github.com/getlantern/lantern-outline/lantern-core/vpn_tunnel"
+	"github.com/getlantern/lantern/lantern-core/common"
+	"github.com/getlantern/lantern/lantern-core/utils"
+	"github.com/getlantern/lantern/lantern-core/vpn_tunnel"
 	"github.com/getlantern/radiance/events"
 	"github.com/getlantern/radiance/vpn/ipc"
 )

--- a/scripts/generate_appcast.py
+++ b/scripts/generate_appcast.py
@@ -18,7 +18,7 @@ import requests
 import xml.etree.ElementTree as ET
 
 # -------- Configuration --------
-REPO = "getlantern/lantern-outline"
+REPO = "getlantern/lantern"
 OUT_PATH = "appcast.xml"
 PLATFORMS = {
     "macos": ".dmg",

--- a/windows/packaging/exe/make_config.yaml
+++ b/windows/packaging/exe/make_config.yaml
@@ -5,7 +5,7 @@ app_id: 5B599538-42C1-4026-A579-AF079F21A65E
 display_name: Lantern
 #app_name: Lantern
 publisher: getlantern
-publisher_url: https://github.com/getlantern/lantern-outline
+publisher_url: https://github.com/getlantern/lantern
 executable_name: lantern.exe
 output_base_file_name: lantern.exe
 create_desktop_icon: true


### PR DESCRIPTION
This pull request updates the repository and import paths throughout the codebase, changing references from `lantern-outline` to `lantern`. This is a large-scale, mechanical change to reflect the new module name and repository location, ensuring consistency and preventing import errors.

Repository/module renaming:

* Changed the Go module name in `go.mod` from `github.com/getlantern/lantern-outline` to `github.com/getlantern/lantern`.
* Updated the repository reference in `scripts/generate_appcast.py` and the publisher URL in `windows/packaging/exe/make_config.yaml` to use `getlantern/lantern` instead of `getlantern/lantern-outline`. [[1]](diffhunk://#diff-11238194a01f9c0dfec115f0ae7d81bbc4b11f6d7ee9404f79c2a8f0ed02cd3dL21-R21) [[2]](diffhunk://#diff-080f03d2ebc626862506a92befc4d6a332d6838a6604d4f81ecb6cd42be42533L8-R8)

Code import path updates:

* Replaced all import paths throughout the `lantern-core` submodules (including `common`, `wintunmgr`, `apps`, `private-server`, `utils`, `vpn_tunnel`, etc.) from `github.com/getlantern/lantern-outline/lantern-core/...` to `github.com/getlantern/lantern/lantern-core/...`. [[1]](diffhunk://#diff-ff622080d8bfa7d00d62b1705db8cf958266478aa3eb5569c40fc48d0e2650adL19-R20) [[2]](diffhunk://#diff-62f35878f2bc3e51174e5c90579a40e547ce99ff63b5001d2d60d5186f726a12L27-R29) [[3]](diffhunk://#diff-6fc1c9f8196232981f804da864f6713d6f5f13773354052a4a8717b78f3b1051L20-R25) [[4]](diffhunk://#diff-3c9849e5e1dc33b75a2fd9ec4a5e462823455fda124a61fa846e4ce80775f3ebL13-R13) [[5]](diffhunk://#diff-29bc68e34649b32f3954f2c51b728288546c01dcd66496ba85a8b7fe22be5351L13-R15) [[6]](diffhunk://#diff-2b7e190d804bf38e63f925f20f16bba2af2d87dfe6a4e56d970b3cc00aa700e5L16-R16) [[7]](diffhunk://#diff-68e230ae8e6c6e9b1448f41e8228bfca35899cad4dcedaba614730590e6f1334L13-R13) [[8]](diffhunk://#diff-1a13ae07d14cc79399d3e4fac1dbd51a743fda15e6fa4d58fb6cff25666e412eL6-R6) [[9]](diffhunk://#diff-17141895aacb31f1b891168daf74157aa9f1f732c61ef491c23fba4da1a81cfcL23-R25)

These changes are necessary for the project to build and reference the correct repository after the rename. No functional or logic changes were made.