### PR TITLE
Fix macOS VPN tunnel deadlock in setTunnelNetworkSettings

### DIFF
--- a/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
@@ -232,7 +232,7 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
 
     networkSettings = settings
     appLogger.info("Setting tunnel network settings to \(settings)...")
-    try self.setTunnelNetworkSettings(settings)
+    try await tunnel.setTunnelNetworkSettings(settings)
 
     appLogger.info("Accessing the socket file descriptor...")
     if let tunFd = tunnel.packetFlow.value(forKeyPath: "socket.fileDescriptor") as? Int32 {
@@ -502,23 +502,4 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     nil
   }
 
-  public func setTunnelNetworkSettings(_ networkSettings: NEPacketTunnelNetworkSettings?) throws {
-    let sem = DispatchSemaphore(value: 0)
-    var systemErr: Error?
-
-    self.tunnel.setTunnelNetworkSettings(networkSettings) { error in
-      systemErr = error
-      sem.signal()
-    }
-
-    let result = sem.wait(timeout: .now() + 5)
-    if result == .timedOut {
-      appLogger.error("(lantern-tunnel) setTunnelNetworkSettings timed out after 5s")
-      throw NSError(
-        domain: "lantern-tunnel",
-        code: 1,
-        userInfo: [NSLocalizedDescriptionKey: "setTunnelNetworkSettings timed out"]
-      )
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- Fixed a deadlock in the macOS PacketTunnel extension that caused VPN startup to fail with `setTunnelNetworkSettings timed out after 5s`
- Replaced the semaphore-based synchronous wrapper with `try await tunnel.setTunnelNetworkSettings(settings)`, matching the iOS implementation
- Removed the unused deadlock-prone `setTunnelNetworkSettings` wrapper method

## Root Cause
During VPN startup, the call chain was:

1. System calls `startTunnel` on the provider's internal serial queue
2. `startVPN()` → `MobileStartVPN()` blocks the cooperative thread while Go starts the tunnel
3. Go calls back `openTun()` → `openTunAsync()` → semaphore-based `setTunnelNetworkSettings`
4. Apple's `setTunnelNetworkSettings` dispatches its completion handler on the provider's internal queue — which is blocked waiting for `startTunnel` to return
5. **Deadlock**: `startTunnel` can't return until Go finishes, Go can't finish until `setTunnelNetworkSettings` completes, and `setTunnelNetworkSettings` can't complete because its completion handler queue is blocked

The iOS code already uses `try await` (async) instead of a semaphore, avoiding this issue entirely.

## Test plan
- [ ] Build and run on macOS
- [ ] Toggle VPN on and verify it connects successfully
- [ ] Verify tunnel is actually running (auto server location resolves)
- [ ] Verify VPN disconnect works cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)