### PR TITLE
feat: Share My Connection peer proxy toggle (feature-flagged)

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1523,3 +1523,9 @@ msgstr "Got it"
 
 msgid "vpn_conflict_connect_anyway"
 msgstr "Connect Anyway"
+
+msgid "share_connection"
+msgstr "Share My Connection"
+
+msgid "share_connection_description"
+msgstr "Help others access the internet by sharing your connection as a volunteer proxy"

--- a/lib/core/models/app_setting.dart
+++ b/lib/core/models/app_setting.dart
@@ -18,6 +18,7 @@ class AppSetting {
   final String routingModeRaw;
   final String dataCapThreshold;
   final bool onboardingCompleted;
+  final bool peerProxyEnabled;
 
   const AppSetting({
     this.isPro = false,
@@ -37,6 +38,7 @@ class AppSetting {
     this.routingModeRaw = 'full_tunnel',
     this.dataCapThreshold = '',
     this.onboardingCompleted = false,
+    this.peerProxyEnabled = false,
   });
 
   AppSetting copyWith({
@@ -57,6 +59,7 @@ class AppSetting {
     String? routingModeRaw,
     String? dataCapThreshold,
     bool? onboardingCompleted,
+    bool? peerProxyEnabled,
   }) {
     return AppSetting(
       isPro: newPro ?? isPro,
@@ -76,6 +79,7 @@ class AppSetting {
       routingModeRaw: routingModeRaw ?? this.routingModeRaw,
       dataCapThreshold: dataCapThreshold ?? this.dataCapThreshold,
       onboardingCompleted: onboardingCompleted ?? this.onboardingCompleted,
+      peerProxyEnabled: peerProxyEnabled ?? this.peerProxyEnabled,
     );
   }
 
@@ -98,6 +102,7 @@ class AppSetting {
         'routingModeRaw': routingModeRaw,
         'dataCapThreshold': dataCapThreshold,
         'onboardingCompleted': onboardingCompleted,
+        'peerProxyEnabled': peerProxyEnabled,
       };
 
   factory AppSetting.fromJson(Map<String, dynamic> json) => AppSetting(
@@ -117,6 +122,7 @@ class AppSetting {
         routingModeRaw: (json['routingModeRaw'] ?? 'full_tunnel').toString(),
         dataCapThreshold: (json['dataCapThreshold'] ?? '').toString(),
         onboardingCompleted: json['onboardingCompleted'] == true,
+        peerProxyEnabled: json['peerProxyEnabled'] == true,
       );
 
   bool get isSSOUser => oAuthToken.isNotEmpty && oAuthLoginProvider.isNotEmpty;

--- a/lib/core/models/feature_flags.dart
+++ b/lib/core/models/feature_flags.dart
@@ -2,7 +2,8 @@ enum FeatureFlag {
   privateGcp('private.gcp'),
   metrics('otel.metrics'),
   traces('otel.traces'),
-  autoUpdateEnabled('autoUpdateEnabled');
+  autoUpdateEnabled('autoUpdateEnabled'),
+  peerProxy('peer_proxy');
 
   final String key;
 

--- a/lib/features/home/provider/app_setting_notifier.dart
+++ b/lib/features/home/provider/app_setting_notifier.dart
@@ -163,6 +163,15 @@ class AppSettingNotifier extends _$AppSettingNotifier {
     return unit;
   }
 
+  Future<void> setPeerProxy(bool value) async {
+    if (state.peerProxyEnabled == value) return;
+    final prev = state.peerProxyEnabled;
+    await update(state.copyWith(peerProxyEnabled: value));
+    // TODO: Call IPC to start/stop peer proxy once radiance integration lands.
+    // For now, just persist the setting locally.
+    appLogger.info('Peer proxy ${value ? "enabled" : "disabled"}');
+  }
+
   void updateAnonymousDataConsent(bool value) {
     update(state.copyWith(telemetryConsent: value));
     updateTelemetryConsent(value);

--- a/lib/features/setting/vpn_setting.dart
+++ b/lib/features/setting/vpn_setting.dart
@@ -5,7 +5,9 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/widgets/split_tunneling_tile.dart';
 import 'package:lantern/core/widgets/switch_button.dart';
+import 'package:lantern/core/models/feature_flags.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/features/home/provider/feature_flag_notifier.dart';
 
 @RoutePage(name: 'VPNSetting')
 class VPNSetting extends HookConsumerWidget {
@@ -107,6 +109,32 @@ class VPNSetting extends HookConsumerWidget {
             },
           ),
         ),
+        if (ref.watch(featureFlagNotifierProvider).getBool(FeatureFlag.peerProxy)) ...[
+          SizedBox(height: 16),
+          AppCard(
+            padding: EdgeInsets.zero,
+            child: AppTile(
+              label: 'share_connection'.i18n,
+              subtitle: Text(
+                'share_connection_description'.i18n,
+                style: textTheme.labelMedium!.copyWith(
+                  color: context.textTertiary,
+                  letterSpacing: 0.0,
+                ),
+              ),
+              icon: AppImagePaths.server,
+              trailing: SwitchButton(
+                value: preferences.peerProxyEnabled,
+                onChanged: (bool? value) {
+                  notifier.setPeerProxy(value ?? false);
+                },
+              ),
+              onPressed: () {
+                notifier.setPeerProxy(!preferences.peerProxyEnabled);
+              },
+            ),
+          ),
+        ],
         SizedBox(height: 16),
         AppCard(
           padding: EdgeInsets.zero,


### PR DESCRIPTION
## Summary

Adds a "Share My Connection" toggle to VPN Settings, gated behind the `peer_proxy` feature flag. When enabled, it will run a samizdat inbound proxy on a UPnP-mapped port so censored users can connect through residential IPs.

### Companion PRs
- getlantern/lantern-cloud#2553 — Peer registration API
- getlantern/radiance#391 — UPnP + peer lifecycle + IPC

## Test plan
- [ ] Toggle hidden when feature flag off (default)
- [ ] Toggle visible when flag on
- [ ] Setting persists across restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)