### PR TITLE
deps: update radiance to fix ~50% bandit callback failure

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260409194319-41a2a5c07035
+	github.com/getlantern/radiance v0.0.0-20260410130405-80ec5c9212f6
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260409194319-41a2a5c07035 h1:/kJJwN+BU9u4TimOA8LKl17Walz19KZdlW3+N8EU2Vg=
-github.com/getlantern/radiance v0.0.0-20260409194319-41a2a5c07035/go.mod h1:kbHgDEozulIE0WkPoC7TMzMmO1leiS8F1ecsGeLokMo=
+github.com/getlantern/radiance v0.0.0-20260410130405-80ec5c9212f6 h1:KHa0XLfBDRz733VIiiYJMCTY3/a4xsMRTHxJblLkurY=
+github.com/getlantern/radiance v0.0.0-20260410130405-80ec5c9212f6/go.mod h1:kbHgDEozulIE0WkPoC7TMzMmO1leiS8F1ecsGeLokMo=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary
Updates radiance to pick up PR #405 which fixes `removeOutbounds` failing when extra outbounds (non-smart Pro locations) aren't in the URL test group.

## Root cause
The extra routes change added outbounds to the selector but not the URL test group. On config refresh, `removeOutbounds` tried to remove them from both groups. The URL test removal failed (tag not in group), causing the entire IPC to return 500. This prevented `SetURLOverrides` and `CheckOutbounds` from running on subsequent configs — only the initial preTest fired callbacks, and ~50% of bandit probes expired.

## Test plan
- [ ] Run client with VPN on, verify no "Failed to forward event" errors in logs
- [ ] Dashboard should show ~100% callback success rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)