### PR TITLE
delete old nightly releases to unpollute our release page

### DIFF
--- a/.github/workflows/release-cleanup.yml
+++ b/.github/workflows/release-cleanup.yml
@@ -4,10 +4,6 @@
 name: Release cleanup
 
 on:
-  push:
-    branches:
-      - jay/release-cleanup  # TODO: remove after testing
-
   schedule:
     - cron: "30 3 * * *"
 


### PR DESCRIPTION
Deletes old (+7 days) nightly builds from the "releases" page.
- tags are kept
- builds stay in S3
- now we always have an `internal` or `beta` or production build on the front page.