### PR TITLE
add retry to gh to ensure that we don't keep failed releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,7 +619,22 @@ jobs:
           else
             echo "Build failed or cancelled - cleaning up draft release"
           fi
-          gh release delete "$RELEASE_TAG" --yes || true
+
+          attempt=0
+          max_retries=5
+          while [ "$attempt" -lt "$max_retries" ]; do
+            attempt=$((attempt + 1))
+            echo "Deleting release $RELEASE_TAG (attempt $attempt/$max_retries)..."
+            if gh release delete "$RELEASE_TAG" --yes --cleanup-tag 2>&1; then
+              echo "Release $RELEASE_TAG deleted"
+              break
+            fi
+            if [ "$attempt" -eq "$max_retries" ]; then
+              echo "Failed to delete release after $max_retries attempts"
+              exit 1
+            fi
+            sleep 3
+          done
 
       - name: Report failure (cleanup disabled)
         if: |


### PR DESCRIPTION
A failed build is supposed to delete the release and cleanup the tag to allow a retry.

However, [this build](https://github.com/getlantern/lantern/actions/runs/22911734945/job/66495614526) didn't cleanup. This PR makes changes to check (and retry) on a `gh` CLI error (which, regrettably, we've seen lots of 500s of the `gh` CLI while running _inside_ a github runner lately).

