### PR TITLE
Add navigation from tray directly to the join server page

### DIFF
--- a/lib/features/system_tray/provider/system_tray_notifier.dart
+++ b/lib/features/system_tray/provider/system_tray_notifier.dart
@@ -66,6 +66,15 @@ class SystemTrayNotifier extends _$SystemTrayNotifier with TrayListener {
         ),
         MenuItem.separator(),
         MenuItem(
+          key: 'join_server',
+          label: 'join_server'.i18n,
+          onClick: (_) {
+            // Open Lantern and navigate to the join server page
+            ref.read(windowProvider.notifier).open(focus: true);
+            appRouter.push(JoinPrivateServer());
+          },
+        ),
+        MenuItem(
           key: 'show_window',
           label: 'show'.i18n,
           onClick: (_) {
@@ -88,6 +97,7 @@ class SystemTrayNotifier extends _$SystemTrayNotifier with TrayListener {
     await trayManager.setContextMenu(menu);
     trayManager.setIcon(_trayIconPath(isConnected),
         isTemplate: Platform.isMacOS);
+    trayManager.setToolTip('app_name'.i18n);
   }
 
   String _trayIconPath(bool connected) {


### PR DESCRIPTION
This pull request enhances the system tray functionality by adding a new menu item for joining a private server and improving the tray icon's user experience. The most important changes are:

**System Tray Menu Enhancements:**

* Added a new `join_server` menu item to the system tray, which opens the main window and navigates the user to the join private server page when clicked.

**User Experience Improvements:**

* Set the tray icon tooltip to display the application's localized name, improving accessibility and usability.