### PR TITLE
Show vpn conflict dialog on smart location

### DIFF
--- a/lib/features/vpn/server_selection.dart
+++ b/lib/features/vpn/server_selection.dart
@@ -204,7 +204,28 @@ class _ServerSelectionState extends ConsumerState<ServerSelection> {
     final result = await ref.read(vpnProvider.notifier).startVPN(force: true);
 
     result.fold(
-      (failure) => context.showSnackBar(failure.localizedErrorMessage),
+      (failure) {
+        if (failure is VpnConflictFailure) {
+          AppDialog.vpnConflictDialog(
+            context: context,
+            onConnectAnyway: () async {
+              appRouter.maybePop();
+              final retryResult = await ref
+                  .read(vpnProvider.notifier)
+                  .startVPN(skipConflictCheck: true, force: true);
+              if (!context.mounted) return;
+              retryResult.fold((failure) {
+                context.showSnackBar(failure.localizedErrorMessage);
+                appLogger.error(
+                  "Error changing VPN state: ${failure.localizedErrorMessage}",
+                );
+              }, (_) => null);
+            },
+          );
+        } else {
+          context.showSnackBar(failure.localizedErrorMessage);
+        }
+      },
       (_) {
         appRouter.popUntilRoot();
       },

--- a/lib/features/vpn/server_selection.dart
+++ b/lib/features/vpn/server_selection.dart
@@ -206,6 +206,9 @@ class _ServerSelectionState extends ConsumerState<ServerSelection> {
     result.fold(
       (failure) {
         if (failure is VpnConflictFailure) {
+          if (!context.mounted) {
+            return;
+          }
           AppDialog.vpnConflictDialog(
             context: context,
             onConnectAnyway: () async {
@@ -219,7 +222,7 @@ class _ServerSelectionState extends ConsumerState<ServerSelection> {
                 appLogger.error(
                   "Error changing VPN state: ${failure.localizedErrorMessage}",
                 );
-              }, (_) => null);
+              }, (_) => appRouter.popUntilRoot());
             },
           );
         } else {


### PR DESCRIPTION
This pull request improves the user experience when a VPN conflict occurs during server selection. Instead of simply showing an error, the app now displays a dialog allowing the user to resolve the conflict and retry the connection.

**Enhanced VPN conflict handling:**

* Updated the failure handling logic in the `startVPN` call within `server_selection.dart` to detect `VpnConflictFailure` and present a `vpnConflictDialog`. The dialog gives the user an option to "Connect Anyway," which retries the VPN connection with the conflict check skipped. Errors on retry are logged and shown to the user as a snackbar.