### PR TITLE
Update radiance/kindling (race transport rewrite)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260325181816-33f69c725899
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260329011310-14ff884717de
+	github.com/getlantern/radiance v0.0.0-20260329145230-a19ebe6b9b4d
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0
@@ -171,7 +171,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260112160750-05100563bd0d // indirect
 	github.com/getlantern/fronted v0.0.0-20260325003030-cb5041ba1538 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae // indirect
-	github.com/getlantern/kindling v0.0.0-20260319225424-4736208dd171 // indirect
+	github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb // indirect
 	github.com/getlantern/lantern-box v0.0.54 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3N/usgEtUMQs8WBzvhKKOfBvHo+18pXgtpds=
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260319225424-4736208dd171 h1:UEjX+Gg+T6oGVUbzHJ4JfLhlsIh8Wl8PmTXZYWGS43A=
-github.com/getlantern/kindling v0.0.0-20260319225424-4736208dd171/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
+github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb h1:A92dC/E/HvkEb1r4tAwCFNlcMsGdqKe5GMmxeUFid9M=
+github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
 github.com/getlantern/lantern-box v0.0.54 h1:k6BVyaHChFzT5jjRi7F9EMYJazp4uir9WWQEp7L63as=
 github.com/getlantern/lantern-box v0.0.54/go.mod h1:whz/CEUuUG0y/+FifJdLiqbkFBuyoO8RFHIWtk27KZk=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260329011310-14ff884717de h1:yZ/lgoojzluDMRGwdeeqkDCzcOVJZGNsbYckjE0GmYQ=
-github.com/getlantern/radiance v0.0.0-20260329011310-14ff884717de/go.mod h1:GUjXNEYUstcix1lV2mNpsGCfpCnL2QVuWWdlyYKowwE=
+github.com/getlantern/radiance v0.0.0-20260329145230-a19ebe6b9b4d h1:wyCFSVKagzU/UQ5yOU6jOXdmk4gp8AdtPqZmTAEu7oI=
+github.com/getlantern/radiance v0.0.0-20260329145230-a19ebe6b9b4d/go.mod h1:oKOGrN0Z3UiFdcIyzD0wvjLkY3qDxfmVUrsTkjJ37kI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary
- Bumps `github.com/getlantern/radiance` and `github.com/getlantern/kindling` to latest
- Dependency-only change: `go.mod` and `go.sum`

### Upstream changes included
- **getlantern/kindling#30**: Rewrote race transport — fixes deadlock when transports are filtered, fixes response body leaks on retryable 4xx, eliminates global mutable logger/mutex, per-instance `*slog.Logger`
- **getlantern/radiance#387**: Adapts to kindling's new `(Kindling, error)` API, guards nil transports, thread-safe `HTTPClient()` lazy init

## Test plan
- [x] `go build ./...` clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)