### PR TITLE
Update radiance: continuous URL tests for bandit callbacks

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260224184656-5aefb9c21c85
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260324154403-6c425327102b
+	github.com/getlantern/radiance v0.0.0-20260324185216-5d134509713d
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YLAuT8r51ApR5z0d8/qjhHu3TW+divQ2C98Ac=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
-github.com/getlantern/radiance v0.0.0-20260324154403-6c425327102b h1:Rl7D7DjBDxz1p+u9f53MavQFQabh4rdbhMA5aWRARr8=
-github.com/getlantern/radiance v0.0.0-20260324154403-6c425327102b/go.mod h1:bqqrKshKfTPIEOjsedL9p1N5bZBRYTZ2UeUZMtgFWWY=
+github.com/getlantern/radiance v0.0.0-20260324185216-5d134509713d h1:Pf0CW29vHudf3JHCmFh8A76HXZcJUGyNgBlul1MdyBI=
+github.com/getlantern/radiance v0.0.0-20260324185216-5d134509713d/go.mod h1:bqqrKshKfTPIEOjsedL9p1N5bZBRYTZ2UeUZMtgFWWY=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60 h1:m9eXjDK9vllbVH467+QXbrxUFFM9Yp7YJ90wZLw4dwU=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## Summary
Updates radiance to latest main with continuous URL testing:

- `RunURLTests` fires on every config update (replaces the run-once `PreStartTests`)
- Skips when VPN tunnel is active (tunnel's `CheckOutbounds` handles it)
- Ensures bandit callbacks flow continuously even when the VPN is off
- Proper cleanup via `Unsubscribe` on shutdown

## Test plan
- [x] `go vet ./lantern-core/...` passes
- [ ] Build client, verify bandit callbacks in SigNoz without VPN active

🤖 Generated with [Claude Code](https://claude.com/claude-code)