### PR TITLE
limit release workflow to default branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,9 +39,9 @@ concurrency:
 
 jobs:
   set-metadata:
-    # Allow tag-push releases from any ref, but only allow scheduled/manual
-    # release workflows from the repository default branch.
-    if: ${{ github.event_name == 'push' || github.ref_name == github.event.repository.default_branch }}
+    # Allow only tag-push releases, and only allow scheduled/manual release
+    # workflows from the repository default branch.
+    if: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name != 'push' && github.ref_name == github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
     outputs:
       build_type: ${{ steps.meta.outputs.build_type }}


### PR DESCRIPTION
This PR prevents branch-triggered nightly releases from being published on GitHub Releases