### PR TITLE
update radiance: fix IPC serialization (samizdat public_key loss)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260325181816-33f69c725899
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260331124105-88882a0aa9a2
+	github.com/getlantern/radiance v0.0.0-20260331161346-42ae3e04d881
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0
@@ -172,7 +172,7 @@ require (
 	github.com/getlantern/fronted v0.0.0-20260325003030-cb5041ba1538 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae // indirect
 	github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb // indirect
-	github.com/getlantern/lantern-box v0.0.54 // indirect
+	github.com/getlantern/lantern-box v0.0.55 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae h1:NMq3K7h3
 github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb h1:A92dC/E/HvkEb1r4tAwCFNlcMsGdqKe5GMmxeUFid9M=
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
-github.com/getlantern/lantern-box v0.0.54 h1:k6BVyaHChFzT5jjRi7F9EMYJazp4uir9WWQEp7L63as=
-github.com/getlantern/lantern-box v0.0.54/go.mod h1:whz/CEUuUG0y/+FifJdLiqbkFBuyoO8RFHIWtk27KZk=
+github.com/getlantern/lantern-box v0.0.55 h1:uOZFkWk9yrZC7Rpkp1BeFpHVGOFzHevJjR8soN4V4Nw=
+github.com/getlantern/lantern-box v0.0.55/go.mod h1:whz/CEUuUG0y/+FifJdLiqbkFBuyoO8RFHIWtk27KZk=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260331124105-88882a0aa9a2 h1:XEewR0UFYSUsX3zxoo+GwXT5WT9KDUK1GzvNQJfVdJA=
-github.com/getlantern/radiance v0.0.0-20260331124105-88882a0aa9a2/go.mod h1:oKOGrN0Z3UiFdcIyzD0wvjLkY3qDxfmVUrsTkjJ37kI=
+github.com/getlantern/radiance v0.0.0-20260331161346-42ae3e04d881 h1:JuvlHmtPZLALNFvH4hdUDs6eG55HbTr7gxNihkrgIC8=
+github.com/getlantern/radiance v0.0.0-20260331161346-42ae3e04d881/go.mod h1:6CJVrrkuD8GjP0z1ws/MjqMBZCzE6ieEP8d5C+8CZfo=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary
Updates radiance to include getlantern/radiance#390 which fixes the root cause of new proxy outbounds failing to load after bandit arm rotation.

**Root cause:** The IPC path between config fetcher and VPN tunnel used Go's standard `encoding/json` for serialization. Standard JSON can't reconstruct typed sing-box outbound options from an `any` interface — `*SamizdatOutboundOptions` became `map[string]any`, silently losing `public_key`, `short_id`, and other fields.

**Fix:** Use sing-box's context-aware JSON (`singjson.MarshalContext`/`UnmarshalExtendedContext`) with `box.BaseContext()` for IPC serialization.

**Why initial load worked:** `tunnel.start()` deserializes the first config directly using `box.BaseContext()`. Only the IPC update path (triggered by subsequent config fetches with different arms) was affected.

Also includes:
- lantern-box v0.0.55 — enhanced key validation diagnostics (getlantern/lantern-box#216)
- radiance #388 — individual outbound creation error logging
- radiance #389 — lantern-box v0.0.55 dependency update

## Verified
Tested on staging: arm rotation at 17:08 UTC successfully loaded 4 new outbounds (`added=4`) — previously all failed with `len=0`.

## Test plan
- [x] Verified fix on staging with arm rotation
- [ ] Run overnight, confirm no "public_key must be 64 hex characters" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)