### PR TITLE
pull in smart routing empty tags sanity check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260325181816-33f69c725899
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260331161346-42ae3e04d881
+	github.com/getlantern/radiance v0.0.0-20260331181627-572a09a7a31d
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260331161346-42ae3e04d881 h1:JuvlHmtPZLALNFvH4hdUDs6eG55HbTr7gxNihkrgIC8=
-github.com/getlantern/radiance v0.0.0-20260331161346-42ae3e04d881/go.mod h1:6CJVrrkuD8GjP0z1ws/MjqMBZCzE6ieEP8d5C+8CZfo=
+github.com/getlantern/radiance v0.0.0-20260331181627-572a09a7a31d h1:bEnI2aYM8vjtXA+CX/14aPtCub1egPos2cDfbXRXY7c=
+github.com/getlantern/radiance v0.0.0-20260331181627-572a09a7a31d/go.mod h1:6CJVrrkuD8GjP0z1ws/MjqMBZCzE6ieEP8d5C+8CZfo=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
This pull request updates the dependency on `github.com/getlantern/radiance` to a newer version in the `go.mod` file.

Dependency update:

* Updated `github.com/getlantern/radiance` from `v0.0.0-20260331161346-42ae3e04d881` to `v0.0.0-20260331181627-572a09a7a31d` in `go.mod`.