### PR TITLE
mobile: return string instead of []byte + update Swift callers

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -447,7 +447,7 @@ class MethodHandler : FlutterPlugin,
                             map["planId"] as String
                         )
                         withContext(Dispatchers.Main) {
-                            success(subscriptionData)
+                            success(subscriptionData.toByteArray(Charsets.UTF_8))
                         }
                     }.onFailure { e ->
                         result.error(
@@ -512,9 +512,9 @@ class MethodHandler : FlutterPlugin,
                 scope.launch {
                     result.runCatching {
                         val token = call.arguments<String>()
-                        val bytes = Mobile.oAuthLoginCallback(token)
+                        val json = Mobile.oAuthLoginCallback(token)
                         withContext(Dispatchers.Main) {
-                            success(bytes)
+                            success(json.toByteArray(Charsets.UTF_8))
                         }
                     }.onFailure { e ->
                         result.error(
@@ -529,9 +529,9 @@ class MethodHandler : FlutterPlugin,
             Methods.GetUserData.method -> {
                 scope.launch {
                     result.runCatching {
-                        val bytes = Mobile.userData()
+                        val json = Mobile.userData()
                         withContext(Dispatchers.Main) {
-                            success(bytes)
+                            success(json.toByteArray(Charsets.UTF_8))
                         }
                     }.onFailure { e ->
                         result.error(
@@ -546,9 +546,9 @@ class MethodHandler : FlutterPlugin,
             Methods.FetchUserData.method -> {
                 scope.launch {
                     result.runCatching {
-                        val bytes = Mobile.fetchUserData()
+                        val json = Mobile.fetchUserData()
                         withContext(Dispatchers.Main) {
-                            success(bytes)
+                            success(json.toByteArray(Charsets.UTF_8))
                         }
 
                     }.onFailure { e ->
@@ -647,9 +647,9 @@ class MethodHandler : FlutterPlugin,
                         val map = call.arguments as Map<*, *>
                         val email = map["email"] as String? ?: error("Missing email")
                         val password = map["password"] as String? ?: error("Missing password")
-                        val bytes = Mobile.login(email, password)
+                        val json = Mobile.login(email, password)
                         withContext(Dispatchers.Main) {
-                            success(bytes)
+                            success(json.toByteArray(Charsets.UTF_8))
                         }
                     }.onFailure { e ->
                         result.error(
@@ -686,9 +686,9 @@ class MethodHandler : FlutterPlugin,
                     result.runCatching {
                         val email = call.arguments<String>();
                         AppLogger.d(TAG, "Logout email: $email")
-                        val bytes = Mobile.logout(email)
+                        val json = Mobile.logout(email)
                         withContext(Dispatchers.Main) {
-                            success(bytes)
+                            success(json.toByteArray(Charsets.UTF_8))
                         }
                     }.onFailure { e ->
                         result.error(
@@ -707,9 +707,9 @@ class MethodHandler : FlutterPlugin,
                         val email = map["email"] as String? ?: error("Missing email")
                         val password = map["password"] as String? ?: error("Missing password")
                         val isSSO = map["isSSO"] as Boolean? ?: error("Missing isSSO")
-                        val bytes = Mobile.deleteAccount(email, password,isSSO)
+                        val json = Mobile.deleteAccount(email, password,isSSO)
                         withContext(Dispatchers.Main) {
-                            success(bytes)
+                            success(json.toByteArray(Charsets.UTF_8))
                         }
                     }.onFailure { e ->
                         result.error(
@@ -1032,9 +1032,9 @@ class MethodHandler : FlutterPlugin,
             Methods.FeatureFlag.method -> {
                 scope.launch {
                     result.runCatching {
-                        val map = Mobile.availableFeatures()
+                        val flags = Mobile.availableFeatures()
                         withContext(Dispatchers.Main) {
-                            success(String(map))
+                            success(if (flags.isEmpty()) "{}" else flags)
                         }
                     }.onFailure { e ->
                         result.error(
@@ -1092,7 +1092,7 @@ class MethodHandler : FlutterPlugin,
                     result.runCatching {
                         val data = Mobile.getAvailableServers()
                         withContext(Dispatchers.Main) {
-                            success(String(data))
+                            success(if (data.isEmpty()) "[]" else data)
                         }
                     }.onFailure { e ->
                         result.error(
@@ -1124,7 +1124,7 @@ class MethodHandler : FlutterPlugin,
             Methods.GetSelectedServerJSON.method -> {
                 scope.handleValue(result, "get_selected_server_json") {
                     val data = Mobile.getSelectedServerJSON()
-                    if (data != null && data.isNotEmpty()) String(data) else "{}"
+                    if (data.isNullOrEmpty()) "{}" else data
                 }
             }
 

--- a/ios/Runner/Handlers/MethodHandler.swift
+++ b/ios/Runner/Handlers/MethodHandler.swift
@@ -438,13 +438,15 @@ class MethodHandler {
   private func oauthLoginCallback(result: @escaping FlutterResult, token: String) {
     Task {
       var error: NSError?
-      let data = try MobileOAuthLoginCallback(token, &error)
+      let json = try MobileOAuthLoginCallback(token, &error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "OAUTH_LOGIN_CALLBACK")
         return
       }
       await MainActor.run {
-        result(data)
+        // Dart side expects bytes to utf8.decode — convert the gomobile-returned
+        // string back to Data to preserve the Flutter contract.
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -452,13 +454,13 @@ class MethodHandler {
   private func getUserData(result: @escaping FlutterResult) {
     Task {
       var error: NSError?
-      let data = try MobileUserData(&error)
+      let json = try MobileUserData(&error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "USER_DATA_ERROR")
         return
       }
       await MainActor.run {
-        result(data)
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -480,13 +482,13 @@ class MethodHandler {
   private func fetchUserData(result: @escaping FlutterResult) {
     Task {
       var error: NSError?
-      let bytes = MobileFetchUserData(&error)
+      let json = MobileFetchUserData(&error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "FETCH_USER_DATA_ERROR")
         return
       }
       await MainActor.run {
-        result(bytes)
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -536,13 +538,13 @@ class MethodHandler {
   func acknowledgeInAppPurchase(token: String, planId: String, result: @escaping FlutterResult) {
     Task {
       var error: NSError?
-      let data = MobileAcknowledgeApplePurchase(token, planId, &error)
+      let json = MobileAcknowledgeApplePurchase(token, planId, &error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "ACKNOWLEDGE_FAILED")
         return
       }
       await MainActor.run {
-        result(data)
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -607,7 +609,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload)
+        result(payload?.data(using: .utf8))
       }
     }
   }
@@ -635,7 +637,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload)
+        result(payload?.data(using: .utf8))
       }
     }
   }
@@ -652,7 +654,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload)
+        result(payload?.data(using: .utf8))
       }
     }
   }
@@ -930,15 +932,9 @@ class MethodHandler {
 
   func featureFlags(result: @escaping FlutterResult) {
     Task {
-      let flags = MobileAvailableFeatures()
-      guard let flags else {
-        await MainActor.run {
-          result("{}")
-        }
-        return
-      }
+      let flags = MobileAvailableFeatures() ?? ""
       await MainActor.run {
-        result(String(data: flags, encoding: .utf8))
+        result(flags.isEmpty ? "{}" : flags)
       }
     }
   }
@@ -963,12 +959,9 @@ class MethodHandler {
         await self.handleFlutterError(error, result: result, code: "GET_LANTERN_SERVERS_ERROR")
         return
       }
-      guard let servers else {
-        await MainActor.run { result("[]") }
-        return
-      }
       await MainActor.run {
-        result(String(data: servers, encoding: .utf8))
+        let s = servers ?? ""
+        result(s.isEmpty ? "[]" : s)
       }
     }
   }
@@ -995,12 +988,8 @@ class MethodHandler {
         await self.handleFlutterError(error, result: result, code: "GET_SELECTED_SERVER_ERROR")
         return
       }
-      let json: String
-      if let data, let decoded = String(data: data, encoding: .utf8), !decoded.isEmpty {
-        json = decoded
-      } else {
-        json = "{}"
-      }
+      let s = data ?? ""
+      let json = s.isEmpty ? "{}" : s
       await MainActor.run {
         result(json)
       }

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -169,12 +169,18 @@ func IsSmartRoutingEnabled() bool {
 	return ok
 }
 
-func AvailableFeatures() []byte {
-	b, err := withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.AvailableFeatures(), nil })
+// AvailableFeatures returns feature-flag data as a JSON string.
+//
+// Returns string (not []byte) so the gomobile wrapper marshals the return value
+// via C.malloc rather than leaving it as a Go slice header. This avoids a
+// runtime.bulkBarrierPreWrite panic on the cgo callback goroutine during GC
+// (see getlantern/engineering#3175).
+func AvailableFeatures() string {
+	s, err := withCoreR(func(c lanterncore.Core) (string, error) { return string(c.AvailableFeatures()), nil })
 	if err != nil {
-		return []byte(`{}`)
+		return `{}`
 	}
-	return b
+	return s
 }
 
 func MyDeviceId() (string, error) {
@@ -342,8 +348,12 @@ func StopAutoLocationListener() error {
 }
 
 // GetAvailableServers returns the available servers in JSON format.
-func GetAvailableServers() ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.GetAvailableServers(), nil })
+//
+// Returns string (not []byte) — see AvailableFeatures for the rationale.
+func GetAvailableServers() (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		return string(c.GetAvailableServers()), nil
+	})
 }
 
 func IsVPNConnected() bool {
@@ -366,9 +376,10 @@ func GetSelectedServer() string {
 	return s
 }
 
-func GetSelectedServerJSON() ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) {
-		return c.GetSelectedServerJSON()
+func GetSelectedServerJSON() (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.GetSelectedServerJSON()
+		return string(b), err
 	})
 }
 
@@ -430,15 +441,21 @@ func LoadInstalledApps(dataDir string) (string, error) {
 
 // User Methods
 // UserData returns pre-fetched user data.
-func UserData() ([]byte, error) {
+func UserData() (string, error) {
 	slog.Debug("User data")
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.UserData() })
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.UserData()
+		return string(b), err
+	})
 }
 
 // FetchUserData will get the user data from the server
-func FetchUserData() ([]byte, error) {
+func FetchUserData() (string, error) {
 	slog.Debug("Fetching user data")
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.FetchUserData() })
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.FetchUserData()
+		return string(b), err
+	})
 }
 
 // OAuth Methods
@@ -446,8 +463,11 @@ func OAuthLoginUrl(provider string) (string, error) {
 	return withCoreR(func(c lanterncore.Core) (string, error) { return c.OAuthLoginUrl(provider) })
 }
 
-func OAuthLoginCallback(oAuthToken string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.OAuthLoginCallback(oAuthToken) })
+func OAuthLoginCallback(oAuthToken string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.OAuthLoginCallback(oAuthToken)
+		return string(b), err
+	})
 }
 
 func StripeSubscription(email, planID string) (string, error) {
@@ -461,15 +481,15 @@ func StripeBillingPortalUrl() (string, error) {
 	return withCoreR(func(c lanterncore.Core) (string, error) { return c.StripeBillingPortalUrl() })
 }
 
-func AcknowledgeGooglePurchase(purchaseToken, planId string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) {
+func AcknowledgeGooglePurchase(purchaseToken, planId string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
 		data, err := c.AcknowledgeGooglePurchase(purchaseToken, planId)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		var resp account.VerifySubscriptionResponse
 		if err := json.Unmarshal([]byte(data), &resp); err != nil {
-			return nil, fmt.Errorf("error unmarshalling acknowledge google purchase response: %v", err)
+			return "", fmt.Errorf("error unmarshalling acknowledge google purchase response: %v", err)
 		}
 
 		if resp.ActualUserID != 0 && resp.ActualUserToken != "" {
@@ -482,29 +502,29 @@ func AcknowledgeGooglePurchase(purchaseToken, planId string) ([]byte, error) {
 				settings.TokenKey:  resp.ActualUserToken,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("error updating settings after account switch: %v", err)
+				return "", fmt.Errorf("error updating settings after account switch: %v", err)
 			}
 			userData, err := FetchUserData()
 			if err != nil {
-				return nil, err
+				return "", err
 			}
 			return userData, nil
 		}
-		/// Purchase was made on the same account, just return nil to indicate success
-		return nil, nil
+		/// Purchase was made on the same account, just return "" to indicate success
+		return "", nil
 
 	})
 }
 
-func AcknowledgeApplePurchase(receipt, planII string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) {
+func AcknowledgeApplePurchase(receipt, planII string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
 		data, err := c.AcknowledgeApplePurchase(receipt, planII)
 		if err != nil {
-			return nil, err
+			return "", err
 		}
 		var resp account.VerifySubscriptionResponse
 		if err := json.Unmarshal([]byte(data), &resp); err != nil {
-			return nil, fmt.Errorf("error unmarshalling acknowledge apple purchase response: %v", err)
+			return "", fmt.Errorf("error unmarshalling acknowledge apple purchase response: %v", err)
 		}
 		if resp.ActualUserID != 0 && resp.ActualUserToken != "" {
 			/// This means the purchase was made on a different account and we need to switch to that account
@@ -516,17 +536,17 @@ func AcknowledgeApplePurchase(receipt, planII string) ([]byte, error) {
 				settings.TokenKey:  resp.ActualUserToken,
 			})
 			if err != nil {
-				return nil, fmt.Errorf("error updating settings after account switch: %v", err)
+				return "", fmt.Errorf("error updating settings after account switch: %v", err)
 			}
 			userData, err := FetchUserData()
 			if err != nil {
-				return nil, err
+				return "", err
 			}
-			slog.Debug("fetched user data after account switch", "userdata", string(userData))
+			slog.Debug("fetched user data after account switch", "userdata", userData)
 			return userData, nil
 		}
-		/// Purchase was made on the same account, just return nil to indicate success
-		return nil, nil
+		/// Purchase was made on the same account, just return "" to indicate success
+		return "", nil
 
 	})
 }
@@ -547,8 +567,11 @@ func StripeSubscriptionPaymentRedirect(subType, planId, email string) (string, e
 
 /// User management apis
 
-func Login(email, password string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.Login(email, password) })
+func Login(email, password string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.Login(email, password)
+		return string(b), err
+	})
 }
 
 func StartChangeEmail(newEmail, password string) error {
@@ -563,8 +586,11 @@ func SignUp(email, password string) error {
 	return withCore(func(c lanterncore.Core) error { return c.SignUp(email, password) })
 }
 
-func Logout(email string) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.Logout(email) })
+func Logout(email string) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.Logout(email)
+		return string(b), err
+	})
 }
 
 func GetDataCapInfo() (string, error) {
@@ -607,8 +633,11 @@ func ReferralAttachment(referralCode string) error {
 	})
 }
 
