### PR TITLE
lantern-core: wire auto-selected events through IPC

### DIFF
--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -198,7 +198,7 @@ func (lc *LanternCore) initialize(opts *utils.Opts, eventEmitter utils.FlutterEv
 	lc.eventEmitter = eventEmitter
 
 	lc.listenConfigEvents()
-	lc.listenAutoSelectedEvents()
+	go lc.listenAutoSelectedEvents()
 	go lc.listenDataCapEvents()
 
 	slog.Debug("LanternCore initialized successfully")
@@ -225,8 +225,17 @@ func (lc *LanternCore) listenConfigEvents() {
 	})
 }
 
+// listenAutoSelectedEvents subscribes to auto-selected-server events over the
+// IPC stream and forwards them to Flutter as EventTypeServerLocation.
+//
+// Must be called as a goroutine — AutoSelectedEvents blocks on the SSE stream
+// until ctx is cancelled or the connection drops.
+//
+// On the mobile/macOS split the event is emitted inside the packet-tunnel
+// extension's radiance process; subscribing via the in-process events.Subscribe
+// fan-out does not cross that boundary, so we use the IPC stream instead.
 func (lc *LanternCore) listenAutoSelectedEvents() {
-	events.SubscribeContext(lc.ctx, func(evt vpn.AutoSelectedEvent) {
+	err := lc.client.AutoSelectedEvents(lc.ctx, func(evt vpn.AutoSelectedEvent) {
 		server, found, err := lc.client.GetServerByTag(lc.ctx, evt.Selected)
 		if err != nil || !found {
 			slog.Error("no server found with tag", "tag", evt.Selected, "error", err)
@@ -240,6 +249,9 @@ func (lc *LanternCore) listenAutoSelectedEvents() {
 		slog.Debug("Auto location server:", "server", string(jsonBytes))
 		lc.notifyFlutter(EventTypeServerLocation, string(jsonBytes))
 	})
+	if err != nil && lc.ctx.Err() == nil {
+		slog.Error("auto-selected event stream ended", "error", err)
+	}
 }
 
 func (lc *LanternCore) listenDataCapEvents() {

--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -243,26 +243,34 @@ func (lc *LanternCore) listenConfigEvents() {
 // the pattern used by ipc.Client.TailLogs.
 func (lc *LanternCore) listenAutoSelectedEvents() {
 	const retryDelay = 500 * time.Millisecond
+	slog.Info("auto-selected: starting SSE subscription loop")
 	for lc.ctx.Err() == nil {
+		slog.Info("auto-selected: opening IPC stream")
 		err := lc.client.AutoSelectedEvents(lc.ctx, func(evt vpn.AutoSelectedEvent) {
+			slog.Info("auto-selected: received event from IPC stream", "tag", evt.Selected)
 			server, found, err := lc.client.GetServerByTag(lc.ctx, evt.Selected)
 			if err != nil || !found {
-				slog.Error("no server found with tag", "tag", evt.Selected, "error", err)
+				slog.Error("auto-selected: no server found with tag", "tag", evt.Selected, "found", found, "error", err)
 				return
 			}
 			jsonBytes, err := json.Marshal(server)
 			if err != nil {
-				slog.Error("Error marshalling server location", "error", err)
+				slog.Error("auto-selected: marshal server", "error", err)
 				return
 			}
-			slog.Debug("Auto location server:", "server", string(jsonBytes))
+			slog.Info("auto-selected: forwarding to Flutter", "server", string(jsonBytes))
 			lc.notifyFlutter(EventTypeServerLocation, string(jsonBytes))
 		})
 		if lc.ctx.Err() != nil {
 			return
 		}
-		if err != nil && !errors.Is(err, ipc.ErrIPCNotRunning) {
-			slog.Debug("auto-selected event stream ended", "error", err)
+		switch {
+		case err == nil:
+			slog.Info("auto-selected: IPC stream closed cleanly; reconnecting")
+		case errors.Is(err, ipc.ErrIPCNotRunning):
+			slog.Debug("auto-selected: IPC not running yet; retrying", "error", err)
+		default:
+			slog.Warn("auto-selected: IPC stream ended with error; retrying", "error", err)
 		}
 		// Stream ended (IPC not yet running, server restarted, tunnel cycled, etc.).
 		// Back off briefly and try again.

--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -3,11 +3,13 @@ package lanterncore
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/getlantern/radiance/account"
 	"github.com/getlantern/radiance/common"
@@ -234,23 +236,41 @@ func (lc *LanternCore) listenConfigEvents() {
 // On the mobile/macOS split the event is emitted inside the packet-tunnel
 // extension's radiance process; subscribing via the in-process events.Subscribe
 // fan-out does not cross that boundary, so we use the IPC stream instead.
+//
+// The extension's IPC server only starts when the tunnel starts, so the first
+// subscription attempts at LanternCore startup will get ErrIPCNotRunning.
+// Retry with backoff until we either succeed or ctx is cancelled, mirroring
+// the pattern used by ipc.Client.TailLogs.
 func (lc *LanternCore) listenAutoSelectedEvents() {
-	err := lc.client.AutoSelectedEvents(lc.ctx, func(evt vpn.AutoSelectedEvent) {
-		server, found, err := lc.client.GetServerByTag(lc.ctx, evt.Selected)
-		if err != nil || !found {
-			slog.Error("no server found with tag", "tag", evt.Selected, "error", err)
+	const retryDelay = 500 * time.Millisecond
+	for lc.ctx.Err() == nil {
+		err := lc.client.AutoSelectedEvents(lc.ctx, func(evt vpn.AutoSelectedEvent) {
+			server, found, err := lc.client.GetServerByTag(lc.ctx, evt.Selected)
+			if err != nil || !found {
+				slog.Error("no server found with tag", "tag", evt.Selected, "error", err)
+				return
+			}
+			jsonBytes, err := json.Marshal(server)
+			if err != nil {
+				slog.Error("Error marshalling server location", "error", err)
+				return
+			}
+			slog.Debug("Auto location server:", "server", string(jsonBytes))
+			lc.notifyFlutter(EventTypeServerLocation, string(jsonBytes))
+		})
+		if lc.ctx.Err() != nil {
 			return
 		}
-		jsonBytes, err := json.Marshal(server)
-		if err != nil {
-			slog.Error("Error marshalling server location", "error", err)
+		if err != nil && !errors.Is(err, ipc.ErrIPCNotRunning) {
+			slog.Debug("auto-selected event stream ended", "error", err)
+		}
+		// Stream ended (IPC not yet running, server restarted, tunnel cycled, etc.).
+		// Back off briefly and try again.
+		select {
+		case <-time.After(retryDelay):
+		case <-lc.ctx.Done():
 			return
 		}
-		slog.Debug("Auto location server:", "server", string(jsonBytes))
-		lc.notifyFlutter(EventTypeServerLocation, string(jsonBytes))
-	})
-	if err != nil && lc.ctx.Err() == nil {
-		slog.Error("auto-selected event stream ended", "error", err)
 	}
 }
 

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -263,6 +263,12 @@ func StartIPCServer(platform utils.PlatformInterface, opts *utils.Opts) error {
 		if err != nil {
 			return struct{}{}, fmt.Errorf("error creating backend for IPC server: %v", err)
 		}
+		// Start() spins up background listeners including AutoSelectedChangeListener,
+		// which polls CurrentAutoSelectedServer and emits AutoSelectedEvent. Without
+		// this, the packet-tunnel extension — the process that actually runs the
+		// tunnel — never emits auto-select events, so no subscribers (including the
+		// host app's IPC SSE stream) ever see them.
+		be.Start()
 		ipcServer = ipc.NewServer(be, !common.IsMobile())
 		ipcClient = newLoopbackClient(be)
 		return struct{}{}, ipcServer.Start()


### PR DESCRIPTION
## Summary

On the refactor branch the **Smart Location** tile on Server Selection never shows the current auto-selected server, and tapping it while connected produces *"Unable to connect to VPN server."* Both symptoms trace back to `listenAutoSelectedEvents` using `events.SubscribeContext` — an in-process fan-out. `vpn.AutoSelectedEvent` is emitted inside the packet-tunnel extension's radiance process, so the host app's subscription never fires.

This PR switches `listenAutoSelectedEvents` in `lantern-core/core.go` to use the existing `lc.client.AutoSelectedEvents` SSE stream (`/server/auto-selected/events`) and wraps it in a reconnect loop. The stream itself was already exposed by `ipc.Client`.

## Why the retry loop matters

On macOS the extension's IPC server only binds its Unix socket (`/var/run/lantern/lanternd.sock`) **after** `PacketTunnelProvider.startTunnel` runs — i.e. after the user initiates a connection. Log evidence from the repro session:

```
20:51:33  LanternStatus: Connected
20:51:34  pkg=radiance (*Server).Start.func1  msg="IPC server started" address=/var/run/lantern/lanternd.sock
20:51:43  (*LocalBackend).Close.func1 msg="Closing Radiance"        ← host's local fallback finally shuts down
```

LanternCore initializes (and previously attempted `listenAutoSelectedEvents`) long before `20:51:34`. A single attempt at startup hits `ErrIPCNotRunning` and exits; auto-selected updates are never delivered to Flutter for the rest of the session.

The new loop reconnects with a 500ms backoff until the stream succeeds or `lc.ctx` is cancelled — the same pattern `ipc.Client.TailLogs` already uses for exactly this reason.

## Scope

- **In scope:** auto-selected events.
- **Known adjacent issue not fixed here:** `listenDataCapEvents` has the same one-shot race and will also lose events until the tunnel starts. Same fix applies; tracked in getlantern/engineering#3182.
- **Out of scope, also tracked in getlantern/engineering#3182:**
  - `config.NewConfigEvent` (still on in-process fan-out; needs a new `/config/events` IPC endpoint on the radiance side before lantern-core can subscribe over IPC)
  - Hardening the Dart path in `lib/features/vpn/server_selection.dart:233` so tapping Smart Location with a null `autoLocation` doesn't send an empty tag to the backend

## Test plan
- [x] `go build ./lantern-core/...`
- [x] `go vet ./lantern-core/...`
- [ ] Smoke test on the macOS build: connect, open Server Selection, confirm the Smart Location tile populates with flag + country + protocol after the tunnel is up, and tapping it doesn't produce the error toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)