### PR TITLE
use test policy for nightly buildsn and expose option for workflow dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: "linux"
+      use_test_signing:
+        description: "Use SignPath test signing policy (instead of production)"
+        required: false
+        type: boolean
+        default: false
       cleanup_on_failure:
         description: "Delete draft release on failure"
         required: false
@@ -254,7 +259,7 @@ jobs:
       build_type: ${{ needs.set-metadata.outputs.build_type }}
       installer_base_name: ${{ needs.set-metadata.outputs.installer_base_name }}
       enable_ip_check: ${{ needs.set-metadata.outputs.build_type == 'nightly' }}
-      use_self_signed_cert: ${{ needs.set-metadata.outputs.build_type == 'nightly' }}
+      use_self_signed_cert: ${{ github.event.inputs.use_test_signing == 'true' || needs.set-metadata.outputs.build_type == 'nightly' }}
 
   build-linux:
     needs: [set-metadata, release-create, release-approval]


### PR DESCRIPTION
relates to getlantern/engineering#3109

This moves from prod policy to test policy, but does *not* actually reduce total org-wide artifact upload quotas.