-func DeleteAccount(email, password string, _ bool) ([]byte, error) {
-	return withCoreR(func(c lanterncore.Core) ([]byte, error) { return c.DeleteAccount(email, password) })
+func DeleteAccount(email, password string, _ bool) (string, error) {
+	return withCoreR(func(c lanterncore.Core) (string, error) {
+		b, err := c.DeleteAccount(email, password)
+		return string(b), err
+	})
 }
 
 func ActivationCode(email, resellerCode string) error {

--- a/macos/Runner/Handlers/MethodHandler.swift
+++ b/macos/Runner/Handlers/MethodHandler.swift
@@ -537,13 +537,15 @@ class MethodHandler {
   private func oauthLoginCallback(result: @escaping FlutterResult, token: String) {
     Task {
       var error: NSError?
-      let data = MobileOAuthLoginCallback(token, &error)
+      let json = MobileOAuthLoginCallback(token, &error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "OAUTH_LOGIN_CALLBACK")
         return
       }
       await MainActor.run {
-        result(data)
+        // Dart side expects bytes to utf8.decode — convert the gomobile-returned
+        // string back to Data to preserve the Flutter contract.
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -551,13 +553,13 @@ class MethodHandler {
   private func getUserData(result: @escaping FlutterResult) {
     Task {
       var error: NSError?
-      let data = MobileUserData(&error)
+      let json = MobileUserData(&error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "USER_DATA_ERROR")
         return
       }
       await MainActor.run {
-        result(data)
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -579,13 +581,13 @@ class MethodHandler {
   private func fetchUserData(result: @escaping FlutterResult) {
     Task {
       var error: NSError?
-      let bytes = MobileFetchUserData(&error)
+      let json = MobileFetchUserData(&error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "FETCH_USER_DATA_ERROR")
         return
       }
       await MainActor.run {
-        result(bytes)
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -593,13 +595,13 @@ class MethodHandler {
   func acknowledgeInAppPurchase(token: String, planId: String, result: @escaping FlutterResult) {
     Task {
       var error: NSError?
-      let data = MobileAcknowledgeApplePurchase(token, planId, &error)
+      let json = MobileAcknowledgeApplePurchase(token, planId, &error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "ACKNOWLEDGE_FAILED")
         return
       }
       await MainActor.run {
-        result(data)
+        result(json?.data(using: .utf8))
       }
     }
   }
@@ -664,7 +666,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload)
+        result(payload?.data(using: .utf8))
       }
     }
   }
@@ -692,7 +694,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload)
+        result(payload?.data(using: .utf8))
       }
     }
   }
@@ -709,7 +711,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload)
+        result(payload?.data(using: .utf8))
       }
     }
   }
