### PR TITLE
chore: bump radiance for bandit distributed tracing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260325181816-33f69c725899
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260326151852-020898b9b028
+	github.com/getlantern/radiance v0.0.0-20260326160312-80e8b51cccce
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YLAuT8r51ApR5z0d8/qjhHu3TW+divQ2C98Ac=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
-github.com/getlantern/radiance v0.0.0-20260326151852-020898b9b028 h1:LXR1YBRvbrhhc7/G8yBSzB4oNJ59vbf8ZIUHbiednEk=
-github.com/getlantern/radiance v0.0.0-20260326151852-020898b9b028/go.mod h1:jn8+Y7vnyULW+8DX1iDp3qKVBa81EUWFVDvMvkaZrQE=
+github.com/getlantern/radiance v0.0.0-20260326160312-80e8b51cccce h1:ARU8+/fVmcz2AJY2SqsrqWV0BHMyY6nmoHGmvWD4PzQ=
+github.com/getlantern/radiance v0.0.0-20260326160312-80e8b51cccce/go.mod h1:jn8+Y7vnyULW+8DX1iDp3qKVBa81EUWFVDvMvkaZrQE=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60 h1:m9eXjDK9vllbVH467+QXbrxUFFM9Yp7YJ90wZLw4dwU=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## Summary
Bump radiance to include [radiance#380](https://github.com/getlantern/radiance/pull/380): distributed tracing for the bandit config → URL test → callback flow.

Adds `radiance.config_received` and `radiance.url_tests_complete` spans linked to the API's bandit trace, enabling end-to-end trace visibility in SigNoz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)