### PR TITLE
fix single platform release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -274,7 +274,7 @@ jobs:
       !cancelled() &&
       needs.set-metadata.result == 'success' &&
       needs.release-create.result == 'success' &&
-      needs.release-approval.result != 'failure' &&
+      (needs.release-approval.result == 'success' || needs.release-approval.result == 'skipped') &&
       (needs.set-metadata.outputs.platform == 'all' || contains(needs.set-metadata.outputs.platform, 'ios'))
     with:
       version: ${{ needs.set-metadata.outputs.version }}
@@ -289,7 +289,7 @@ jobs:
       !cancelled() &&
       needs.set-metadata.result == 'success' &&
       needs.release-create.result == 'success' &&
-      needs.release-approval.result != 'failure' &&
+      (needs.release-approval.result == 'success' || needs.release-approval.result == 'skipped') &&
       (needs.set-metadata.outputs.platform == 'all' || contains(needs.set-metadata.outputs.platform, 'android'))
     with:
       version: ${{ needs.set-metadata.outputs.version }}


### PR DESCRIPTION
fixes errors from https://github.com/getlantern/lantern/actions/runs/23199508060/job/67417524980
- handles platform suffix correctly
- release-notify no longer blocks
- don't try to upload when no builds succeed
