### PR TITLE
deps: update radiance for RADIANCE_VERSION support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260401123408-b813f776085f
+	github.com/getlantern/radiance v0.0.0-20260402194959-6fac6eb879bc
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260401123408-b813f776085f h1:2i10xwnoQSVaJR+detAaZAeZbwKENYMoA9ThK0M/sFU=
-github.com/getlantern/radiance v0.0.0-20260401123408-b813f776085f/go.mod h1:7NKtvubqTSWhFyf9ELUmza7yk7JnFuYYve+g3TOwfcM=
+github.com/getlantern/radiance v0.0.0-20260402194959-6fac6eb879bc h1:5DDf7vBGwp/Owuoq3YCZK0ACexeuQvCDvvEBzbvFUyI=
+github.com/getlantern/radiance v0.0.0-20260402194959-6fac6eb879bc/go.mod h1:7NKtvubqTSWhFyf9ELUmza7yk7JnFuYYve+g3TOwfcM=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary
- Updates radiance to [`6fac6eb`](https://github.com/getlantern/radiance/commit/6fac6eb879bcdd18c976452b5ea93a745ce1b6ca) to pick up [radiance#395](https://github.com/getlantern/radiance/pull/395)
- Adds support for overriding app version at runtime via `RADIANCE_VERSION` env var (e.g. `RADIANCE_VERSION=9.1.1 ./lanternd`)

## Test plan
- [ ] `go build ./...` passes
- [ ] Run with `RADIANCE_VERSION=9.1.1` and confirm version appears in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)