### PR TITLE
update radiance: log outbound creation errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260325181816-33f69c725899
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260329145230-a19ebe6b9b4d
+	github.com/getlantern/radiance v0.0.0-20260331124105-88882a0aa9a2
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,10 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260327180314-a82a3a4c9755 h1:SHYzRc164yuYwyPDKnBFFlWzvT6/RIJuGPbOAY081Y4=
-github.com/getlantern/radiance v0.0.0-20260327180314-a82a3a4c9755/go.mod h1:tDaC3t6/EIC2c93iu259pl7rVaKiqjJ5vM5Z+Fksrkc=
-github.com/getlantern/radiance v0.0.0-20260329145230-a19ebe6b9b4d h1:wyCFSVKagzU/UQ5yOU6jOXdmk4gp8AdtPqZmTAEu7oI=
-github.com/getlantern/radiance v0.0.0-20260329145230-a19ebe6b9b4d/go.mod h1:oKOGrN0Z3UiFdcIyzD0wvjLkY3qDxfmVUrsTkjJ37kI=
+github.com/getlantern/radiance v0.0.0-20260331124105-88882a0aa9a2 h1:XEewR0UFYSUsX3zxoo+GwXT5WT9KDUK1GzvNQJfVdJA=
+github.com/getlantern/radiance v0.0.0-20260331124105-88882a0aa9a2/go.mod h1:oKOGrN0Z3UiFdcIyzD0wvjLkY3qDxfmVUrsTkjJ37kI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary
Updates radiance to include getlantern/radiance#388 — logs individual outbound creation errors that were previously silently swallowed.

## Context
Investigating why the bandit showed ~67% callback failure rate on staging. The client only tested 2 of 6 assigned proxies. The other 4 failed `CreateOutboundForGroup` every config cycle, but the error was invisible — `added=0` in debug logs was the only clue. With this update, each failed outbound gets a WARN log with the actual error (likely hex encoding or TLS config issue).

## Test plan
- [ ] Build and run client
- [ ] Trigger config fetch with new proxies
- [ ] Check logs for WARN "Failed to load outbound" with error details

🤖 Generated with [Claude Code](https://claude.com/claude-code)