### PR TITLE
Save last server location

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/getlantern/lantern
 
 go 1.25.4
 
-// replace github.com/getlantern/radiance => ../radiance
+replace github.com/getlantern/radiance => ../radiance
 
 // replace github.com/getlantern/lantern-server-provisioner => ../lantern-server-provisioner
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260413153018-60dad8ede0fd
+	github.com/getlantern/radiance v0.0.0-20260414121753-1a2d88b13b6e
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260414121753-1a2d88b13b6e
+	github.com/getlantern/radiance v0.0.0-20260417101633-2d396075314e
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0
@@ -172,7 +172,7 @@ require (
 	github.com/getlantern/fronted v0.0.0-20260325003030-cb5041ba1538 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260304213122-017d542145ae // indirect
 	github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb // indirect
-	github.com/getlantern/lantern-box v0.0.65 // indirect
+	github.com/getlantern/lantern-box v0.0.67 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/getlantern/lantern
 
 go 1.25.4
 
-replace github.com/getlantern/radiance => ../radiance
+// replace github.com/getlantern/radiance => ../radiance
 
 // replace github.com/getlantern/lantern-server-provisioner => ../lantern-server-provisioner
 
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260410214540-728cf4962aab
+	github.com/getlantern/radiance v0.0.0-20260413153156-4a5fc84dadd3
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260413153018-60dad8ede0fd h1:isi3cnnv9yKOooWtlI6mYK3vxDisMdiDe9/Xex/vtpE=
-github.com/getlantern/radiance v0.0.0-20260413153018-60dad8ede0fd/go.mod h1:H7/Tvde1mBz1/lyz76VfiEdOGAWualquyJAl/LH7rbo=
+github.com/getlantern/radiance v0.0.0-20260414121753-1a2d88b13b6e h1:AccPmAe69O8p2mVM+UIkgWT2lhxeKbQ/6PPMWX0Ej68=
+github.com/getlantern/radiance v0.0.0-20260414121753-1a2d88b13b6e/go.mod h1:H7/Tvde1mBz1/lyz76VfiEdOGAWualquyJAl/LH7rbo=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,6 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260410214540-728cf4962aab h1:bBUEEcHjy8Jm+AZKn0MjNSH3MayWstX/eBZlgVxy2as=
-github.com/getlantern/radiance v0.0.0-20260410214540-728cf4962aab/go.mod h1:klBNcGQTdvk01bH770D5Ctfx++uLLzCo9gP0fdJ7aBg=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
+github.com/getlantern/radiance v0.0.0-20260413153156-4a5fc84dadd3 h1:XC7bCCBvWUf/PS/m5rT6/R3Fn0w2sPDDc1DRd2M/RTs=
+github.com/getlantern/radiance v0.0.0-20260413153156-4a5fc84dadd3/go.mod h1:klBNcGQTdvk01bH770D5Ctfx++uLLzCo9gP0fdJ7aBg=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -249,6 +249,8 @@ github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb h1:A92dC/E/Hvk
 github.com/getlantern/kindling v0.0.0-20260329144042-b1825b9cb1bb/go.mod h1:c5cFjpNrqX8wQ0PUE2blHrO7knAlRCVx3j1/G6zaVlY=
 github.com/getlantern/lantern-box v0.0.65 h1:/PvWqm61PvSjlYWTpLhUHwacpLQ6gTQGXB6BCrYAdko=
 github.com/getlantern/lantern-box v0.0.65/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
+github.com/getlantern/lantern-box v0.0.67 h1:0uDILTY2fVzy47IoEecsMoeplqdxFU/KE/izaZXwM/Q=
+github.com/getlantern/lantern-box v0.0.67/go.mod h1:n5NzI/rqr1USYIQPnEy3oZBYNPDyi8EODXNg8jPsQqY=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
@@ -263,6 +265,8 @@ github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmI
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
 github.com/getlantern/radiance v0.0.0-20260414121753-1a2d88b13b6e h1:AccPmAe69O8p2mVM+UIkgWT2lhxeKbQ/6PPMWX0Ej68=
 github.com/getlantern/radiance v0.0.0-20260414121753-1a2d88b13b6e/go.mod h1:H7/Tvde1mBz1/lyz76VfiEdOGAWualquyJAl/LH7rbo=
+github.com/getlantern/radiance v0.0.0-20260417101633-2d396075314e h1:zxW4xfPSeHtfByibiF1Us2EfGOlpzMIpIPanQ6zD4i0=
+github.com/getlantern/radiance v0.0.0-20260417101633-2d396075314e/go.mod h1:pQoVlqah4QNAb5tPVu+vZ1LA1nB1JclXPjMWwFv+Ec0=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -45,9 +45,7 @@ func StartVPN(platform rvpn.PlatformInterface, opts *utils.Opts) error {
 		if err := vpn.Connect(group, tag); err != nil {
 			return fmt.Errorf("failed to restore selected server %s/%s: %w", group, tag, err)
 		}
-		slog.Info("No persisted server selection found, falling back to AutoConnect", group, tag)
 		return nil
-
 	}
 	slog.Info("No persisted server selection found, falling back to AutoConnect")
 	if err := vpn.AutoConnect(""); err != nil {

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -26,17 +26,31 @@ const (
 var ipcServer atomic.Pointer[ipc.Server]
 
 // StartVPN will start the VPN tunnel using the provided platform interface.
-// It passes the empty string so it will connect to best server available.
+// If the user previously selected a specific server (persisted by
+// vpn.SelectServer), the new tunnel is pinned to that selection. Otherwise it
+// falls back to AutoConnect which picks the best server.
+//
+// This is critical on Android: the OS VPN service lifecycle tears down and
+// recreates libbox on every settings-driven restart, and the in-memory selector
+// state of the previous libbox doesn't carry over. Reading the persisted
+// selection here is what keeps the user pinned to their chosen server across
+// routing-mode toggles, ad-block toggles, etc.
 func StartVPN(platform rvpn.PlatformInterface, opts *utils.Opts) error {
-	// As soon user connects to VPN, we start listening for auto location changes.
 	slog.Info("StartVPN called")
 	if err := initIPC(opts, platform); err != nil {
 		return fmt.Errorf("failed to initialize IPC server: %w", err)
 	}
-	// it should use InternalTagLantern so it will connect to best lantern server by default.
-	// if you want to connect to user server, use ConnectToServer with InternalTagUser
-	err := vpn.AutoConnect("")
-	if err != nil {
+	if group, tag := vpn.LastSelectedServer(); group != "" && tag != "" {
+		slog.Info("Restoring persisted server selection", "group", group, "tag", tag)
+		if err := vpn.Connect(group, tag); err != nil {
+			return fmt.Errorf("failed to restore selected server %s/%s: %w", group, tag, err)
+		}
+		slog.Info("No persisted server selection found, falling back to AutoConnect", group, tag)
+		return nil
+
+	}
+	slog.Info("No persisted server selection found, falling back to AutoConnect")
+	if err := vpn.AutoConnect(""); err != nil {
 		return fmt.Errorf("failed to start VPN: %w", err)
 	}
 	return nil

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -45,6 +45,7 @@ func StartVPN(platform rvpn.PlatformInterface, opts *utils.Opts) error {
 		if err := vpn.Connect(group, tag); err != nil {
 			slog.Warn("Failed to restore persisted server, falling back to AutoConnect",
 				"group", group, "tag", tag, "error", err)
+			vpn.ClearLastSelectedServer()
 		} else {
 			return nil
 		}

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -43,11 +43,14 @@ func StartVPN(platform rvpn.PlatformInterface, opts *utils.Opts) error {
 	if group, tag := vpn.LastSelectedServer(); group != "" && tag != "" {
 		slog.Info("Restoring persisted server selection", "group", group, "tag", tag)
 		if err := vpn.Connect(group, tag); err != nil {
-			return fmt.Errorf("failed to restore selected server %s/%s: %w", group, tag, err)
+			slog.Warn("Failed to restore persisted server, falling back to AutoConnect",
+				"group", group, "tag", tag, "error", err)
+		} else {
+			return nil
 		}
-		return nil
+	} else {
+		slog.Info("No persisted server selection found, falling back to AutoConnect")
 	}
-	slog.Info("No persisted server selection found, falling back to AutoConnect")
 	if err := vpn.AutoConnect(""); err != nil {
 		return fmt.Errorf("failed to start VPN: %w", err)
 	}

--- a/lib/features/home/home.dart
+++ b/lib/features/home/home.dart
@@ -203,27 +203,27 @@ class _HomeState extends ConsumerState<Home> {
             VpnStatus(),
             DividerSpace(),
             LocationSetting(),
-
-            DividerSpace(),
-            SettingTile(
-              label: 'routing_mode'.i18n,
-              icon: AppImagePaths.route,
-              value: routingMode.label(),
-              actions: [
-                IconButton(
-                  onPressed: null,
-                  style: ElevatedButton.styleFrom(
-                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+            if (!PlatformUtils.isIOS) ...[
+              DividerSpace(),
+              SettingTile(
+                label: 'routing_mode'.i18n,
+                icon: AppImagePaths.route,
+                value: routingMode.label(),
+                actions: [
+                  IconButton(
+                    onPressed: null,
+                    style: ElevatedButton.styleFrom(
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    icon: AppImage(path: AppImagePaths.arrowForward),
+                    padding: EdgeInsets.zero,
+                    constraints: BoxConstraints(),
+                    visualDensity: VisualDensity.compact,
                   ),
-                  icon: AppImage(path: AppImagePaths.arrowForward),
-                  padding: EdgeInsets.zero,
-                  constraints: BoxConstraints(),
-                  visualDensity: VisualDensity.compact,
-                ),
-              ],
-              onTap: () => onSettingTileTap(_SettingTileType.smartRouting),
-            ),
-
+                ],
+                onTap: () => onSettingTileTap(_SettingTileType.smartRouting),
+              ),
+            ],
             if (PlatformUtils.isAndroid ||
                 PlatformUtils.isMacOS ||
                 PlatformUtils.isWindows) ...{

--- a/lib/features/home/home.dart
+++ b/lib/features/home/home.dart
@@ -203,27 +203,27 @@ class _HomeState extends ConsumerState<Home> {
             VpnStatus(),
             DividerSpace(),
             LocationSetting(),
-            if (!PlatformUtils.isIOS) ...{
-              DividerSpace(),
-              SettingTile(
-                label: 'routing_mode'.i18n,
-                icon: AppImagePaths.route,
-                value: routingMode.label(),
-                actions: [
-                  IconButton(
-                    onPressed: null,
-                    style: ElevatedButton.styleFrom(
-                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
-                    ),
-                    icon: AppImage(path: AppImagePaths.arrowForward),
-                    padding: EdgeInsets.zero,
-                    constraints: BoxConstraints(),
-                    visualDensity: VisualDensity.compact,
+
+            DividerSpace(),
+            SettingTile(
+              label: 'routing_mode'.i18n,
+              icon: AppImagePaths.route,
+              value: routingMode.label(),
+              actions: [
+                IconButton(
+                  onPressed: null,
+                  style: ElevatedButton.styleFrom(
+                    tapTargetSize: MaterialTapTargetSize.shrinkWrap,
                   ),
-                ],
-                onTap: () => onSettingTileTap(_SettingTileType.smartRouting),
-              ),
-            },
+                  icon: AppImage(path: AppImagePaths.arrowForward),
+                  padding: EdgeInsets.zero,
+                  constraints: BoxConstraints(),
+                  visualDensity: VisualDensity.compact,
+                ),
+              ],
+              onTap: () => onSettingTileTap(_SettingTileType.smartRouting),
+            ),
+
             if (PlatformUtils.isAndroid ||
                 PlatformUtils.isMacOS ||
                 PlatformUtils.isWindows) ...{

--- a/lib/features/home/provider/app_event_notifier.dart
+++ b/lib/features/home/provider/app_event_notifier.dart
@@ -28,8 +28,9 @@ class AppEventNotifier extends _$AppEventNotifier {
   Future<void> build() async {
     watchAppEvents();
     ref.onDispose(() {
-      appLogger
-          .debug('Disposing AppEventNotifier and cancelling subscriptions.');
+      appLogger.debug(
+        'Disposing AppEventNotifier and cancelling subscriptions.',
+      );
       _appEventSub?.cancel();
     });
   }
@@ -38,8 +39,9 @@ class AppEventNotifier extends _$AppEventNotifier {
   /// Currently, it listens for 'config' and server-location events.
   void watchAppEvents() {
     appLogger.debug('Setting up app event listener...');
-    _appEventSub =
-        ref.read(lanternServiceProvider).watchAppEvents().listen((event) {
+    _appEventSub = ref.read(lanternServiceProvider).watchAppEvents().listen((
+      event,
+    ) {
       final eventType = event.eventType;
       appLogger.debug('Received app event of type: $eventType');
       switch (eventType) {
@@ -52,6 +54,14 @@ class AppEventNotifier extends _$AppEventNotifier {
           ref.read(homeProvider.notifier).fetchUserDataIfNeeded();
           break;
         case 'server-location':
+          // Only consume this event when the user is actually in auto mode.
+          // Otherwise (custom server selected) ignore it — applying it would
+          // silently flip the user's selection back to Smart Location on
+          // routing-mode changes or any other tunnel rebuild.
+          final currentLocation = ref.read(serverLocationProvider);
+          if (currentLocation.serverType != ServerLocationType.auto.name) {
+            break;
+          }
           try {
             final autoLocation = Server.fromJson(jsonDecode(event.message));
             final countryName = autoLocation.location!.country;

--- a/lib/features/vpn/provider/server_location_notifier.dart
+++ b/lib/features/vpn/provider/server_location_notifier.dart
@@ -31,6 +31,28 @@ class ServerLocationNotifier extends _$ServerLocationNotifier {
     }
   }
 
+  /// Updates only the auto-location metadata (the "Smart Location" label)
+  /// without changing the user's active selection. Used by the `server-location`
+  /// push event from the Go side, which reports what auto-routing chose and
+  /// must NOT overwrite a custom server the user has selected.
+  Future<void> updateAutoLocationMetadata(AutoLocation autoLocation) async {
+    final updated = state.copyWith(autoLocation: autoLocation);
+    state = updated;
+    await _storage.saveServerLocation(updated);
+  }
+
+  /// Flips the active selection to auto without discarding any existing
+  /// fields. The previous custom-server fields (serverName, country, etc.)
+  /// stay in state — only [serverType] changes — so the existing
+  /// autoLocation metadata (if any) remains and the Smart Location label
+  /// doesn't briefly flicker to "fastest_server" before the next push event.
+  Future<void> switchToAuto() async {
+    if (state.serverType == ServerLocationType.auto.name) return;
+    final updated = state.copyWith(serverType: ServerLocationType.auto.name);
+    state = updated;
+    await _storage.saveServerLocation(updated);
+  }
+
   Future<void> ifNeededGetAutoServerLocation() async {
     final status = ref.read(vpnProvider);
     final current = state;

--- a/lib/features/vpn/provider/server_location_notifier.dart
+++ b/lib/features/vpn/provider/server_location_notifier.dart
@@ -31,21 +31,10 @@ class ServerLocationNotifier extends _$ServerLocationNotifier {
     }
   }
 
-  /// Updates only the auto-location metadata (the "Smart Location" label)
-  /// without changing the user's active selection. Used by the `server-location`
-  /// push event from the Go side, which reports what auto-routing chose and
-  /// must NOT overwrite a custom server the user has selected.
-  Future<void> updateAutoLocationMetadata(AutoLocation autoLocation) async {
-    final updated = state.copyWith(autoLocation: autoLocation);
-    state = updated;
-    await _storage.saveServerLocation(updated);
-  }
-
-  /// Flips the active selection to auto without discarding any existing
-  /// fields. The previous custom-server fields (serverName, country, etc.)
-  /// stay in state — only [serverType] changes — so the existing
-  /// autoLocation metadata (if any) remains and the Smart Location label
-  /// doesn't briefly flicker to "fastest_server" before the next push event.
+  /// Flips the active selection to auto and clears any stale custom-server
+  /// identity fields so downstream UI does not keep highlighting a previous
+  /// manual selection. The existing [autoLocation] metadata is preserved so
+  /// the Smart Location label remains available until the next push event.
   Future<void> switchToAuto() async {
     if (state.serverType == ServerLocationType.auto.name) return;
     final updated = state.copyWith(serverType: ServerLocationType.auto.name);

--- a/lib/features/vpn/server_selection.dart
+++ b/lib/features/vpn/server_selection.dart
@@ -205,7 +205,8 @@ class _ServerSelectionState extends ConsumerState<ServerSelection> {
 
     result.fold(
       (failure) => context.showSnackBar(failure.localizedErrorMessage),
-      (_) {
+      (_) async {
+        await ref.read(serverLocationProvider.notifier).switchToAuto();
         appRouter.popUntilRoot();
       },
     );


### PR DESCRIPTION
This pull request introduces several improvements to the VPN server selection and event handling logic, ensuring that user-selected servers are correctly persisted and restored, and that automatic server updates do not override user choices. It also adds new methods for more granular state management and improves logging and code clarity.

**VPN server selection and persistence improvements:**

* Updated `StartVPN` in `vpn_tunnel.go` to restore the user's previously selected server on tunnel startup, falling back to auto-selection only if no prior selection exists. This ensures user choices persist across VPN restarts, especially on Android.
* In `server_selection.dart`, ensured that switching to auto server selection explicitly updates the state before navigating, preventing stale or inconsistent UI.

**Event handling enhancements:**

* Modified `AppEventNotifier` to process `server-location` events only when the user is in auto mode, preventing unwanted overrides of custom server selections.
* Improved logging and code formatting in `app_event_notifier.dart` for better readability and maintainability. [[1]](diffhunk://#diff-a796ab2befef63f34821d469e984851e9db569f8a428836a363eb49d0244918cL31-R33) [[2]](diffhunk://#diff-a796ab2befef63f34821d469e984851e9db569f8a428836a363eb49d0244918cL41-R44)

**State management additions:**

* Added `updateAutoLocationMetadata` and `switchToAuto` methods to `ServerLocationNotifier`, allowing for metadata updates and seamless switching to auto mode without losing previous custom server information.

**Other:**

* Minor formatting fix in `go.mod` for the `replace` directive.