### PR TITLE
Save user state

### DIFF
--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -75,16 +75,20 @@ class HomeNotifier extends _$HomeNotifier {
   void _applyUserData(UserResponse userData) {
     state = AsyncValue.data(userData);
 
-    if (!userData.legacyUserData.isPro) {
+    // Step 1: Sync all user fields to app settings first before any other logic.
+    final isPro = userData.legacyUserData.isPro;
+    final email = userData.legacyUserData.email.isEmpty
+        ? userData.id
+        : userData.legacyUserData.email;
+    appLogger.info('Syncing user data to app settings — isPro=$isPro email=$email');
+    ref.read(appSettingProvider.notifier)
+      ..togglePro(isPro)
+      ..setEmail(email);
+
+    // Step 2: Now run derived logic that depends on the stored settings.
+    if (!isPro) {
       resetServerLocation();
     }
-    String email;
-    if (userData.legacyUserData.email.isEmpty) {
-      email = userData.id;
-    } else {
-      email = userData.legacyUserData.email;
-    }
-    ref.read(appSettingProvider.notifier).setEmail(email);
     checkIfUserProAndDeviceIsAdded();
   }
 
@@ -143,9 +147,7 @@ class HomeNotifier extends _$HomeNotifier {
         .info("current device added for user ${user.legacyUserData.email}: "
             "$isDeviceAdded");
     if (isDeviceAdded) {
-      ref.read(appSettingProvider.notifier)
-        ..setUserLoggedIn(true)
-        ..setEmail(user.legacyUserData.email);
+      ref.read(appSettingProvider.notifier).setUserLoggedIn(true);
       appLogger.info(
         "User is Pro and device is added. Logging in automatically.",
       );


### PR DESCRIPTION
This pull request refactors how user data is synchronized with app settings in the `HomeNotifier` class to ensure that all user fields are updated before any dependent logic runs. It also simplifies the logic for setting the logged-in user's email.

**User data synchronization improvements:**

* The `_applyUserData` method now syncs all relevant user fields (`isPro` and `email`) to `appSettingProvider` before executing any logic that depends on these settings. This ensures consistency and prevents potential issues from stale settings.

**Simplification of login logic:**

* When marking a user as logged in after device addition, the code now only sets the logged-in status and no longer redundantly sets the email, as this is already handled in the initial sync.