### PR TITLE
Cleaned up stopping VPN on Windows

### DIFF
--- a/lantern-core/wintunmgr/service_windows.go
+++ b/lantern-core/wintunmgr/service_windows.go
@@ -143,6 +143,7 @@ func (s *Service) Start(ctx context.Context) error {
 		conn, err := ln.Accept()
 		if err != nil {
 			if ctx.Err() != nil {
+				s.shutdown()
 				return nil
 			}
 			continue
@@ -150,6 +151,18 @@ func (s *Service) Start(ctx context.Context) error {
 		connID := randID("c_", 6)
 		slog.Debug("Service accept", "conn_id", connID)
 		go s.handleConn(ctx, conn, token, connID)
+	}
+}
+
+// shutdown cleanly stops any running VPN tunnel and closes the IPC server
+// during service shutdown.
+func (s *Service) shutdown() {
+	slog.Info("Service shutting down, stopping VPN and IPC")
+	if err := vpn_tunnel.StopVPN(); err != nil {
+		slog.Error("Error stopping VPN during service shutdown", "error", err)
+	}
+	if err := vpn_tunnel.CloseIPC(); err != nil {
+		slog.Error("Error closing IPC during service shutdown", "error", err)
 	}
 }
 
@@ -353,15 +366,13 @@ func (s *Service) dispatch(ctx context.Context, r *Request) *Response {
 		return &Response{ID: r.ID, Result: map[string]any{"started": true}}
 
 	case common.CmdStopTunnel:
-		go func() {
-			events.Emit(ipc.StatusUpdateEvent{Status: ipc.Disconnecting})
-			if err := vpn_tunnel.StopVPN(); err != nil {
-				slog.Error("Error stopping service", "error", err)
-				events.Emit(ipc.StatusUpdateEvent{Status: ipc.ErrorStatus, Error: err})
-			} else {
-				events.Emit(ipc.StatusUpdateEvent{Status: ipc.Disconnected})
-			}
-		}()
+		events.Emit(ipc.StatusUpdateEvent{Status: ipc.Disconnecting})
+		if err := vpn_tunnel.StopVPN(); err != nil {
+			slog.Error("Error stopping service", "error", err)
+			events.Emit(ipc.StatusUpdateEvent{Status: ipc.ErrorStatus, Error: err})
+			return rpcErr(r.ID, "stop_error", err.Error())
+		}
+		events.Emit(ipc.StatusUpdateEvent{Status: ipc.Disconnected})
 		return &Response{ID: r.ID, Result: map[string]any{"stopped": true}}
 
 	case common.CmdIsVPNRunning:


### PR DESCRIPTION
From Claude Code -- will need testing.

```
  1. CmdStopTunnel dispatch (line 368-376) — Made synchronous

  Previously fired vpn_tunnel.StopVPN() in a goroutine and immediately returned "stopped": true. Now it runs synchronously so the Dart client's disconnect() call actually waits for the VPN to
  stop before returning. The Go-side vpn.Disconnect() already has a 10-second internal timeout, so this won't hang.

  2. shutdown() method (lines 157-167) — New

  Explicitly calls vpn_tunnel.StopVPN() and vpn_tunnel.CloseIPC() during service shutdown. Previously neither was called — the service just cancelled the context and closed the pipe listener.

  3. Start() exit path (line 146) — Calls shutdown() on context cancellation

  When the Windows SCM sends Stop/Shutdown, the context is cancelled, the pipe listener closes, and ln.Accept() fails. Now s.shutdown() is called before returning, ensuring the VPN tunnel and
  IPC server are properly cleaned up even if the Dart client didn't send a CmdStopTunnel first (e.g., if the app crashed or the system is shutting down).
```