### PR TITLE
Update radiance to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260325181816-33f69c725899
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260327013217-5c2f58909206
+	github.com/getlantern/radiance v0.0.0-20260327103316-c566c18fed75
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 h1:JWH5BB2o0e
 github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175/go.mod h1:h3S9LBmmzN/xM+lwYZHE4abzTtCTtidKtG+nxZcCZX0=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YLAuT8r51ApR5z0d8/qjhHu3TW+divQ2C98Ac=
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
-github.com/getlantern/radiance v0.0.0-20260327013217-5c2f58909206 h1:CrYAd2nhyvGbTIVdFHdNdRriMk101lY6bQnAe8mebk8=
-github.com/getlantern/radiance v0.0.0-20260327013217-5c2f58909206/go.mod h1:gSq2a5hMCrREBj9wUrokogBkI7PeYWLb0f9C2J269bA=
+github.com/getlantern/radiance v0.0.0-20260327103316-c566c18fed75 h1:dR1yQ8sbkfZZP6JNT3pnFaO2BF0MkJPvOJq31CSesKA=
+github.com/getlantern/radiance v0.0.0-20260327103316-c566c18fed75/go.mod h1:gSq2a5hMCrREBj9wUrokogBkI7PeYWLb0f9C2J269bA=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60 h1:m9eXjDK9vllbVH467+QXbrxUFFM9Yp7YJ90wZLw4dwU=
 github.com/getlantern/samizdat v0.0.3-0.20260310125445-325cf1bd1b60/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## Summary
- Bumps radiance from `5c2f589` to `c566c18`
- Picks up outbound removal safety fix (only remove old outbounds when new ones successfully load)
- Adds distributed tracing support (bandit trace context extraction, url_tests_complete span)
- Populates all server locations in config for location picker
- Includes common bump for `PollIntervalSeconds` in ConfigResponse

## Test plan
- [ ] Verify config fetch succeeds and server locations are populated
- [ ] Verify outbound updates don't remove working proxies on partial failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)