### PR TITLE
re-enable trace logging as default

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -98,7 +98,7 @@ class AppDelegate: FlutterAppDelegate {
     opts.dataDir = FilePath.dataDirectory.relativePath
     opts.logDir = FilePath.logsDirectory.relativePath
     opts.deviceid = ""
-    opts.logLevel = "debug"
+    opts.logLevel = "trace"
     opts.telemetryConsent = FilePath.isTelemetryEnabled()
     opts.locale = Locale.current.identifier
     appLogger.info(


### PR DESCRIPTION
Set default log level to trace on macOS.