### PR TITLE
mobile: return string instead of []byte from gomobile-exported funcs

### DIFF
--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -252,8 +252,15 @@ func StopAutoLocationListener() error {
 }
 
 // GetAvailableServers returns the available servers in JSON format.
-func GetAvailableServers() ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.GetAvailableServers(), nil })
+//
+// Returns string (not []byte) so the gomobile wrapper marshals the return value
+// via C.malloc rather than leaving it as a Go slice header. This avoids a
+// runtime.bulkBarrierPreWrite panic on the cgo callback goroutine during GC
+// (see getlantern/engineering#3175).
+func GetAvailableServers() (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		return string(c.GetAvailableServers()), nil
+	})
 }
 
 func IsVPNConnected() bool {
@@ -335,15 +342,24 @@ func LoadInstalledApps(dataDir string) (string, error) {
 
 // User Methods
 // UserData returns pre-fetched user data.
-func UserData() ([]byte, error) {
+//
+// Returns string (not []byte) to avoid the gomobile cgo return-path write barrier
+// panic. See getlantern/engineering#3175.
+func UserData() (string, error) {
 	slog.Debug("User data")
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.UserData() })
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.UserData()
+		return string(b), err
+	})
 }
 
 // FetchUserData will get the user data from the server
-func FetchUserData() ([]byte, error) {
+func FetchUserData() (string, error) {
 	slog.Debug("Fetching user data")
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.FetchUserData() })
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.FetchUserData()
+		return string(b), err
+	})
 }
 
 // OAuth Methods
@@ -351,8 +367,11 @@ func OAuthLoginUrl(provider string) (string, error) {
 	return withCoreR(func(c lanterncore.Core) (string, error) { return c.OAuthLoginUrl(provider) })
 }
 
-func OAuthLoginCallback(oAuthToken string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.OAuthLoginCallback(oAuthToken) })
+func OAuthLoginCallback(oAuthToken string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.OAuthLoginCallback(oAuthToken)
+		return string(b), err
+	})
 }
 
 func StripeSubscription(email, planID string) (string, error) {
@@ -366,15 +385,15 @@ func StripeBillingPortalUrl() (string, error) {
 	return withCoreR(func(c lanterncore.Core) (string, error) { return c.StripeBillingPortalUrl() })
 }
 
-func AcknowledgeGooglePurchase(purchaseToken, planId string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) {
+func AcknowledgeGooglePurchase(purchaseToken, planId string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
 		data, err := c.AcknowledgeGooglePurchase(purchaseToken, planId)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		var resp api.VerifySubscriptionResponse
 		if err := json.Unmarshal([]byte(data), &resp); err != nil {
-			return nil, fmt.Errorf("error unmarshalling acknowledge google purchase response: %v", err)
+			return "", fmt.Errorf("error unmarshalling acknowledge google purchase response: %v", err)
 		}
 
 		if resp.ActualUserId != 0 && resp.ActualUserToken != "" {
@@ -385,25 +404,25 @@ func AcknowledgeGooglePurchase(purchaseToken, planId string) ([]byte, error) {
 			settings.Set(settings.TokenKey, resp.ActualUserToken)
 			userData, err := FetchUserData()
 			if err != nil {
-				return nil, err
+				return "", err
 			}
 			return userData, nil
 		}
-		/// Purchase was made on the same account, just return nil to indicate success
-		return nil, nil
+		/// Purchase was made on the same account, just return "" to indicate success
+		return "", nil
 
 	})
 }
 
-func AcknowledgeApplePurchase(receipt, planII string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) {
+func AcknowledgeApplePurchase(receipt, planII string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
 		data, err := c.AcknowledgeApplePurchase(receipt, planII)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		var resp api.VerifySubscriptionResponse
 		if err := json.Unmarshal([]byte(data), &resp); err != nil {
-			return nil, fmt.Errorf("error unmarshalling acknowledge apple purchase response: %v", err)
+			return "", fmt.Errorf("error unmarshalling acknowledge apple purchase response: %v", err)
 		}
 		if resp.ActualUserId != 0 && resp.ActualUserToken != "" {
 			/// This means the purchase was made on a different account and we need to switch to that account
@@ -413,13 +432,13 @@ func AcknowledgeApplePurchase(receipt, planII string) ([]byte, error) {
 			settings.Set(settings.TokenKey, resp.ActualUserToken)
 			userData, err := FetchUserData()
 			if err != nil {
-				return nil, err
+				return "", err
 			}
-			slog.Debug("fetched user data after account switch", "userdata", string(userData))
+			slog.Debug("fetched user data after account switch", "userdata", userData)
 			return userData, nil
 		}
-		/// Purchase was made on the same account, just return nil to indicate success
-		return nil, nil
+		/// Purchase was made on the same account, just return "" to indicate success
+		return "", nil
 
 	})
 }
@@ -440,8 +459,11 @@ func StripeSubscriptionPaymentRedirect(subType, planId, email string) (string, e
 
 /// User management apis
 
-func Login(email, password string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.Login(email, password) })
+func Login(email, password string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.Login(email, password)
+		return string(b), err
+	})
 }
 
 func StartChangeEmail(newEmail, password string) error {
@@ -456,8 +478,11 @@ func SignUp(email, password string) error {
 	return withCore(func(c lanterncore.Core) error { return c.SignUp(email, password) })
 }
 
-func Logout(email string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.Logout(email) })
+func Logout(email string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.Logout(email)
+		return string(b), err
+	})
 }
 
 func GetDataCapInfo() (string, error) {
@@ -500,8 +525,11 @@ func ReferralAttachment(referralCode string) error {
 	})
 }
 
