### PR TITLE
update radiance-to-device limit flow fix.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260413153018-60dad8ede0fd
+	github.com/getlantern/radiance v0.0.0-20260414112821-f1c425231e41
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260413153018-60dad8ede0fd h1:isi3cnnv9yKOooWtlI6mYK3vxDisMdiDe9/Xex/vtpE=
-github.com/getlantern/radiance v0.0.0-20260413153018-60dad8ede0fd/go.mod h1:H7/Tvde1mBz1/lyz76VfiEdOGAWualquyJAl/LH7rbo=
+github.com/getlantern/radiance v0.0.0-20260414112821-f1c425231e41 h1:Ffi1bJDwAxHD31IiVzlQad8AULxbxIYcUSMrJest1fU=
+github.com/getlantern/radiance v0.0.0-20260414112821-f1c425231e41/go.mod h1:H7/Tvde1mBz1/lyz76VfiEdOGAWualquyJAl/LH7rbo=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
This pull request updates the dependency version for `github.com/getlantern/radiance` in the `go.mod` file. The new version likely includes bug fixes or improvements from the upstream repository.

Dependency update:

* Upgraded `github.com/getlantern/radiance` to version `v0.0.0-20260414112821-f1c425231e41` in `go.mod`