### PR TITLE
Storekit-v2 version radiance.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260227010202-aaebc26205fc
+	github.com/getlantern/radiance v0.0.0-20260303063111-5f0e03f5e307
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.40.0

--- a/go.sum
+++ b/go.sum
@@ -242,8 +242,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YLAuT8r51ApR5z0d8/qjhHu3TW+divQ2C98Ac=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
-github.com/getlantern/radiance v0.0.0-20260227010202-aaebc26205fc h1:HkDYo2wT0zIggUZIsXYaxc++4eprJOARRPe5aEILDOw=
-github.com/getlantern/radiance v0.0.0-20260227010202-aaebc26205fc/go.mod h1:nkeBEjB0/Kfh02W8LAHnLhzSHfu0Aj2ID83EZBe2Jiw=
+github.com/getlantern/radiance v0.0.0-20260303063111-5f0e03f5e307 h1:ZbpA8SYPuSq8eRqVBqrXTv5epXDkmAWdsJtS5xHdZPM=
+github.com/getlantern/radiance v0.0.0-20260303063111-5f0e03f5e307/go.mod h1:nkeBEjB0/Kfh02W8LAHnLhzSHfu0Aj2ID83EZBe2Jiw=
 github.com/getlantern/samizdat v0.0.2 h1:PkMu6jsfUz7DLZUH2xh548XfzgPASmq5CajZyUKj/9Y=
 github.com/getlantern/samizdat v0.0.2/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -187,7 +187,7 @@ SPEC CHECKSUMS:
   flutter_inappwebview_ios: 6f63631e2c62a7c350263b13fa5427aedefe81d4
   flutter_local_notifications: ff50f8405aaa0ccdc7dcfb9022ca192e8ad9688f
   flutter_timezone: ac3da59ac941ff1c98a2e1f0293420e020120282
-  in_app_purchase_storekit: a1ce04056e23eecc666b086040239da7619cd783
+  in_app_purchase_storekit: 2342c0a5da86593124d08dd13d920f39a52b273a
   integration_test: 252f60fa39af5e17c3aa9899d35d908a0721b573
   mobile_scanner: 77265f3dc8d580810e91849d4a0811a90467ed5e
   ObjectBox: a60820ec1c903702350585d8cc99c1268c99e688

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -872,13 +872,13 @@ packages:
     source: hosted
     version: "1.4.0"
   in_app_purchase_storekit:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
       name: in_app_purchase_storekit
-      sha256: "6ce1361278cacc0481508989ba419b2c9f46a2b0dc54b3fe54f5ee63c2718fef"
+      sha256: "2f1a1db44798158076ced07d401b349880dd24a29c7c50a1b1a0de230b7f2f62"
       url: "https://pub.dev"
     source: hosted
-    version: "0.3.22+1"
+    version: "0.4.8"
   installed_apps:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,10 +21,6 @@ version: 9.0.3+91
 environment:
   sdk: ^3.6.0
   flutter: 3.35.6
-
-dependency_overrides:
-  in_app_purchase_storekit: 0.3.22+1
-
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
 # consider running `flutter pub upgrade --major-versions`. Alternatively,


### PR DESCRIPTION
This pull request includes minor dependency updates and cleanup. The most notable changes are:

Dependency updates:

* Updated the `github.com/getlantern/radiance` Go module to a newer version in `go.mod`.

Dependency cleanup:

* Removed the `dependency_overrides` section for `in_app_purchase_storekit` from `pubspec.yaml`, indicating that the override is no longer needed.