### PR TITLE
ios/macos: drop invalid optional-chaining on non-optional String

### DIFF
--- a/ios/Runner/Handlers/MethodHandler.swift
+++ b/ios/Runner/Handlers/MethodHandler.swift
@@ -446,7 +446,7 @@ class MethodHandler {
       await MainActor.run {
         // Dart side expects bytes to utf8.decode — convert the gomobile-returned
         // string back to Data to preserve the Flutter contract.
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -460,7 +460,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -488,7 +488,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -544,7 +544,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -609,7 +609,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload?.data(using: .utf8))
+        result(payload.data(using: .utf8))
       }
     }
   }
@@ -637,7 +637,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload?.data(using: .utf8))
+        result(payload.data(using: .utf8))
       }
     }
   }
@@ -654,7 +654,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload?.data(using: .utf8))
+        result(payload.data(using: .utf8))
       }
     }
   }

--- a/macos/Runner/Handlers/MethodHandler.swift
+++ b/macos/Runner/Handlers/MethodHandler.swift
@@ -545,7 +545,7 @@ class MethodHandler {
       await MainActor.run {
         // Dart side expects bytes to utf8.decode — convert the gomobile-returned
         // string back to Data to preserve the Flutter contract.
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -559,7 +559,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -587,7 +587,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -601,7 +601,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(json?.data(using: .utf8))
+        result(json.data(using: .utf8))
       }
     }
   }
@@ -666,7 +666,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload?.data(using: .utf8))
+        result(payload.data(using: .utf8))
       }
     }
   }
@@ -694,7 +694,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload?.data(using: .utf8))
+        result(payload.data(using: .utf8))
       }
     }
   }
@@ -711,7 +711,7 @@ class MethodHandler {
         return
       }
       await MainActor.run {
-        result(payload?.data(using: .utf8))
+        result(payload.data(using: .utf8))
       }
     }
   }


### PR DESCRIPTION
## Summary
The gomobile-exported functions in \`lantern-core/mobile/mobile.go\` were migrated from \`([]byte, error)\` to \`(string, error)\` (PR #8663). gomobile renders the new signatures with a **non-optional** Swift \`String\` return (\`Data\` was optional; \`String\` is not), which makes \`json?.data(using: .utf8)\` and \`payload?.data(using: .utf8)\` fail to compile:

\`\`\`
macos/Runner/Handlers/MethodHandler.swift:548:20: error: cannot use optional chaining on non-optional value of type 'String'
        result(json?.data(using: .utf8))
               ~~~~^
\`\`\`

(and 13 more, both macOS and iOS.)

This PR drops the \`?\` on all 14 call sites (7 each in \`ios/\` and \`macos/\`). \`json.data(using: .utf8)\` returns \`Data?\` anyway — an empty Go string still produces a non-nil empty \`Data\`, which preserves the Flutter contract the existing comment describes.

## Test plan
- [x] \`grep -n \"?.data(using: .utf8)\" ios/Runner/Handlers/MethodHandler.swift macos/Runner/Handlers/MethodHandler.swift\` returns zero matches
- [ ] macOS build compiles
- [ ] iOS build compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)