@@ -1025,15 +1027,9 @@ class MethodHandler {
 
   func featureFlags(result: @escaping FlutterResult) {
     Task {
-      let flags = MobileAvailableFeatures()
-      guard let flags else {
-        await MainActor.run {
-          result("{}")
-        }
-        return
-      }
+      let flags = MobileAvailableFeatures() ?? ""
       await MainActor.run {
-        result(String(data: flags, encoding: .utf8))
+        result(flags.isEmpty ? "{}" : flags)
       }
     }
   }
@@ -1058,12 +1054,9 @@ class MethodHandler {
         await self.handleFlutterError(error, result: result, code: "GET_LANTERN_SERVERS_ERROR")
         return
       }
-      guard let servers else {
-        await MainActor.run { result("[]") }
-        return
-      }
       await MainActor.run {
-        result(String(data: servers, encoding: .utf8))
+        let s = servers ?? ""
+        result(s.isEmpty ? "[]" : s)
       }
     }
   }
@@ -1071,17 +1064,14 @@ class MethodHandler {
   func getSelectedServerJSON(result: @escaping FlutterResult) {
     Task {
       var error: NSError?
-      let data = MobileGetSelectedServerJSON(&error)
+      let json = MobileGetSelectedServerJSON(&error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "GET_SELECTED_SERVER_ERROR")
         return
       }
-      guard let data else {
-        await MainActor.run { result("{}") }
-        return
-      }
       await MainActor.run {
-        result(String(data: data, encoding: .utf8))
+        let s = json ?? ""
+        result(s.isEmpty ? "{}" : s)
       }
     }
   }


