### PR TITLE
Fix Android network blackout — call setUnderlyingNetworks on VPN start

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkMonitor.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkMonitor.kt
@@ -19,7 +19,7 @@ object DefaultNetworkMonitor {
 
     /**
      * Register a callback that fires whenever the default network changes.
-     * Used by [LanternVpnService] to call [VpnService.setUnderlyingNetworks].
+     * Used by [LanternVpnService] to call [android.net.VpnService.setUnderlyingNetworks].
      */
     fun setNetworkChangeCallback(callback: ((Network?) -> Unit)?) {
         networkChangeCallback = callback
@@ -39,6 +39,7 @@ object DefaultNetworkMonitor {
     }
 
     suspend fun stop() {
+        networkChangeCallback = null
         DefaultNetworkListener.stop(this)
     }
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -299,6 +299,11 @@ class LanternVpnService :
             }
         }.onFailure { e ->
             AppLogger.e(TAG, "Error in VPN operation ($errorCode)", e)
+            // Clear the network change callback to avoid leaking this service
+            // instance through the static DefaultNetworkMonitor singleton.
+            DefaultNetworkMonitor.setNetworkChangeCallback(null)
+            runCatching { runBlocking { DefaultNetworkMonitor.stop() } }
+                .onFailure { stopErr -> AppLogger.e(TAG, "DefaultNetworkMonitor.stop() failed in error path", stopErr) }
             VpnStatusManager.postVPNError(
                 errorCode = errorCode,
                 errorMessage = "Error in VPN operation",
@@ -332,10 +337,7 @@ class LanternVpnService :
             }
                 .onFailure { e -> AppLogger.e(TAG, "Mobile.stopVPN() failed", e) }
 
-            runCatching {
-                DefaultNetworkMonitor.setNetworkChangeCallback(null)
-                DefaultNetworkMonitor.stop()
-            }
+            runCatching { DefaultNetworkMonitor.stop() }
                 .onFailure { e -> AppLogger.e(TAG, "DefaultNetworkMonitor.stop() failed", e) }
         } catch (e: Exception) {
             AppLogger.e(TAG, "Error tearing down VPN tunnel", e)


### PR DESCRIPTION
## Summary

Fix the Android "no available network interface" bug that causes total network blackout on some devices (especially Android 10).

## Root Cause

`VpnService.setUnderlyingNetworks()` was never called. On Android 10+, `ConnectivityManager.getAllNetworks()` may return only the VPN network when the VPN hasn't declared its underlying physical networks. This causes:

1. sing-box's `NetworkManager` sees no physical interfaces
2. The `direct` outbound fails → domain fronting bootstrap breaks
3. No proxy connections are ever attempted
4. With `strict_route: true`, the TUN captures all traffic but has no working outbound → **total device network loss**

## Bug Reproduced on Emulator

Confirmed on Android 10 (API 29) emulator with Lantern 9.0.21 nightly:

| What | Result |
|------|--------|
| VPN status | Shows "Connected" ✅ |
| `setUnderlyingNetworks()` | Never called ❌ |
| `no available network interface` errors | **882 occurrences** ❌ |
| sing-box interface detection | Zero events ❌ |
| Data flowing | Zero bytes ❌ |
| Physical networks visible to OS | Yes (radio0, wlan0) |
| Physical networks visible to sing-box | No |

The VPN reports "Connected" but zero data flows — exactly matching user reports. `dumpsys connectivity` confirms the VPN has no underlying networks declared.

## Evidence from User Tickets

| Ticket | Device | Android | Symptom |
|--------|--------|---------|---------|
| [#171589](https://lantern.freshdesk.com/a/tickets/171589) | Vivo V2002A | 10 | 4,600 "no available network interface" errors in 21 seconds, phone loses all internet |
| [#171317](https://lantern.freshdesk.com/a/tickets/171317) | Xiaomi 2112123AC | 11 | VPN shows "Connected" but 0 bytes transferred, 538 interface errors |

## Changes

**`LanternVpnService.kt`**:
- Call `setUnderlyingNetworks(arrayOf(defaultNetwork))` after VPN start
- Register a callback to update underlying networks on WiFi/mobile switches
- Clean up callback on VPN stop and in the failure path

**`DefaultNetworkMonitor.kt`**:
- Add `networkChangeCallback` for the VPN service to subscribe to
- Clear callback defensively in `stop()` to prevent leaking service instances
- Fix missing `return` after successful `updateDefaultInterface` — the retry loop was calling it up to 10 times instead of once

## Test plan

- [x] Bug reproduced on Android 10 emulator — 882 "no available network interface" errors with nightly APK
- [x] `dumpsys connectivity` confirms VPN has no underlying networks declared
- [ ] Build APK with fix and verify errors disappear on same emulator
- [ ] Test WiFi → mobile switch with VPN active — verify underlying networks update
- [ ] Verify data flows after VPN connects (`bytesUsed > 0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)