### PR TITLE
Smart location country fix

### DIFF
--- a/lib/features/vpn/server_selection.dart
+++ b/lib/features/vpn/server_selection.dart
@@ -205,7 +205,7 @@ class _ServerSelectionState extends ConsumerState<ServerSelection> {
 
     result.fold(
       (failure) => context.showSnackBar(failure.localizedErrorMessage),
-      (_) async {
+      (_) {
         appRouter.popUntilRoot();
       },
     );
@@ -376,31 +376,29 @@ class _ServerLocationListViewState
           selectedServer.tag,
         );
 
-    result.fold(
-      (failure) {
-        if (failure is VpnConflictFailure) {
-          AppDialog.vpnConflictDialog(
-            context: context,
-            onConnectAnyway: () async {
-              appRouter.maybePop();
-              final retryResult =
-                  await ref.read(vpnProvider.notifier).connectToServer(
-                        ServerLocationType.lanternLocation,
-                        selectedServer.tag,
-                        skipConflictCheck: true,
-                      );
-              retryResult.fold(
-                (failure) => context.showSnackBar(failure.localizedErrorMessage),
-                (_) => _onLanternServerConnected(ref, selectedServer),
-              );
-            },
-          );
-        } else {
-          context.showSnackBar(failure.localizedErrorMessage);
-        }
-      },
-      (_) => _onLanternServerConnected(ref, selectedServer),
-    );
+    result.fold((failure) {
+      if (failure is VpnConflictFailure) {
+        AppDialog.vpnConflictDialog(
+          context: context,
+          onConnectAnyway: () async {
+            appRouter.maybePop();
+            final retryResult = await ref
+                .read(vpnProvider.notifier)
+                .connectToServer(
+                  ServerLocationType.lanternLocation,
+                  selectedServer.tag,
+                  skipConflictCheck: true,
+                );
+            retryResult.fold(
+              (failure) => context.showSnackBar(failure.localizedErrorMessage),
+              (_) => _onLanternServerConnected(ref, selectedServer),
+            );
+          },
+        );
+      } else {
+        context.showSnackBar(failure.localizedErrorMessage);
+      }
+    }, (_) => _onLanternServerConnected(ref, selectedServer));
   }
 
   void _onLanternServerConnected(WidgetRef ref, Location_ selectedServer) {
@@ -673,35 +671,30 @@ class _PrivateServerLocationListViewState
         .read(vpnProvider.notifier)
         .connectToServer(ServerLocationType.privateServer, location.tag);
 
-    result.fold(
-      (failure) {
-        context.hideLoadingDialog();
-        if (failure is VpnConflictFailure) {
-          AppDialog.vpnConflictDialog(
-            context: context,
-            onConnectAnyway: () async {
-              appRouter.maybePop();
-              final retryResult =
-                  await ref.read(vpnProvider.notifier).connectToServer(
-                        ServerLocationType.privateServer,
-                        location.tag,
-                        skipConflictCheck: true,
-                      );
-              retryResult.fold(
-                (failure) {
-                  context.hideLoadingDialog();
-                  context.showSnackBar(failure.localizedErrorMessage);
-                },
-                (_) => _onPrivateServerConnected(ref, location),
-              );
-            },
-          );
-        } else {
-          context.showSnackBar(failure.localizedErrorMessage);
-        }
-      },
-      (_) => _onPrivateServerConnected(ref, location),
-    );
+    result.fold((failure) {
+      context.hideLoadingDialog();
+      if (failure is VpnConflictFailure) {
+        AppDialog.vpnConflictDialog(
+          context: context,
+          onConnectAnyway: () async {
+            appRouter.maybePop();
+            final retryResult = await ref
+                .read(vpnProvider.notifier)
+                .connectToServer(
+                  ServerLocationType.privateServer,
+                  location.tag,
+                  skipConflictCheck: true,
+                );
+            retryResult.fold((failure) {
+              context.hideLoadingDialog();
+              context.showSnackBar(failure.localizedErrorMessage);
+            }, (_) => _onPrivateServerConnected(ref, location));
+          },
+        );
+      } else {
+        context.showSnackBar(failure.localizedErrorMessage);
+      }
+    }, (_) => _onPrivateServerConnected(ref, location));
   }
 
   void _onPrivateServerConnected(WidgetRef ref, Location_ location) async {

--- a/lib/features/vpn/server_selection.dart
+++ b/lib/features/vpn/server_selection.dart
@@ -206,14 +206,6 @@ class _ServerSelectionState extends ConsumerState<ServerSelection> {
     result.fold(
       (failure) => context.showSnackBar(failure.localizedErrorMessage),
       (_) async {
-        await ref
-            .read(serverLocationProvider.notifier)
-            .updateServerLocation(
-              ServerLocation(
-                serverType: ServerLocationType.auto.name,
-                serverName: '',
-              ),
-            );
         appRouter.popUntilRoot();
       },
     );


### PR DESCRIPTION
This pull request makes a minor update to the server selection logic by removing the code that reset the server location to "auto" after a successful operation. Now, after the operation succeeds, the app simply navigates back to the root without changing the server location.

- Removed the call to `updateServerLocation` with an "auto" server location in `_ServerSelectionState`, so the server location is no longer reset after a successful operation (`lib/features/vpn/server_selection.dart`).