### PR TITLE
move includeAllNetworks to VPN profile level to avoid gvisor TUN stack #2

### DIFF
--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -52,7 +52,8 @@ import flutter_local_notifications
       do {
         try await setupFileSystem()
       } catch {
-        appLogger.error("File system setup failed, aborting backend startup: \(error.localizedDescription)")
+        appLogger.error(
+          "File system setup failed, aborting backend startup: \(error.localizedDescription)")
         return
       }
       setupRadiance()
@@ -124,7 +125,11 @@ import flutter_local_notifications
       "apps_cache.json",
       "url_test_history.json",
     ]
-    guard legacyFiles.contains(where: { fm.fileExists(atPath: FilePath.sharedDirectory.appendingPathComponent($0).path) }) else {
+    guard
+      legacyFiles.contains(where: {
+        fm.fileExists(atPath: FilePath.sharedDirectory.appendingPathComponent($0).path)
+      })
+    else {
       appLogger.info("Data directory migration: already migrated or new install, skipping")
       return
     }
@@ -139,7 +144,9 @@ import flutter_local_notifications
         do {
           try fm.removeItem(at: src)
         } catch {
-          appLogger.error("Data directory migration: failed to remove legacy \(fileName): \(error.localizedDescription)")
+          appLogger.error(
+            "Data directory migration: failed to remove legacy \(fileName): \(error.localizedDescription)"
+          )
         }
         continue
       }

