### PR TITLE
Update radiance to latest main (idle timeout fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260325181816-33f69c725899
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260326160312-80e8b51cccce
+	github.com/getlantern/radiance v0.0.0-20260327013217-5c2f58909206
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0
@@ -172,7 +172,7 @@ require (
 	github.com/getlantern/fronted v0.0.0-20260325003030-cb5041ba1538 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae // indirect
 	github.com/getlantern/kindling v0.0.0-20260319225424-4736208dd171 // indirect
-	github.com/getlantern/lantern-box v0.0.51 // indirect
+	github.com/getlantern/lantern-box v0.0.52 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260319225424-4736208dd171 h1:UEjX+Gg+T6oGVUbzHJ4JfLhlsIh8Wl8PmTXZYWGS43A=
 github.com/getlantern/kindling v0.0.0-20260319225424-4736208dd171/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
-github.com/getlantern/lantern-box v0.0.51 h1:ahneSAcd75m8jHqx9k85dghmboEhLp6NpjMtp1/zBcM=
-github.com/getlantern/lantern-box v0.0.51/go.mod h1:Luj0rLyuokADHg2B+eXlAdxVXYO+T5Reeds+hKuQkZA=
+github.com/getlantern/lantern-box v0.0.52 h1:3bDXuhKsfJly5nKBb/TcrwcWIsmFKKnRWYJfkIcvdcU=
+github.com/getlantern/lantern-box v0.0.52/go.mod h1:Luj0rLyuokADHg2B+eXlAdxVXYO+T5Reeds+hKuQkZA=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
@@ -259,8 +259,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YLAuT8r51ApR5z0d8/qjhHu3TW+divQ2C98Ac=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
-github.com/getlantern/radiance v0.0.0-20260326160312-80e8b51cccce h1:ARU8+/fVmcz2AJY2SqsrqWV0BHMyY6nmoHGmvWD4PzQ=
-github.com/getlantern/radiance v0.0.0-20260326160312-80e8b51cccce/go.mod h1:jn8+Y7vnyULW+8DX1iDp3qKVBa81EUWFVDvMvkaZrQE=
+github.com/getlantern/radiance v0.0.0-20260327013217-5c2f58909206 h1:CrYAd2nhyvGbTIVdFHdNdRriMk101lY6bQnAe8mebk8=
+github.com/getlantern/radiance v0.0.0-20260327013217-5c2f58909206/go.mod h1:gSq2a5hMCrREBj9wUrokogBkI7PeYWLb0f9C2J269bA=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60 h1:m9eXjDK9vllbVH467+QXbrxUFFM9Yp7YJ90wZLw4dwU=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## Summary

- Update `github.com/getlantern/radiance` to latest main (5c2f589)
- Also bumps `github.com/getlantern/lantern-box` v0.0.51 → v0.0.52 (transitive)

Picks up the fix for VPN losing all proxy routes after ~15min idle / wake from sleep. `MutableURLTest` now re-populates outbound groups on network interface changes (macOS wake), preventing the "missing supported outbound" failure.

Fixes getlantern/engineering#3115

## Test plan

- [x] `go build ./...` passes
- [x] `go mod tidy` clean
- [ ] Manual: connect VPN, sleep Mac >15min, wake — VPN should auto-recover

🤖 Generated with [Claude Code](https://claude.com/claude-code)