### PR TITLE
temp allow jay/signpath to build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,8 @@ concurrency:
 jobs:
   set-metadata:
     # Allow only tag-push releases, and only allow scheduled/manual release
-    # workflows from the repository default branch.
-    if: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name != 'push' && github.ref_name == github.event.repository.default_branch) }}
+    # workflows from the repository default branch (or jay/signpath for testing).
+    if: ${{ startsWith(github.ref, 'refs/tags/') || (github.event_name != 'push' && (github.ref_name == github.event.repository.default_branch || github.ref_name == 'jay/signpath')) }}
     runs-on: ubuntu-latest
     outputs:
       build_type: ${{ steps.meta.outputs.build_type }}


### PR DESCRIPTION
Temporary testing allowance that will be reverted with the merge of Windows build:
- https://github.com/getlantern/lantern/pull/8443