--- a/ios/Runner/Handlers/MethodHandler.swift
+++ b/ios/Runner/Handlers/MethodHandler.swift
@@ -890,7 +890,8 @@ class MethodHandler {
       var error: NSError?
       MobileUpdatePrivateServerName(oldName, newName, &error)
       if let error {
-        await self.handleFlutterError(error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
+        await self.handleFlutterError(
+          error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
         return
       }
       await self.replyOK(result)
@@ -996,7 +997,8 @@ class MethodHandler {
           options: [.skipsHiddenFiles]
         )
 
-        let files = try entries
+        let files =
+          try entries
           .filter { entry in
             let values = try entry.resourceValues(forKeys: [.isRegularFileKey])
             return values.isRegularFile ?? false

--- a/ios/Runner/VPN/Profile.swift
+++ b/ios/Runner/VPN/Profile.swift
@@ -53,6 +53,18 @@ public class Profile {
     }
   }
 
+  /// Read-only load — never creates or migrates. Safe to call at app startup.
+  /// Returns nil if no profile exists yet.
+  func loadExistingManager() async -> NETunnelProviderManager? {
+    do {
+      let all = try await NETunnelProviderManager.loadAllFromPreferences()
+      return all.first
+    } catch {
+      appLogger.error("Failed to load existing VPN manager: \(error.localizedDescription)")
+      return nil
+    }
+  }
+
   func vpnManagerExists() async -> Bool {
     do {
       let managers = try await NETunnelProviderManager.loadAllFromPreferences()
@@ -70,7 +82,14 @@ public class Profile {
     let proto = NETunnelProviderProtocol()
     proto.providerBundleIdentifier = "org.getlantern.lantern.Tunnel"
     proto.serverAddress = "0.0.0.0"
-
+    // Force iOS to route ALL traffic (including DNS) through the VPN tunnel,
+    // even on cellular. Without this, iOS 26.4+ may bypass the TUN's fakeip
+    // DNS resolver on mobile data, causing "no internet" in Safari/Chrome.
+    // This is set at the VPN profile level (not platformInterface level) so
+    // sing-tun can still use the system/mixed TUN stack instead of gvisor.
+    // See getlantern/engineering#3128, getlantern/engineering#3133.
+    proto.includeAllNetworks = true
+    proto.excludeLocalNetworks = true
     manager.protocolConfiguration = proto
     manager.localizedDescription = FilePath.vpnProfileName
     manager.isEnabled = true
@@ -101,6 +120,12 @@ public class Profile {
     // 1. VPN name changed (user may have old name)
     if manager.localizedDescription != "LanternVPN" {
       return true
+    }
+
+    if let proto = manager.protocolConfiguration {
+      if !proto.includeAllNetworks {
+        return true
+      }
     }
     return false
   }

--- a/ios/Runner/VPN/VPNManager.swift
+++ b/ios/Runner/VPN/VPNManager.swift
@@ -38,29 +38,15 @@ class VPNManager: VPNBase {
   //    Restores the VPN connection status from the system when the user closes the app without disconnecting VPN.
   func restoreVPNStatus() async {
     appLogger.log("Restoring VPN status...")
-
-    do {
-      let vpnManagerFound = await Profile.shared.vpnManagerExists()
-      if !vpnManagerFound {
-        appLogger.log("No existing VPN profile found during restore. must be first run.")
-        return
-      }
-
-      guard let manager = await Profile.shared.getManager() else {
-        let msg = "Unable to load or create VPN manager."
-        appLogger.error(msg)
-        throw NSError(
-          domain: "VPNManagerError",
-          code: 1003,
-          userInfo: [NSLocalizedDescriptionKey: msg]
-        )
-      }
-      let status = manager.connection.status
-      appLogger.log("Restored VPN status: \(status.rawValue)")
-      self.connectionStatus = status
-    } catch {
-      appLogger.error("Failed to restore VPN status: \(error.localizedDescription)")
+    // Read-only: never triggers migration or the VPN permission dialog.
+    // Migration happens lazily in startTunnel() when the user explicitly connects.
+    guard let manager = await Profile.shared.loadExistingManager() else {
+      appLogger.log("No existing VPN profile found during restore. must be first run.")
+      return
     }
+    let status = manager.connection.status
+    appLogger.log("Restored VPN status: \(status.rawValue)")
+    self.connectionStatus = status
   }
 
   deinit {

--- a/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
@@ -16,8 +16,7 @@ import Liblantern
 import NetworkExtension
 import UserNotifications
 
-public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtocol
-{
+public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtocol {
 
   private let tunnel: ExtensionProvider
   private var networkSettings: NEPacketTunnelNetworkSettings?
@@ -57,6 +56,9 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
       let dnsSettings = NEDNSSettings(servers: [dnsServer.value])
       dnsSettings.matchDomains = [""]
       dnsSettings.matchDomainsNoSearch = true
+      if #available(iOS 26.0, *) {
+        dnsSettings.allowFailover = false
+      }
       settings.dnsSettings = dnsSettings
 
       var ipv4Address: [String] = []
@@ -345,11 +347,14 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     true
   }
 
-  // Lantern override: must be true so DNS goes through the VPN tunnel on cellular.
-  // Without this, iOS 26.4+ bypasses the TUN fakeip resolver on mobile data,
-  // causing "no internet" in Safari/Chrome. See getlantern/engineering#3128.
+  // Return false so sing-tun uses the system/mixed TUN stack (not gvisor).
+  // gvisor caused TCP data transfer stalls on cellular (connections open but
+  // no data flows). includeAllNetworks is set at the VPN profile level in
+  // Profile.swift instead, which forces iOS to route all traffic through the
+  // tunnel without affecting the TUN stack choice.
+  // See getlantern/engineering#3128, getlantern/engineering#3133.
   public func includeAllNetworks() -> Bool {
-    return true
+    return false
   }
 
   public func clearDNSCache() {

--- a/macos/Runner/Handlers/MethodHandler.swift
+++ b/macos/Runner/Handlers/MethodHandler.swift
@@ -899,7 +899,8 @@ class MethodHandler {
       var error: NSError?
       MobileUpdatePrivateServerName(oldName, newName, &error)
       if let error {
-        await self.handleFlutterError(error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
+        await self.handleFlutterError(
+          error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
         return
       }
       await self.replyOK(result)


### PR DESCRIPTION
This pull request focuses on improving VPN profile handling and network routing on iOS, particularly to ensure reliable VPN operation on iOS 26.4+ and to address issues with DNS routing and data flow on cellular connections. It also includes some code style improvements and minor refactoring for clarity.

**VPN Profile and Network Routing Improvements:**

* Added a new `loadExistingManager()` method in `Profile.swift` for read-only loading of VPN profiles, ensuring no migration or creation occurs unless explicitly needed. This is now used in `VPNManager.swift` to avoid unnecessary migrations or permission dialogs at app startup. [[1]](diffhunk://#diff-9af609bc622a0cc76909e3bf73dfa7ea98e001c0ef97650df20d776ee8d1def3R56-R67) [[2]](diffhunk://#diff-05cb5bbffc9ab490ff6c442d54384610b2a92d5b45f8fd39ab37dd02032b8b79L41-L63)
* Updated VPN profile configuration in `Profile.swift` to set `includeAllNetworks = true` and `excludeLocalNetworks = true`, forcing iOS to route all traffic (including DNS) through the VPN tunnel—even on cellular. This addresses DNS bypass and "no internet" issues in iOS 26.4+.
* Improved profile migration checks to ensure that profiles missing the new settings (`includeAllNetworks`) are correctly migrated.

**VPN Tunnel Extension Adjustments:**

* Changed the `includeAllNetworks()` implementation in `ExtensionPlatformInterface.swift` to return `false` instead of `true`, allowing the system/mixed TUN stack to be used instead of gvisor, which resolves TCP data flow issues on cellular. The routing is now enforced at the VPN profile level.
* For iOS 26+, set `allowFailover = false` in DNS settings to further control DNS behavior within the tunnel.

**Code Style and Minor Refactoring:**

* Improved code formatting and readability in several files, including line breaks for long log/error statements and variable assignments in `AppDelegate.swift`, `MethodHandler.swift`, and others. [[1]](diffhunk://#diff-2d8ca8a3da302654c934d7f3be4c2f6c8edc7788f2b8ed0178730d6d703ebe72L55-R56) [[2]](diffhunk://#diff-2d8ca8a3da302654c934d7f3be4c2f6c8edc7788f2b8ed0178730d6d703ebe72L127-R132) [[3]](diffhunk://#diff-2d8ca8a3da302654c934d7f3be4c2f6c8edc7788f2b8ed0178730d6d703ebe72L142-R149) [[4]](diffhunk://#diff-b8d375d46b22447c9a4f12a2c9cad7e3c05b7509d27e8ba120a3075a2e44437aL893-R894) [[5]](diffhunk://#diff-b8d375d46b22447c9a4f12a2c9cad7e3c05b7509d27e8ba120a3075a2e44437aL999-R1001) [[6]](diffhunk://#diff-d7a442e1ee49365d098c7b181e17160e4d21ae78dfaf0ae4737103df754cac37L19-R19) [[7]](diffhunk://#diff-dbbb8255da90fab5ea15d937e32a56a355b5a50f744118abb0fce0b0dfdeebefL902-R903)