### PR TITLE
if email is found pre-fill in report issue

### DIFF
--- a/lib/core/common/app_text_field.dart
+++ b/lib/core/common/app_text_field.dart
@@ -29,6 +29,7 @@ class AppTextField extends StatelessWidget {
   final bool? autocorrect;
   final Widget? counter;
   final List<String>? autofillHints;
+  final bool? autofocus;
 
   const AppTextField({
     super.key,
@@ -55,12 +56,14 @@ class AppTextField extends StatelessWidget {
     this.onEditingComplete,
     this.counter,
     this.autofillHints,
+    this. autofocus,
   });
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     Widget inputField = TextFormField(
+        autofocus: autofocus ??false,
         textAlign: TextAlign.start,
         textAlignVertical: TextAlignVertical.top,
         keyboardType: keyboardType,

--- a/lib/features/auth/sign_in_password.dart
+++ b/lib/features/auth/sign_in_password.dart
@@ -47,6 +47,7 @@ class _SignInPasswordState extends ConsumerState<SignInPassword> {
               SizedBox(height: defaultSize),
               AppTextField(
                 hintText: '',
+                autofocus: true,
                 controller: passwordController,
                 autofillHints: [AutofillHints.password],
                 prefixIcon: AppImagePaths.lock,

--- a/lib/features/report_Issue/report_issue.dart
+++ b/lib/features/report_Issue/report_issue.dart
@@ -7,6 +7,7 @@ import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/utils/device_utils.dart';
 import 'package:lantern/core/utils/storage_utils.dart';
 import 'package:lantern/core/widgets/radio_listview.dart';
+import 'package:lantern/features/home/provider/home_notifier.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
 
 @RoutePage(name: 'ReportIssue')
@@ -43,6 +44,10 @@ class _ReportIssueState extends ConsumerState<ReportIssue> {
     final emailController = useTextEditingController();
     final descriptionController =
         useTextEditingController(text: widget.description);
+    final user = ref.read(homeProvider).value;
+    if (user != null) {
+      emailController.text = user.legacyUserData.email ?? '';
+    }
     String type = '';
     try {
       if (widget.type != null) {


### PR DESCRIPTION
This pull request introduces a new `autofocus` property to the `AppTextField` widget, allowing text fields to request focus automatically when built. It also updates the sign-in password field to autofocus by default and improves the report issue form by pre-filling the email field with the user's email if available.

**AppTextField improvements:**
* Added an optional `autofocus` property to the `AppTextField` widget, enabling automatic focus when the field is built. (`lib/core/common/app_text_field.dart`) [[1]](diffhunk://#diff-ea7775b6329c70430b1e805a6e081ebeeb2d843783917db33806d07c0b2f531eR32) [[2]](diffhunk://#diff-ea7775b6329c70430b1e805a6e081ebeeb2d843783917db33806d07c0b2f531eR59-R66)
* Updated the sign-in password field to use `autofocus: true`, so the password field is focused when the sign-in screen appears. (`lib/features/auth/sign_in_password.dart`)

**Report Issue form enhancements:**
* Imported the `home_notifier` provider to access user data in the report issue form. (`lib/features/report_Issue/report_issue.dart`)
* Pre-fills the email field in the report issue form with the logged-in user's email, if available. (`lib/features/report_Issue/report_issue.dart`)