### PR TITLE
Macos system extension updates #2

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -44,7 +44,6 @@ jobs:
         with:
           path: |
             ~/.pub-cache
-            .dart_tool
           key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-flutter-
@@ -101,7 +100,6 @@ jobs:
         with:
           path: |
             ~/.pub-cache
-            .dart_tool
           key: ${{ runner.os }}-dart-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-dart-

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -52,7 +52,7 @@ jobs:
         continue-on-error: true
         with:
           path: |
-            .dart_tool
+            ~/.pub-cache
           key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-flutter-    

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -53,7 +53,6 @@ jobs:
         with:
           path: |
             ~/.pub-cache
-            .dart_tool
           key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-flutter-

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -46,10 +46,9 @@ jobs:
         with:
           path: |
             ~/.pub-cache
-            .dart_tool
           key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
-            ${{ runner.os }}-flutter-    
+            ${{ runner.os }}-flutter-
 
       - name: Cache macOS CocoaPods
         uses: actions/cache@v4

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -55,7 +55,6 @@ jobs:
         with:
           path: |
             ~/.pub-cache
-            .dart_tool
           key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
           restore-keys: |
             ${{ runner.os }}-flutter-

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -52,7 +52,8 @@ import flutter_local_notifications
       do {
         try await setupFileSystem()
       } catch {
-        appLogger.error("File system setup failed, aborting backend startup: \(error.localizedDescription)")
+        appLogger.error(
+          "File system setup failed, aborting backend startup: \(error.localizedDescription)")
         return
       }
       setupRadiance()
@@ -124,7 +125,11 @@ import flutter_local_notifications
       "apps_cache.json",
       "url_test_history.json",
     ]
-    guard legacyFiles.contains(where: { fm.fileExists(atPath: FilePath.sharedDirectory.appendingPathComponent($0).path) }) else {
+    guard
+      legacyFiles.contains(where: {
+        fm.fileExists(atPath: FilePath.sharedDirectory.appendingPathComponent($0).path)
+      })
+    else {
       appLogger.info("Data directory migration: already migrated or new install, skipping")
       return
     }
@@ -139,7 +144,9 @@ import flutter_local_notifications
         do {
           try fm.removeItem(at: src)
         } catch {
-          appLogger.error("Data directory migration: failed to remove legacy \(fileName): \(error.localizedDescription)")
+          appLogger.error(
+            "Data directory migration: failed to remove legacy \(fileName): \(error.localizedDescription)"
+          )
         }
         continue
       }

