### PR TITLE
Fixes blank screen if the user chooses to Connect Now during onboarding

### DIFF
--- a/lib/features/macos_extension/macos_extension_dialog.dart
+++ b/lib/features/macos_extension/macos_extension_dialog.dart
@@ -37,9 +37,11 @@ class _MacOSExtensionDialogState extends ConsumerState<MacOSExtensionDialog> {
       }
       if (systemExtensionStatus.status == SystemExtensionStatus.installed ||
           systemExtensionStatus.status == SystemExtensionStatus.activated) {
-        appLogger.info(
-            "System Extension is installed and activated. Closing dialog.");
-        appRouter.pop();
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          appLogger.info(
+              "System Extension is installed and activated. Closing dialog.");
+          appRouter.pop();
+        });
       }
       return null;
     }, [systemExtensionStatus.status]);

--- a/lib/features/onboarding/onboarding.dart
+++ b/lib/features/onboarding/onboarding.dart
@@ -26,13 +26,17 @@ class _OnboardingState extends ConsumerState<Onboarding> {
 
     void onboardingCompleted() {
       ref.read(appSettingProvider.notifier).setOnboardingCompleted(true);
+      final shouldShowExtensionDialog =
+          appSetting.showSplashScreen && PlatformUtils.isMacOS;
       appRouter.pop();
-      if (appSetting.showSplashScreen && PlatformUtils.isMacOS) {
+      if (shouldShowExtensionDialog) {
         appLogger.info("Showing System Extension Dialog");
-        appRouter.push(const MacOSExtensionDialog());
+        // Defer the push to the next frame to avoid calling setState during build
+        WidgetsBinding.instance.addPostFrameCallback((_) {
+          appRouter.push(const MacOSExtensionDialog());
+        });
         // User has seen dialog, do not show again
         appLogger.info("Setting showSplashScreen to false");
-
         ref.read(appSettingProvider.notifier).setSplashScreen(false);
         return;
       }
@@ -120,7 +124,6 @@ class _OnboardingState extends ConsumerState<Onboarding> {
                 label: 'skip_connect_now'.i18n,
                 textColor: AppColors.gray9,
                 onPressed: () {
-                  appRouter.pop();
                   onboardingCompleted();
                 },
               )
@@ -243,14 +246,16 @@ class _OnboardingState extends ConsumerState<Onboarding> {
     final routeMode =
         ref.watch(appSettingProvider.select((value) => value.routingMode));
     useEffect(() {
-      final routeMode =
-      ref.read(appSettingProvider.select((v) => v.routingMode));
+      Future(() {
+        final routeMode =
+            ref.read(appSettingProvider.select((v) => v.routingMode));
 
-      if (routeMode == RoutingMode.full) {
-        ref
-            .read(appSettingProvider.notifier)
-            .setRoutingMode(RoutingMode.smart);
-      }
+        if (routeMode == RoutingMode.full) {
+          ref
+              .read(appSettingProvider.notifier)
+              .setRoutingMode(RoutingMode.smart);
+        }
+      });
 
       return null;
     }, const []);


### PR DESCRIPTION
See https://wdynhnkxvsdx.slack.com/archives/C04T8M4AB1Q/p1770411785853549

This pull request improves the user experience and stability of the onboarding and system extension dialogs, particularly on macOS. The main focus is on deferring navigation actions to the next frame to prevent calling navigation or state changes during widget builds, which can cause runtime errors or unexpected behavior.

**Improvements to navigation and dialog handling:**

* Defers the closing of the system extension dialog until the next frame after detecting the extension is installed and activated, preventing navigation during the build process (`macos_extension_dialog.dart`).
* Defers the presentation of the macOS extension dialog until the next frame after onboarding is completed, ensuring navigation actions are not performed during build (`onboarding.dart`).
* Removes redundant `appRouter.pop()` call before calling `onboardingCompleted()` to streamline the onboarding completion logic (`onboarding.dart`).

**Stability improvements in effect hooks:**

* Wraps routing mode logic in a microtask using `Future(() { ... })` to ensure it runs after the current build, avoiding side effects during widget construction (`onboarding.dart`). [[1]](diffhunk://#diff-51e3892197bcc08a723c4517156186cf9d272c895680713c012d8e3a9ce0fe6bR249) [[2]](diffhunk://#diff-51e3892197bcc08a723c4517156186cf9d272c895680713c012d8e3a9ce0fe6bR258)