### PR TITLE
deps: update sing-box-minimal to v1.12.21-lantern

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ go 1.25.4
 
 replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 
-replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.19-lantern
+replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.21-lantern
 
 replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v0.0.1-beta.7.0.20251208214020-d78e69f1eff4
 

--- a/go.sum
+++ b/go.sum
@@ -269,8 +269,8 @@ github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=
 github.com/getlantern/sing v0.7.18-lantern/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
-github.com/getlantern/sing-box-minimal v1.12.19-lantern h1:Tntq+Udsvyv6A/mjxfSoZ8NhvhXRSX6i/CICKGPFhAY=
-github.com/getlantern/sing-box-minimal v1.12.19-lantern/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
+github.com/getlantern/sing-box-minimal v1.12.21-lantern h1:DUlwWDHrU60hd/83mvU/fR9aASiq4KaN5Z1wa8gaRtM=
+github.com/getlantern/sing-box-minimal v1.12.21-lantern/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 h1:VTNjZxSuAHUzu13lYpEVB8gc3xz5hZePGNHG5enHYLY=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9/go.mod h1:7uvbzuoOr3uYGHZx5QWlI8/C52XEf/aTb/tJFEe41Ak=
 github.com/getlantern/waitforserver v1.0.1 h1:xBjqJ3GgEk9JMWnDgRSiNHXINi6Lv2tGNjJR0hCkHFY=


### PR DESCRIPTION
## Summary

Bumps \`github.com/sagernet/sing-box\` replace directive from \`getlantern/sing-box-minimal v1.12.19-lantern\` → \`v1.12.21-lantern\`.

### Changes ([getlantern/sing-box-minimal](https://github.com/getlantern/sing-box-minimal))

**Fix: non-fatal remote rule-set fetch on Android ([#39](https://github.com/getlantern/sing-box-minimal/pull/39), [#40](https://github.com/getlantern/sing-box-minimal/pull/40))**
- On Android, the network interface isn't available during VPN initialization, so fetching remote rule-sets (e.g. \`common.srs\` from GitHub) was failing fatally and preventing the VPN from starting entirely
- Now logs a warning and continues without rule-sets; \`PostStart\` retries the fetch after the tunnel is connected and the network is available
- Also prevents log spam: if the \`PostStart\` retry also fails, \`lastUpdated\` is set to \`now\` so \`loopUpdate\` doesn't immediately re-fetch on the next tick

**Fix: DefaultInterfaceMonitor fallback for VPN TUN interfaces ([#36](https://github.com/getlantern/sing-box-minimal/pull/36))**
- Fixed \`DefaultInterfaceMonitor\` fallback path when the active interface is a VPN TUN interface (e.g. \`tun0\`)
- Added unit tests for the fallback path

## Test plan
- [ ] \`go build ./...\` passes
- [ ] On Android: VPN starts successfully even when remote rule-sets are initially unreachable
- [ ] Smart routing rules apply after tunnel connects (brief delay instead of blocking startup)

🤖 Generated with [Claude Code](https://claude.com/claude-code)