--- a/ios/Runner/Handlers/MethodHandler.swift
+++ b/ios/Runner/Handlers/MethodHandler.swift
@@ -890,7 +890,8 @@ class MethodHandler {
       var error: NSError?
       MobileUpdatePrivateServerName(oldName, newName, &error)
       if let error {
-        await self.handleFlutterError(error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
+        await self.handleFlutterError(
+          error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
         return
       }
       await self.replyOK(result)
@@ -996,7 +997,8 @@ class MethodHandler {
           options: [.skipsHiddenFiles]
         )
 
-        let files = try entries
+        let files =
+          try entries
           .filter { entry in
             let values = try entry.resourceValues(forKeys: [.isRegularFileKey])
             return values.isRegularFile ?? false

--- a/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
@@ -16,8 +16,7 @@ import Liblantern
 import NetworkExtension
 import UserNotifications
 
-public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtocol
-{
+public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtocol {
 
   private let tunnel: ExtensionProvider
   private var networkSettings: NEPacketTunnelNetworkSettings?

--- a/lib/features/macos_extension/macos_extension_dialog.dart
+++ b/lib/features/macos_extension/macos_extension_dialog.dart
@@ -79,20 +79,6 @@ class _MacOSExtensionDialogState extends ConsumerState<MacOSExtensionDialog> {
               ),
             ),
           ),
-          if (systemExtensionStatus.message != null &&
-              systemExtensionStatus.status != SystemExtensionStatus.error) ...[
-            const SizedBox(height: 12.0),
-            Padding(
-              padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: Text(
-                systemExtensionStatus.message!,
-                style: textTheme.bodyMedium!.copyWith(
-                  color: context.textTertiary,
-                ),
-                textAlign: TextAlign.center,
-              ),
-            ),
-          ],
           const SizedBox(height: 16.0),
           RichText(
             text: TextSpan(

--- a/lib/features/macos_extension/provider/macos_extension_notifier.dart
+++ b/lib/features/macos_extension/provider/macos_extension_notifier.dart
@@ -22,7 +22,7 @@ class MacosExtensionNotifier extends _$MacosExtensionNotifier {
           'Disposing MacosExtensionNotifier and cancelling subscriptions.');
       _extensionStatusSub?.cancel();
     });
-    return MacOSExtensionState(SystemExtensionStatus.notInstalled);
+    return const MacOSExtensionState(SystemExtensionStatus.unknown);
   }
 
   void watchExtensionStatus() {

--- a/lib/features/vpn/vpn_status.dart
+++ b/lib/features/vpn/vpn_status.dart
@@ -18,7 +18,7 @@ class VpnStatus extends HookConsumerWidget {
     final statusValue = vpnStatus.name.capitalize;
     final textTheme = Theme.of(context).textTheme;
     MacOSExtensionState systemExtensionStatus =
-        MacOSExtensionState(SystemExtensionStatus.notInstalled);
+        const MacOSExtensionState(SystemExtensionStatus.unknown);
     if (PlatformUtils.isMacOS) {
       systemExtensionStatus = ref.watch(macosExtensionProvider);
     }
@@ -73,6 +73,9 @@ class VpnStatus extends HookConsumerWidget {
 
   bool isExtensionNeeded(MacOSExtensionState systemExtensionStatus) {
     if (!PlatformUtils.isMacOS) {
+      return false;
+    }
+    if (systemExtensionStatus.status == SystemExtensionStatus.unknown) {
       return false;
     }
     return !systemExtensionStatus.isReady;

--- a/macos/Runner/Handlers/MethodHandler.swift
+++ b/macos/Runner/Handlers/MethodHandler.swift
@@ -944,7 +944,8 @@ class MethodHandler {
       var error: NSError?
       MobileUpdatePrivateServerName(oldName, newName, &error)
       if let error {
-        await self.handleFlutterError(error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
+        await self.handleFlutterError(
+          error, result: result, code: "UPDATE_PRIVATE_SERVER_NAME_ERROR")
         return
       }
       await self.replyOK(result)

--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -575,10 +575,7 @@ internal enum SystemExtensionReconciler {
           action: .activate(reason: "activate bundled extension while old version awaits removal"),
           change: .install)
       }
-      return SystemExtensionReconciliation(
-        status: .requiresReboot(details: "system extension changes are waiting on a reboot"),
-        action: .none,
-        change: classifyChange(current: enabled, desired: bundled))
+      //  An enabled extension exists but doesn't match bundled Fall through to normal upgrade/content-change handling — a stale uninstalling copy should not block reconciliation.
     }
 
     guard !installed.isEmpty else {

--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -84,7 +84,8 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
       switch context {
       case .deactivateThenActivate(_, let activateAfter):
         if activateAfter {
-          submitActivationRequest(reason: "activating bundled extension after removing mismatched version")
+          submitActivationRequest(
+            reason: "activating bundled extension after removing mismatched version")
         } else {
           submitPropertiesRequest(context: .inspectStatus)
         }
@@ -98,8 +99,10 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
       // the activation chain breaks and the user gets stuck after reboot
       // with no enabled extension.
       if case .deactivateThenActivate(_, true)? = context {
-        appLogger.info("Deactivation needs reboot, but still attempting activation of bundled extension")
-        submitActivationRequest(reason: "activating bundled extension while old version awaits reboot removal")
+        appLogger.info(
+          "Deactivation needs reboot, but still attempting activation of bundled extension")
+        submitActivationRequest(
+          reason: "activating bundled extension while old version awaits reboot removal")
         return
       }
       let details = context?.rebootDetails ?? "system extension change will finish after reboot"
@@ -117,10 +120,8 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
     let nsError = error as NSError
 
     if nsError.domain == OSSystemExtensionErrorDomain
-      && (
-        nsError.code == OSSystemExtensionError.requestCanceled.rawValue
-          || nsError.code == OSSystemExtensionError.requestSuperseded.rawValue
-      )
+      && (nsError.code == OSSystemExtensionError.requestCanceled.rawValue
+        || nsError.code == OSSystemExtensionError.requestSuperseded.rawValue)
     {
       appLogger.info(
         "System extension request ended without applying changes: context=\(context?.logDescription ?? "unknown") error=\(nsError.localizedDescription)"
@@ -294,7 +295,8 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
       }
     } else if #available(macOS 13.0, *) {
       // URL(string:) with a valid literal always succeeds; no fallback needed.
-      let url = URL(string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension")!
+      let url = URL(
+        string: "x-apple.systempreferences:com.apple.settings.PrivacySecurity.extension")!
       appLogger.log("Opening PrivacySecurity.extension URL")
       NSWorkspace.shared.open(url)
     } else {
@@ -434,18 +436,20 @@ internal struct SystemExtensionDescriptor: Equatable {
     }
 
     let fileManager = FileManager.default
-    guard let items = try? fileManager.contentsOfDirectory(
-      at: sysExtURL,
-      includingPropertiesForKeys: nil,
-      options: [])
+    guard
+      let items = try? fileManager.contentsOfDirectory(
+        at: sysExtURL,
+        includingPropertiesForKeys: nil,
+        options: [])
     else {
       return nil
     }
 
-    guard let url = items.first(where: { candidate in
-      candidate.pathExtension == "systemextension"
-        && (Bundle(url: candidate)?.bundleIdentifier == bundleID)
-    }), let bundle = Bundle(url: url)
+    guard
+      let url = items.first(where: { candidate in
+        candidate.pathExtension == "systemextension"
+          && (Bundle(url: candidate)?.bundleIdentifier == bundleID)
+      }), let bundle = Bundle(url: url)
     else {
       return nil
     }
@@ -571,11 +575,14 @@ internal enum SystemExtensionReconciler {
         // for a reboot that may never clear the state. Submit an activation request
         // so macOS can install the bundled extension alongside the pending removal.
         return SystemExtensionReconciliation(
-          status: .updatePending(details: "old extension is uninstalling, replacement activation pending"),
+          status: .updatePending(
+            details: "old extension is uninstalling, replacement activation pending"),
           action: .activate(reason: "activate bundled extension while old version awaits removal"),
           change: .install)
       }
-      //  An enabled extension exists but doesn't match bundled Fall through to normal upgrade/content-change handling — a stale uninstalling copy should not block reconciliation.
+      // An enabled extension exists, but it does not match the bundled extension.
+      // Fall through to normal upgrade/content-change handling. A stale uninstalling
+      // copy should not block reconciliation.
     }
 
     guard !installed.isEmpty else {
@@ -598,18 +605,22 @@ internal enum SystemExtensionReconciler {
       return SystemExtensionReconciliation(status: .activated, action: .none, change: .matched)
     case .upgrade:
       return SystemExtensionReconciliation(
-        status: .updatePending(details: "bundled system extension is newer than the active extension"),
+        status: .updatePending(
+          details: "bundled system extension is newer than the active extension"),
         action: .activate(reason: "replace active system extension with bundled upgrade"),
         change: .upgrade)
     case .downgrade:
       return SystemExtensionReconciliation(
         status: .updatePending(details: "active system extension is newer than the current app"),
-        action: .deactivateThenActivate(reason: "replace newer system extension with bundled downgrade"),
+        action: .deactivateThenActivate(
+          reason: "replace newer system extension with bundled downgrade"),
         change: .downgrade)
     case .contentChange:
       return SystemExtensionReconciliation(
-        status: .updatePending(details: "active system extension contents differ from the bundled extension"),
-        action: .deactivateThenActivate(reason: "reload same-version system extension with bundled contents"),
+        status: .updatePending(
+          details: "active system extension contents differ from the bundled extension"),
+        action: .deactivateThenActivate(
+          reason: "reload same-version system extension with bundled contents"),
         change: .contentChange)
     case .install:
       return SystemExtensionReconciliation(
@@ -679,11 +690,12 @@ internal enum SystemExtensionBundleHasher {
 
   static func hashBundle(at url: URL) -> String? {
     let fileManager = FileManager.default
-    guard let enumerator = fileManager.enumerator(
-      at: url,
-      includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
-      options: [],
-      errorHandler: nil)
+    guard
+      let enumerator = fileManager.enumerator(
+        at: url,
+        includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey],
+        options: [],
+        errorHandler: nil)
     else {
       appLogger.error("Failed to enumerate system extension bundle for hashing at \(url.path)")
       return nil
@@ -724,7 +736,8 @@ internal enum SystemExtensionBundleHasher {
     for entry in entries {
       switch entry.kind {
       case .symbolicLink:
-        guard let destination = try? fileManager.destinationOfSymbolicLink(atPath: entry.fileURL.path)
+        guard
+          let destination = try? fileManager.destinationOfSymbolicLink(atPath: entry.fileURL.path)
         else {
           appLogger.error("Failed to read symlink destination while hashing \(entry.fileURL.path)")
           return nil
@@ -777,7 +790,8 @@ internal enum SystemExtensionBundleHasher {
   }
 
   private static func relativePath(for fileURL: URL, under rootURL: URL) -> String {
-    let rootPath = rootURL.standardizedFileURL.path.hasSuffix("/")
+    let rootPath =
+      rootURL.standardizedFileURL.path.hasSuffix("/")
       ? rootURL.standardizedFileURL.path
       : rootURL.standardizedFileURL.path + "/"
     let filePath = fileURL.standardizedFileURL.path

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -180,7 +180,7 @@ final class RunnerTests: XCTestCase {
     XCTAssertEqual(reconciliation.action, .none)
   }
 
-  func testReconcileRequiresRebootWhenEnabledExtensionIsUninstalling() {
+  func testReconcileReplacesEnabledExtensionThatIsUninstallingWhenContentDiffers() {
     let bundled = makeDescriptor(build: "220", hash: "hash-a")
     let uninstalling = makeDescriptor(
       build: "220",
@@ -194,11 +194,15 @@ final class RunnerTests: XCTestCase {
       installed: [uninstalling]
     )
 
-    assertRequiresReboot(
+    XCTAssertEqual(reconciliation.change, .contentChange)
+    assertUpdatePending(
       reconciliation.status,
-      contains: "waiting on a reboot"
+      contains: "contents differ"
     )
-    XCTAssertEqual(reconciliation.action, .none)
+    assertDeactivateThenActivate(
+      reconciliation.action,
+      contains: "bundled contents"
+    )
   }
 
   func testReconcileActivatesWhenUninstallingButNoneEnabled() {


### PR DESCRIPTION
This pull request includes several changes across CI workflows, macOS extension state management, and the system extension reconciliation logic. The main goals are to streamline caching in CI, improve the accuracy of macOS extension status handling, and refine the logic for reconciling system extension states, especially when dealing with uninstalling extensions.

**CI Workflow Improvements:**

* Removed `.dart_tool` from the cache paths in all workflow files (`build-android.yml`, `build-linux.yml`, `build-macos.yml`, `build-windows.yml`) and ensured only `~/.pub-cache` is cached, which should reduce cache size and avoid unnecessary cache invalidation. (`[[1]](diffhunk://#diff-990269d44b14b14a290b6d577fde890babb7b7f98e88f9e33753db2d5fca4570L47)`, `[[2]](diffhunk://#diff-990269d44b14b14a290b6d577fde890babb7b7f98e88f9e33753db2d5fca4570L104)`, `[[3]](diffhunk://#diff-bfc3aeacfea5c320a79818465fb6d4b9901e2c1fc26af712702cae54db219bdcL56)`, `[[4]](diffhunk://#diff-a1654f4357833dfc4d0c6a8d39c2e3ee30ceea604c29238846903993434ab384L49)`, `[[5]](diffhunk://#diff-01d393d5fc96ff0e19c736f6b445df76a62887b81071928a950e936379746f2dL58)`)
* In `build-ios.yml`, replaced `.dart_tool` with `~/.pub-cache` in the cache path for consistency with other platforms. (`[.github/workflows/build-ios.ymlL55-R55](diffhunk://#diff-c75570ad4e0fdfe6f209247388e447fb5bcca0d45461735d9211e0f971beb406L55-R55)`)

**macOS Extension State Management:**

* Changed the default state for `MacOSExtensionState` from `notInstalled` to `unknown` to better reflect the initial state before status is determined. (`[[1]](diffhunk://#diff-775ff7db23dca67ed061eed2e38459a20aadd0324ed9c259665c0b262ec59617L25-R25)`, `[[2]](diffhunk://#diff-03faae1021be7e1189ff7cefc9374af69a34ec9c16e8da99f29922389f974b9fL21-R21)`)
* Updated logic in `VpnStatus` to treat the `unknown` status as not ready and to prevent certain UI actions if the extension status is unknown. (`[lib/features/vpn/vpn_status.dartR78-R80](diffhunk://#diff-03faae1021be7e1189ff7cefc9374af69a34ec9c16e8da99f29922389f974b9fR78-R80)`)
* Removed the display of non-error extension status messages from the `MacOSExtensionDialog` UI for a cleaner user experience. (`[lib/features/macos_extension/macos_extension_dialog.dartL82-L95](diffhunk://#diff-805a5ba0a3facf797739dc375d663ba01257478e0011c6eca6ae90a8a2284a7dL82-L95)`)

**System Extension Reconciliation Logic:**

* Refined the reconciliation logic in `SystemExtensionManager.swift` to handle cases where an enabled extension is uninstalling but its contents differ from the bundled version, allowing normal upgrade/content-change handling instead of blocking on a reboot. (`[macos/Runner/VPN/SystemExtensionManager.swiftL578-R578](diffhunk://#diff-3c337cbd9892c03a95394ca9b8a870b55b1a83c5925c0ecc0c7f8042620f2ca2L578-R578)`)
* Updated the corresponding test to verify that the reconciliation process now triggers a content change and appropriate actions, rather than requiring a reboot. (`[[1]](diffhunk://#diff-c8d0858157e18aeeae5bca9ab00aa55061c93d358aa6e9b85f106e6186e3c91dL183-R183)`, `[[2]](diffhunk://#diff-c8d0858157e18aeeae5bca9ab00aa55061c93d358aa6e9b85f106e6186e3c91dL197-L201)`)