### PR TITLE
Fix for closing TUN on Android

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -54,6 +54,22 @@ class LanternVpnService :
 
     private var mInterface: ParcelFileDescriptor? = null
 
+    /**
+     * Safely close the TUN interface file descriptor.
+     * Synchronized to prevent double-close from concurrent callers
+     * (onDestroy, postServiceClose, doStopVPN can all race).
+     */
+    @Synchronized
+    private fun closeTunInterface() {
+        try {
+            mInterface?.close()
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "Error closing TUN interface", e)
+        } finally {
+            mInterface = null
+        }
+    }
+
     // Create a CoroutineScope tied to the service's lifecycle.
     // SupervisorJob ensures that failure in one child doesn't cancel the whole scope.
     private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -124,6 +140,11 @@ class LanternVpnService :
 
     override fun onDestroy() {
         try {
+            // Close TUN fd synchronously BEFORE cancelling scope to prevent orphaned TUN.
+            // Without this, destroy() -> doStopVPN() launches a coroutine that gets
+            // immediately cancelled by serviceScope.cancel(), leaving the TUN open and
+            // routing all traffic into a black hole.
+            closeTunInterface()
             destroy()
         } finally {
             serviceScope.cancel()
@@ -146,8 +167,7 @@ class LanternVpnService :
 
     override fun postServiceClose() {
         AppLogger.i(TAG, "postServiceClose called")
-        mInterface = null
-
+        closeTunInterface()
     }
 
     override fun restartService() {
@@ -263,8 +283,7 @@ class LanternVpnService :
         VpnStatusManager.postVPNStatus(VPNStatus.Disconnecting)
         serviceScope.launch {
             try {
-                mInterface?.close()
-                mInterface = null
+                closeTunInterface()
                 runCatching { Mobile.stopVPN() }
                     .onFailure { e -> AppLogger.e(TAG, "Mobile.stopVPN() failed", e) }
 


### PR DESCRIPTION
Fixes https://github.com/getlantern/engineering/issues/2997

This pull request improves the reliability and safety of shutting down the VPN service by adding a dedicated, synchronized method for closing the TUN interface file descriptor. This change helps prevent resource leaks and potential networking issues caused by the TUN interface remaining open due to race conditions during service shutdown.

Resource management and shutdown improvements:

* Added a new `closeTunInterface` method to safely and synchronously close the TUN interface file descriptor, ensuring it is not closed multiple times from concurrent shutdown paths.
* Updated `onDestroy`, `postServiceClose`, and `doStopVPN` to use the new `closeTunInterface` method instead of directly closing or nullifying `mInterface`, preventing orphaned TUN interfaces and possible routing issues. [[1]](diffhunk://#diff-a400f0e30f6722821b76288490c3f168bfdf06d313fbeca0a1342f81c4582166R143-R147) [[2]](diffhunk://#diff-a400f0e30f6722821b76288490c3f168bfdf06d313fbeca0a1342f81c4582166L149-R170) [[3]](diffhunk://#diff-a400f0e30f6722821b76288490c3f168bfdf06d313fbeca0a1342f81c4582166L266-R286)