-func DeleteAccount(email, password string, isOAuthUser bool) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.DeleteAccount(email, password, isOAuthUser) })
+func DeleteAccount(email, password string, isOAuthUser bool) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.DeleteAccount(email, password, isOAuthUser)
+		return string(b), err
+	})
 }
 
 func ActivationCode(email, resellerCode string) error {


### PR DESCRIPTION
## Summary

Gomobile-exported functions returning `([]byte, error)` can crash with a Go runtime write-barrier panic during GC. This PR converts 9 such functions to return `(string, error)`.

## Root Cause

The gomobile wrapper runs on the cgo callback goroutine (locked to the C thread). After the Go function returns, the wrapper copies the return value into a C struct on the OS thread stack using `runtime.wbMove`. Because `[]byte` contains a pointer (slice data), `wbMove` calls `bulkBarrierPreWrite` to track the write. With an active GC cycle, `bulkBarrierPreWrite` verifies the destination is GC-tracked — the C thread stack is not — and calls `runtime.throw`.

Full analysis: getlantern/engineering#3175

## Affected Functions

- `UserData`, `FetchUserData`
- `GetAvailableServers`
- `OAuthLoginCallback`
- `AcknowledgeGooglePurchase`, `AcknowledgeApplePurchase`
- `Login`, `Logout`
- `DeleteAccount`

## Breaking Changes for Swift/Obj-C

The gomobile-generated Objective-C signatures change from `NSData*` to `NSString*`. Callers that need raw bytes can convert with `.data(using: .utf8)`.

## Source

Diagnosed from Freshdesk [#172640](https://lantern.freshdesk.com/a/tickets/172640) — internal user Derek reported a hard crash on macOS 26.3.1. The crash signature was `runtime.throw` in `runtime.bulkBarrierPreWrite` from `_cgoexp_*_proxymobile__UserData` with a GC mark termination cycle active concurrently.

Note: `radiance/common/gostack.go` has a `RunOffCgoStack` shim that was intended to fix this class of bug. Its comment claims moving the function body to a real goroutine "avoids this entirely", but the return-value marshaling still happens on the cgo callback goroutine — so the shim only protected the body, not the return path. This PR addresses the remaining gap.

## Test Plan
- [x] `go build ./...` passes in lantern repo
- [x] `go vet ./lantern-core/...` clean
- [ ] Swift/Obj-C callers updated to handle `NSString` return types (follow-up)
- [ ] Verify in v9.0.26 beta that the crash no longer reproduces

🤖 Generated with [Claude Code](https://claude.com/claude-code)