### PR TITLE
Fix ldflags path for version injection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LANTERN_LIB_NAME := liblantern
 LANTERN_CORE := lantern-core
 RADIANCE_REPO := github.com/getlantern/radiance
 FFI_DIR := $(LANTERN_CORE)/ffi
-EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.constants.AppVersion=$(VERSION)'
+EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.AppVersion=$(VERSION)'
 
 DARWIN_APP_NAME := $(CAPITALIZED_APP).app
 DARWIN_LIB := $(LANTERN_LIB_NAME).dylib


### PR DESCRIPTION
## Summary
- Fix ldflags path from `common.constants.AppVersion` to `common.AppVersion`

## Context
`AppVersion` lives in package `common`, not a sub-package `constants`. The incorrect path caused Go to silently ignore the `-X` flag, so builds never had the version injected — every release reported `9.0.1` (the hardcoded default) regardless of actual version.

This is why SigNoz shows all 9.x traffic as `9.0.1` in both `X-Lantern-Version` and `X-Lantern-App-Version` headers.

**Companion PR**: getlantern/radiance#358 removes the `Version` const and switches all code to use the ldflags-injected `AppVersion` var.

## Test plan
- [ ] Build with `VERSION=9.0.14 make desktop-lib` and verify the binary reports the correct version

🤖 Generated with [Claude Code](https://claude.com/claude-code)