### PR TITLE
ci: verify go.mod and go.sum are tidy

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,6 +42,19 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: Verify go.mod and go.sum are tidy
+        # Stale entries in go.sum can cause tooling (notably `gomobile bind`)
+        # to resolve transitive deps to older versions that still have
+        # valid hashes, even when go.mod declares newer ones. This bit us
+        # on 2026-04-13 when a release build ended up with lantern-box
+        # v0.0.58 baked in despite go.mod declaring v0.0.65.
+        run: |
+          go mod tidy
+          if ! git diff --exit-code go.mod go.sum; then
+            echo "::error::go.mod or go.sum is not tidy. Run 'go mod tidy' locally and commit the result."
+            exit 1
+          fi
+
       - name: Run gofmt
         run: |
           UNFORMATTED=$(gofmt -l .)


### PR DESCRIPTION
## Summary

Adds a CI step that runs \`go mod tidy\` and fails if the result differs from what's committed.

## Why

Stale entries in \`go.sum\` can cause Go tooling — notably \`gomobile bind\` — to resolve transitive dependencies to older versions that still have valid hashes, even when \`go.mod\` correctly declares newer ones.

This bit us on 2026-04-13:

- \`go.mod\` correctly declared \`github.com/getlantern/lantern-box v0.0.65\` (via getlantern/lantern#8654)
- \`go.sum\` still had hash entries for v0.0.62 and v0.0.58
- A release build produced by CI ended up with \`lantern-box@v0.0.58\` compiled in (confirmed via \`strings\` on the binary)
- The compiled-in v0.0.58 did not include \`"reflex"\` in \`supportedProtocols\`, so Reflex routes were invisible to the client even though the server was fully configured
- Fixed by \`go mod tidy\` in d1861a27e, which removed 4 stale lines from \`go.sum\`

This PR guards against the same failure mode next time someone bumps a dependency with \`go get\` and forgets \`go mod tidy\`.

## Check behavior

\`\`\`bash
- name: Verify go.mod and go.sum are tidy
  run: |
    go mod tidy
    if ! git diff --exit-code go.mod go.sum; then
      echo "::error::go.mod or go.sum is not tidy. Run 'go mod tidy' locally and commit the result."
      exit 1
    fi
\`\`\`

Runs after \`go mod download\` so the module cache is already warm.

## Test

The step should be a no-op on the current tidy tree. If anyone submits a PR with an out-of-sync \`go.sum\`, the job fails with a clear actionable message.