### PR TITLE
Upgrade radiance to latest with version fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,8 +23,9 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 require (
 	github.com/Microsoft/go-winio v0.6.2
 	github.com/alecthomas/assert/v2 v2.3.0
+	github.com/getlantern/common v1.2.1-0.20260224184656-5aefb9c21c85
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260318132022-04e4c564c823
+	github.com/getlantern/radiance v0.0.0-20260318170544-725ad379e90b
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.40.0
@@ -172,7 +173,6 @@ require (
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
 	github.com/getlantern/amp v0.0.0-20260305201851-782bc8045e58 // indirect
 	github.com/getlantern/appdir v0.0.0-20250324200952-507a0625eb01 // indirect
-	github.com/getlantern/common v1.2.1-0.20260224184656-5aefb9c21c85 // indirect
 	github.com/getlantern/dnstt v0.0.0-20260112160750-05100563bd0d // indirect
 	github.com/getlantern/fronted v0.0.0-20260316001628-14e5f21104b5 // indirect
 	github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 // indirect

--- a/go.sum
+++ b/go.sum
@@ -277,10 +277,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YLAuT8r51ApR5z0d8/qjhHu3TW+divQ2C98Ac=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
-github.com/getlantern/radiance v0.0.0-20260318124306-1e77cc653668 h1:KnSUKcpA3nVf/Xd4gnRAjb5NIJGwUFtC59pMgqz4NlE=
-github.com/getlantern/radiance v0.0.0-20260318124306-1e77cc653668/go.mod h1:QG9fHG/GresYdPa3Tr5gYeg8yDkE+crdyvg6KXChQdQ=
-github.com/getlantern/radiance v0.0.0-20260318132022-04e4c564c823 h1:DaqyTQI7o4pp/Wgr87k5C7CYrZBTZxDdYKWDjeQBWiw=
-github.com/getlantern/radiance v0.0.0-20260318132022-04e4c564c823/go.mod h1:QG9fHG/GresYdPa3Tr5gYeg8yDkE+crdyvg6KXChQdQ=
+github.com/getlantern/radiance v0.0.0-20260318170544-725ad379e90b h1:TYLWfqi5L3ijG0TdonpA4M0kgzWRKgndy7OIUqn8WMs=
+github.com/getlantern/radiance v0.0.0-20260318170544-725ad379e90b/go.mod h1:QG9fHG/GresYdPa3Tr5gYeg8yDkE+crdyvg6KXChQdQ=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60 h1:m9eXjDK9vllbVH467+QXbrxUFFM9Yp7YJ90wZLw4dwU=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## Summary
- Updates `getlantern/radiance` from `04e4c564c823` to `725ad379e90b`
- Promotes `getlantern/common` from indirect to direct dependency

## Test plan
- [ ] Verify the app builds on all platforms
- [ ] Confirm VPN connects and version is reported correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)