### PR DESCRIPTION
## Summary

Gomobile-exported functions returning \`([]byte, error)\` can crash with a Go runtime write-barrier panic during GC. This PR converts them to return \`(string, error)\` and updates the macOS + iOS Swift callers accordingly.

## Root Cause

The gomobile wrapper runs on the cgo callback goroutine (locked to the C thread). After the Go function returns, the wrapper copies the return value into a C struct on the OS thread stack using \`runtime.wbMove\`. Because \`[]byte\` contains a pointer (slice data), \`wbMove\` calls \`bulkBarrierPreWrite\` to track the write. With an active GC cycle, \`bulkBarrierPreWrite\` verifies the destination is GC-tracked — the C thread stack is not — and calls \`runtime.throw\`.

Full analysis: getlantern/engineering#3175 (from Freshdesk [#172640](https://lantern.freshdesk.com/a/tickets/172640) — Derek's crash on macOS 26.3.1).

Note: \`radiance/common.RunOffCgoStack\` (the \`withCoreR\` wrapper) was intended to fix this class of bug, but it only moves the function *body* to a worker goroutine — the return-value copy still happens on the cgo callback goroutine, so it's still vulnerable for pointer-bearing return types.

## Go changes (\`lantern-core/mobile/mobile.go\`)

11 functions converted from \`([]byte, error)\` or \`[]byte\` to \`(string, error)\` or \`string\`:

- \`AvailableFeatures\`
- \`UserData\`, \`FetchUserData\`
- \`GetAvailableServers\`, \`GetSelectedServerJSON\`
- \`OAuthLoginCallback\`
- \`AcknowledgeGooglePurchase\`, \`AcknowledgeApplePurchase\`
- \`Login\`, \`Logout\`, \`DeleteAccount\`

## Swift changes (\`macos/\` + \`ios/\` MethodHandler)

The Dart side reads some method results via \`jsonDecode(utf8.decode(bytes))\` and others via \`jsonDecode(result)\` (string). To avoid touching the Dart side:

- For methods whose Dart side reads bytes: convert \`String?\` back to \`Data\` in Swift via \`.data(using: .utf8)\` before passing to \`result()\`. Applies to \`getUserData\`, \`fetchUserData\`, \`oauthLoginCallback\`, \`login\`, \`logout\`, \`deleteAccount\`, \`acknowledgeInAppPurchase\`.
- For methods whose Dart side expects String: drop the old \`String(data: ..., encoding: .utf8)\` conversion and pass the gomobile string directly. Applies to \`featureFlags\`, \`getLanternAvailableServers\`, \`getSelectedServerJSON\`.

## Test Plan
- [x] \`go build ./...\` passes in lantern repo
- [ ] Swift builds + links against regenerated \`Liblantern\` (the \`Mobile.objc.h\` header in \`macos/Frameworks/Liblantern.xcframework/\` needs to be regenerated by the gomobile build for the new signatures)
- [ ] End-to-end: user data flow, login/logout, purchase flow all work on macOS beta
- [ ] Verify crash no longer reproduces in next beta

## Target branch

Targeting \`garmr/radiance-daemon-refactor\` per discussion in Slack — the same fix landed on \`radiance\` main as getlantern/radiance#416 (lock + telemetry), and this is the client-side half.

🤖 Generated with [Claude Code](https://claude.com/claude-code)