### PR TITLE
Add AI-powered release notes generation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -456,6 +456,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.sha }}
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4

--- a/scripts/ci/generate-release-notes.sh
+++ b/scripts/ci/generate-release-notes.sh
@@ -17,6 +17,15 @@ RELEASE_TAG="${RELEASE_TAG:?RELEASE_TAG required}"
 BUILD_TYPE="${BUILD_TYPE:?BUILD_TYPE required}"
 GITHUB_SHA="${GITHUB_SHA:?GITHUB_SHA required}"
 
+# Verify jq is available (needed for JSON construction and response parsing)
+if ! command -v jq >/dev/null 2>&1; then
+  echo "Warning: jq not found, generating basic changelog" >&2
+  echo "## Changes"
+  echo ""
+  git log --oneline -50 | while read -r line; do echo "- $line"; done
+  exit 0
+fi
+
 # Find the previous release tag to determine the commit range
 find_previous_tag() {
   local current_tag="$1"
@@ -24,16 +33,16 @@ find_previous_tag() {
 
   case "$build_type" in
     production)
-      # Previous production tag (no suffix)
-      git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | grep -v "^${current_tag}$" | head -1
+      # Previous production tag, optionally with platform suffix
+      git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-(windows|macos|linux|android|ios))?$' | grep -Fvx "$current_tag" | head -1
       ;;
     beta)
-      # Previous beta or production tag
-      git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-beta)?$' | grep -v "^${current_tag}$" | head -1
+      # Previous beta or production tag, including optional platform suffix
+      git tag --sort=-version:refname | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+(-beta[0-9A-Za-z._-]*)?(-(windows|macos|linux|android|ios))?$' | grep -Fvx "$current_tag" | head -1
       ;;
     nightly)
       # Previous nightly, beta, or production tag
-      git tag --sort=-version:refname | grep -v "^${current_tag}$" | head -1
+      git tag --sort=-version:refname | grep -Fvx "$current_tag" | head -1
       ;;
   esac
 }
@@ -42,16 +51,10 @@ PREV_TAG=$(find_previous_tag "$RELEASE_TAG" "$BUILD_TYPE")
 if [[ -z "$PREV_TAG" ]]; then
   echo "Warning: No previous tag found, using last 50 commits" >&2
   GIT_LOG=$(git log --oneline -50)
-  COMMIT_RANGE="last 50 commits"
 else
   GIT_LOG=$(git log --oneline "${PREV_TAG}..${GITHUB_SHA}")
-  COMMIT_RANGE="${PREV_TAG}..${RELEASE_TAG}"
 fi
 
-# Get PR titles for richer context (merge commits reference PRs)
-PR_LIST=$(echo "$GIT_LOG" | grep -oE '#[0-9]+' | sort -u | head -20 || true)
-
-# Build the commit summary
 COMMIT_COUNT=$(echo "$GIT_LOG" | wc -l | tr -d ' ')
 
 # Collect dependency changes from sub-repos (radiance, lantern-box, etc.)


### PR DESCRIPTION
## Summary

Adds Claude-powered release notes generation to the CI release workflow. After builds complete, the git log between the previous release and the current one is sent to Claude Haiku for summarization into categorized, human-readable release notes.

## Example Output

For v9.0.20-ios (production):

> ## Bug Fixes
> - Fixed auto location UI that was stuck on "Fastest Server" after connecting
> - Fixed server rotation issues
> - Fixed iOS diagnostic log collection
>
> ## New Features
> - Added support for WATER protocol
>
> ## Improvements
> - Updated Radiance with bandit callback fixes and continuous URL testing
> - Upgraded Flutter to 3.41

## How it works

1. `generate-release-notes.sh` finds the previous release tag (by build type)
2. Extracts the git log between the two tags
3. Sends to Claude Haiku via the API for categorized summarization
4. Output is prepended to the existing download links in the GitHub Release
5. Falls back gracefully to a basic commit list if the API is unavailable

## Setup

Requires `ANTHROPIC_API_KEY` repo secret. Uses Haiku for speed and cost (~$0.001 per release).

## Test plan

- [x] Tested locally with `v9.0.20-ios` — generated clean categorized notes
- [x] Tested with `v9.0.21` nightly — handled single-commit range correctly
- [x] Tested without API key — falls back to basic changelog
- [ ] Test in CI with actual release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)