### PR TITLE
fix: use github.run_number for monotonic sysext build numbers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -170,6 +170,11 @@ jobs:
         shell: bash
         env:
           RELEASE_TAG: ${{ steps.meta.outputs.release_tag }}
+          # github.run_number is monotonically increasing across all workflow
+          # runs and never resets when the base version changes. This is
+          # critical for macOS system extensions, which compare CFBundleVersion
+          # numerically and refuse to upgrade to a lower build number.
+          BUILD_NUMBER: ${{ github.run_number }}
         run: |
           # Strip 'v' prefix if present
           VERSION="${RELEASE_TAG#v}"
@@ -177,13 +182,11 @@ jobs:
           # Extract base semver (strip suffixes like -beta, -nightly-...)
           BASE_VERSION=$(./scripts/ci/version.sh extract "$VERSION")
 
-          CURRENT_BUILD=$(grep '^version:' pubspec.yaml | sed -E 's/^version: [0-9]+\.[0-9]+\.[0-9]+\+([0-9]+).*/\1/')
-          BUILD_NUMBER=$((CURRENT_BUILD + 1))
           FULL_VERSION="${BASE_VERSION}+${BUILD_NUMBER}"
 
           echo "Setting pubspec version: $FULL_VERSION"
           echo "  Base version: $BASE_VERSION"
-          echo "  Build number: $BUILD_NUMBER"
+          echo "  Build number: $BUILD_NUMBER (github.run_number)"
 
           sed -i.bak -E "s/^version:.*/version: ${FULL_VERSION}/" pubspec.yaml
           grep '^version:' pubspec.yaml


### PR DESCRIPTION
## Summary
- Replaces the pubspec.yaml-derived build number with `github.run_number` in the release workflow
- `github.run_number` is monotonically increasing across all workflow runs and never resets when the base version changes
- This prevents the macOS system extension build number regression where 9.0.18 had build number 95 but 9.0.3 had 155, causing macOS to silently refuse the sysext upgrade

## Root cause
The previous logic read the `+N` suffix from pubspec.yaml and incremented it:
```bash
CURRENT_BUILD=$(grep '^version:' pubspec.yaml | sed -E '...')
BUILD_NUMBER=$((CURRENT_BUILD + 1))
```
When the base version changed from 9.0.3 → 9.0.15, the build number was manually reset to 94 (commit b2dcb4519). Subsequent nightlies incremented from there (95, 96...), all below the old high-water mark of 155. macOS compares `CFBundleVersion` strictly and won't upgrade a system extension to a lower number.

## Fix
Use `github.run_number` instead — it's a GitHub-managed counter that:
- Monotonically increases across all runs of this workflow
- Never resets on version bumps or branch changes
- Requires no commit-back step to persist state
- Is already well above 155, so existing users will immediately get a valid upgrade

## Test plan
- [ ] Trigger a workflow_dispatch nightly build and verify the pubspec version uses `github.run_number` as the build number
- [ ] Confirm the resulting macOS sysext `CFBundleVersion` is higher than 155
- [ ] Verify Android/iOS builds also pick up the correct build number from the uploaded pubspec artifact

Fixes https://github.com/getlantern/engineering/issues/3091

🤖 Generated with [Claude Code](https://claude.com/claude-code)