### PR TITLE
fix: upload and notify for nightlies even when some platforms fail

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -388,13 +388,10 @@ jobs:
         build-android,
         build-ios,
       ]
+    # Run if at least one platform build succeeded. Individual platform failures
+    # (e.g., Linux arm64) should not block uploading successful builds.
     if: |
       !cancelled() &&
-      (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') &&
-      (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped') &&
-      (needs.build-linux.result == 'success' || needs.build-linux.result == 'skipped') &&
-      (needs.build-android.result == 'success' || needs.build-android.result == 'skipped') &&
-      (needs.build-ios.result == 'success' || needs.build-ios.result == 'skipped') &&
       (needs.build-macos.result == 'success' || needs.build-windows.result == 'success' ||
        needs.build-linux.result == 'success' || needs.build-android.result == 'success' ||
        needs.build-ios.result == 'success')
@@ -470,14 +467,10 @@ jobs:
         build-android,
         build-ios,
       ]
+    # Run if at least one platform build succeeded.
     if: |
       !cancelled() &&
       needs.release-create.result == 'success' &&
-      (needs.build-macos.result == 'success' || needs.build-macos.result == 'skipped') &&
-      (needs.build-windows.result == 'success' || needs.build-windows.result == 'skipped') &&
-      (needs.build-linux.result == 'success' || needs.build-linux.result == 'skipped') &&
-      (needs.build-android.result == 'success' || needs.build-android.result == 'skipped') &&
-      (needs.build-ios.result == 'success' || needs.build-ios.result == 'skipped') &&
       (needs.build-macos.result == 'success' || needs.build-windows.result == 'success' ||
        needs.build-linux.result == 'success' || needs.build-android.result == 'success' ||
        needs.build-ios.result == 'success')


### PR DESCRIPTION
## Summary

When a single platform build fails in the nightly (e.g., Linux arm64 or Windows), the entire upload + Slack notification pipeline was skipped. This meant no nightly release was posted even though macOS, Android, iOS, and Linux amd64 all succeeded.

### Root cause

`upload-s3` and `upload-release-artifacts` conditions required **every** build to be `success` or `skipped`:
```yaml
(needs.build-linux.result == 'success' || needs.build-linux.result == 'skipped') &&
```

When Linux is a matrix job (amd64 + arm64) and arm64 fails, `build-linux.result` is `failure` — not `success` and not `skipped`. The condition evaluates to false, skipping uploads entirely.

### Fix

Simplify to: run if **at least one** platform succeeded:
```yaml
(needs.build-macos.result == 'success' || needs.build-windows.result == 'success' ||
 needs.build-linux.result == 'success' || needs.build-android.result == 'success' ||
 needs.build-ios.result == 'success')
```

The upload steps already handle missing artifacts gracefully (`upload_if_exists`).

### Evidence

Latest nightly (run 24299006547):
- ✅ macOS, Android, iOS, Linux amd64
- ❌ Linux arm64, Windows
- ⏭️ upload-s3: **skipped** (should have run)
- ⏭️ upload-release-artifacts: **skipped** (should have run)

## Test plan
- [ ] Trigger nightly with one platform disabled — verify uploads + Slack still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)