### PR TITLE
fix: publish nightly releases even when some platforms fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -726,7 +726,6 @@ jobs:
       - name: Publish release on success
         if: |
           env.IS_TEST_RUN != 'true' &&
-          env.BUILD_TYPE != 'nightly' &&
           needs.upload-s3.result == 'success' &&
           needs.upload-release-artifacts.result == 'success' &&
           (needs.upload-google-play.result == 'success' || needs.upload-google-play.result == 'skipped') &&
@@ -734,13 +733,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          echo "All steps succeeded - publishing draft release"
+          echo "Publishing release (at least one platform succeeded)"
           gh release edit "$RELEASE_TAG" --draft=false
 
       - name: Delete draft release
         if: |
           env.IS_TEST_RUN == 'true' ||
-          env.BUILD_TYPE == 'nightly' ||
           (env.CLEANUP_ON_FAILURE == 'true' &&
            !(needs.upload-s3.result == 'success' &&
              needs.upload-release-artifacts.result == 'success' &&
@@ -751,8 +749,6 @@ jobs:
         run: |
           if [[ "$IS_TEST_RUN" == "true" ]]; then
             echo "Test run from non-main branch - deleting draft release"
-          elif [[ "$BUILD_TYPE" == "nightly" ]]; then
-            echo "Nightly build - deleting draft release"
           else
             echo "Build failed or cancelled - cleaning up draft release"
           fi


### PR DESCRIPTION
## Summary

Nightly builds were always deleting the draft GitHub Release regardless of build success, so nightlies were only available via S3. Now nightlies get published as GitHub Releases when at least one platform succeeds.

### Changes to `release-finalize` in `release.yml`:
- **Publish step**: Remove `BUILD_TYPE != 'nightly'` gate — nightlies now publish when uploads succeed
- **Delete step**: Remove `BUILD_TYPE == 'nightly'` unconditional delete — nightlies only deleted on total failure

The upload jobs already handle partial success (they run if any build succeeded), so a broken Linux build won't block the macOS/Windows/Android/iOS artifacts from being released.

### Context
https://wdynhnkxvsdx.slack.com/archives/C06F5EKHN5S/p1776014784078499

## Test plan
- [ ] Trigger a nightly workflow_dispatch with one platform
- [ ] Verify the GitHub Release is published (not deleted)
- [ ] Verify a total failure still cleans up the draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)