### PR TITLE
Added ability to upgrade to pro from the tray

### DIFF
--- a/lib/features/system_tray/provider/system_tray_notifier.dart
+++ b/lib/features/system_tray/provider/system_tray_notifier.dart
@@ -12,6 +12,7 @@ part 'system_tray_notifier.g.dart';
 @Riverpod(keepAlive: true)
 class SystemTrayNotifier extends _$SystemTrayNotifier with TrayListener {
   late VPNStatus _currentStatus;
+  bool _isUserPro = false;
 
   @override
   Future<void> build() async {
@@ -22,6 +23,15 @@ class SystemTrayNotifier extends _$SystemTrayNotifier with TrayListener {
       (previous, next) async {
         _currentStatus = next;
         // Refresh menu on change
+        await updateTrayMenu();
+      },
+    );
+
+    _isUserPro = ref.read(isUserProProvider);
+    ref.listen<bool>(
+      isUserProProvider,
+      (previous, next) async {
+        _isUserPro = next;
         await updateTrayMenu();
       },
     );
@@ -64,6 +74,16 @@ class SystemTrayNotifier extends _$SystemTrayNotifier with TrayListener {
               _currentStatus == VPNStatus.disconnecting,
           onClick: (_) => toggleVPN(),
         ),
+        MenuItem.separator(),
+        if (!_isUserPro)
+          MenuItem(
+            key: 'upgrade_to_pro',
+            label: 'upgrade_to_pro'.i18n,
+            onClick: (_) {
+              ref.read(windowProvider.notifier).open(focus: true);
+              appRouter.push(Plans());
+            },
+          ),
         MenuItem.separator(),
         MenuItem(
           key: 'join_server',


### PR DESCRIPTION
This pull request enhances the system tray menu by introducing dynamic behavior based on the user's subscription status. The main improvement is the addition of an "Upgrade to Pro" menu item for non-Pro users, and the notifier now listens for changes in the user's Pro status to update the tray menu accordingly.

**User subscription awareness and tray menu updates:**

* Added a `_isUserPro` field to `SystemTrayNotifier` and initialized it using the `isUserProProvider`. The notifier now listens for changes to the user's Pro status and updates the tray menu when it changes. [[1]](diffhunk://#diff-a3e55cc39b3bee727fc6e47e2ae152ad1ab810185ea756c3654b8c781f792bfdR15) [[2]](diffhunk://#diff-a3e55cc39b3bee727fc6e47e2ae152ad1ab810185ea756c3654b8c781f792bfdR30-R38)
* Updated the tray menu to conditionally show an "Upgrade to Pro" menu item for non-Pro users, which opens the plans page when clicked.