### PR TITLE
add android-test + android-reproduce for emulator testing and ticket reproduction

### DIFF
--- a/scripts/android/android-reproduce
+++ b/scripts/android/android-reproduce
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# android-reproduce — Reproduce a Freshdesk ticket on an Android emulator
+#
+# Usage:
+#   android-reproduce <ticket-dir> [apk-path]
+#
+# Examples:
+#   android-reproduce /tmp/ticket-172722                         # auto-downloads APK
+#   android-reproduce /tmp/ticket-172722 ~/Downloads/lantern.apk # uses provided APK
+#
+# The ticket-dir should contain files downloaded by /analyze-ticket:
+#   config.json      — user's sing-box config (pushed to emulator)
+#   servers.json     — user's proxy server list (pushed to emulator)
+#   split-tunnel.json — user's split-tunnel rules (pushed to emulator)
+#
+# What it does:
+#   1. Extracts the user's country and app version from config.json
+#   2. Downloads the matching APK from GitHub releases (if not provided)
+#   3. Pushes config.json, servers.json, split-tunnel.json to the emulator
+#      so the app uses the exact same proxies, DNS rules, and rule sets
+#   4. Sets RADIANCE_COUNTRY to match the user's region
+#   5. Installs, restarts, and streams logs
+#
+# Prerequisites:
+#   - Run /analyze-ticket <ticket-id> first to download attachments
+#   - Android SDK (same as android-test)
+#   - gh CLI (for auto-downloading APK from GitHub releases)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PKG="org.getlantern.lantern"
+
+# --- Parse args ---
+if [ $# -lt 1 ]; then
+    echo "Usage: android-reproduce <ticket-dir> [apk-path]"
+    echo ""
+    echo "Examples:"
+    echo "  android-reproduce /tmp/ticket-172722                         # auto-downloads APK"
+    echo "  android-reproduce /tmp/ticket-172722 ~/Downloads/lantern.apk # uses provided APK"
+    echo ""
+    echo "Run /analyze-ticket <ticket-id> first to download the config files."
+    exit 1
+fi
+
+TICKET_DIR="$1"
+APK="${2:-}"
+
+# --- Locate config files ---
+# /analyze-ticket puts files either directly in ticket-dir or in ticket-dir/logs/
+CONFIG_JSON=""
+for candidate in "$TICKET_DIR/config.json" "$TICKET_DIR/logs/config.json"; do
+    if [ -f "$candidate" ]; then
+        CONFIG_JSON="$candidate"
+        break
+    fi
+done
+
+if [ -z "$CONFIG_JSON" ]; then
+    echo "Error: config.json not found in $TICKET_DIR"
+    echo "Run /analyze-ticket <ticket-id> first to download it."
+    exit 1
+fi
+
+echo "=== Ticket reproduction setup ==="
+echo "Ticket dir: $TICKET_DIR"
+echo "Config:     $CONFIG_JSON"
+
+# --- Extract country from config ---
+COUNTRY=""
+if command -v python3 >/dev/null 2>&1; then
+    COUNTRY=$(python3 -c "
+import json, sys
+try:
+    with open('$CONFIG_JSON') as f:
+        cfg = json.load(f)
+    # Try nested ConfigResponse format (from Freshdesk attachment)
+    cr = cfg.get('ConfigResponse', cfg)
+    print(cr.get('country', ''))
+except:
+    pass
+" 2>/dev/null)
+elif command -v jq >/dev/null 2>&1; then
+    COUNTRY=$(jq -r '.ConfigResponse.country // .country // ""' "$CONFIG_JSON" 2>/dev/null)
+fi
+
+if [ -n "$COUNTRY" ]; then
+    echo "Country:    $COUNTRY"
+else
+    echo "Country:    (not detected — config will still be pushed)"
+fi
+
+# --- Extract version and auto-download APK if needed ---
+if [ -z "$APK" ]; then
+    # Try to find the version from config.json metadata or ticket files
+    VERSION=""
+    if command -v python3 >/dev/null 2>&1; then
+        VERSION=$(python3 -c "
+import json, sys, os, glob
+# Try to find version from flutter.log (most reliable)
+for log_dir in ['$TICKET_DIR/logs/logs', '$TICKET_DIR/logs', '$TICKET_DIR']:
+    for f in glob.glob(os.path.join(log_dir, 'flutter.log')):
+        with open(f) as fh:
+            for line in fh:
+                if 'version:' in line.lower():
+                    # Extract version like '9.0.25'
+                    import re
+                    m = re.search(r'version:\s*(\d+\.\d+\.\d+)', line)
+                    if m:
+                        print(m.group(1))
+                        sys.exit(0)
+# Fall back to looking for version in config request logs
+for log_dir in ['$TICKET_DIR/logs/logs', '$TICKET_DIR/logs', '$TICKET_DIR']:
+    for f in glob.glob(os.path.join(log_dir, 'lantern.log')):
+        with open(f) as fh:
+            for line in fh:
+                if 'appVersion' in line or 'app_version' in line:
+                    import re
+                    m = re.search(r'(\d+\.\d+\.\d+)', line)
+                    if m:
+                        print(m.group(1))
+                        sys.exit(0)
+" 2>/dev/null)
+    fi
+
+    if [ -z "$VERSION" ]; then
+        echo "Error: No APK provided and couldn't detect version from ticket logs."
+        echo "Provide the APK path as the second argument."
+        exit 1
+    fi
+
+    RELEASE_TAG="v${VERSION}-beta-android"
+    APK="$TICKET_DIR/lantern-${VERSION}.apk"
+
+    if [ -f "$APK" ]; then
+        echo "APK:        $APK (cached from previous download)"
+    else
+        echo "Downloading APK for v${VERSION} from GitHub releases..."
+        if ! command -v gh >/dev/null 2>&1; then
+            echo "Error: gh CLI not found. Install it or provide the APK path manually."
+            exit 1
+        fi
+        if gh release download "$RELEASE_TAG" --repo getlantern/lantern \
+                --pattern "lantern-installer-beta.apk" \
+                --output "$APK" 2>/dev/null; then
+            echo "APK:        $APK (downloaded from $RELEASE_TAG)"
+        else
+            echo "Error: Failed to download APK from release $RELEASE_TAG"
+            echo "Available Android releases:"
+            gh release list --repo getlantern/lantern --limit 5 | grep android || true
+            echo ""
+            echo "Provide the APK path manually as the second argument."
+            exit 1
+        fi
+    fi
+fi
+
+# --- Extract server locations for display ---
+if command -v python3 >/dev/null 2>&1; then
+    python3 -c "
+import json
+with open('$CONFIG_JSON') as f:
+    cfg = json.load(f)
+cr = cfg.get('ConfigResponse', cfg)
+locs = cr.get('outbound_locations', cr.get('servers', {}))
+if isinstance(locs, dict):
+    cities = sorted(set(v.get('city', '?') for v in locs.values()))
+    print(f'Locations:  {', '.join(cities)}')
+elif isinstance(locs, list):
+    cities = sorted(set(s.get('city', '?') for s in locs))
+    print(f'Locations:  {', '.join(cities)}')
+" 2>/dev/null || true
+fi
+echo "APK:        $APK"
+echo "================================="
+echo ""
+
+# --- Build env overrides ---
+ENV_OVERRIDES=()
+if [ -n "$COUNTRY" ]; then
+    ENV_OVERRIDES+=("RADIANCE_COUNTRY=$COUNTRY")
+fi
+
+# --- Run android-test to handle emulator setup + install ---
+echo "Starting android-test..."
+echo ""
+
+# We need to intercept after install but before app start to push configs.
+# Instead, run android-test and then push configs separately.
+# First, start android-test in a way that we can push configs before the app restarts.
+
+# Actually, the cleanest approach: call android-test which handles everything,
+# then ALSO push the config files. The app will pick them up on the next config
+# cycle (or we force-restart it after pushing).
+
+# Run android-test (it installs, pushes .env, restarts, streams logs).
+# We pipe to tee so we can capture logs while also monitoring.
+# But first, we need to push the config files AFTER install but BEFORE the app starts.
+# android-test does: install → push .env → restart → stream logs.
+# We want:           install → push .env + configs → restart → stream logs.
+
+# The simplest approach: run android-test but tell it to skip log streaming,
+# then push configs, restart, and stream ourselves. But android-test doesn't
+# have that option. So let's just:
+# 1. Run android-test (which handles everything including streaming)
+# 2. In a separate terminal or after Ctrl+C, the configs are already there
+
+# Actually, the BEST approach: push configs as part of the .env push.
+# We can do this by running android-test, which sets up emulator + installs + pushes .env,
+# then we push the config files to the same data dir, force-restart, and stream.
+
+# Let's just do it all ourselves, reusing android-test's emulator/AVD setup.
+
+# Source android-test's tool-finding logic by running it with --help
+# Actually let's just duplicate the minimal setup and push everything together.
+
+# Find tools (same logic as android-test)
+if [ -n "${ANDROID_HOME:-}" ]; then
+    ADB="${ANDROID_HOME}/platform-tools/adb"
+elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+    ADB="${ANDROID_SDK_ROOT}/platform-tools/adb"
+else
+    ADB="$(command -v adb 2>/dev/null || true)"
+fi
+
+if [ -z "$ADB" ] || [ ! -x "$ADB" ]; then
+    echo "Error: adb not found. Set ANDROID_HOME or add Android SDK to PATH."
+    exit 1
+fi
+
+# Run android-test for emulator setup + APK install (it will stream logs at the end)
+# We intercept by running it in background briefly, then pushing configs.
+# Actually, the simplest correct approach: just call android-test with the env
+# overrides, then in a post-hook push the config files.
+
+# BUT android-test ends with `exec` for log streaming, so we can't run code after it.
+# So instead: do the full flow ourselves.
+
+# Step 1: Call android-test WITHOUT log streaming — just setup + install + .env
+# We can't do that with the current script, so let's use it for setup and
+# handle the config push ourselves.
+
+# The pragmatic solution: run android-test in background, wait for "Restarting Lantern",
+# then push configs and let it continue.
+
+# ACTUALLY — the simplest: just run the same steps inline.
+
+# Detect emulator serial
+TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
+if [ -z "$TARGET_SERIAL" ]; then
+    echo "No emulator running. Starting one via android-test..."
+    # Run android-test just to get the emulator up and APK installed, skip log streaming
+    # by backgrounding and killing after install
+    "$SCRIPT_DIR/android-test" "$APK" "${ENV_OVERRIDES[@]}" &
+    TEST_PID=$!
+    # Wait for "Restarting Lantern" to appear (means install + .env push done)
+    sleep 30  # generous wait for emulator boot + install
+    kill "$TEST_PID" 2>/dev/null || true
+    wait "$TEST_PID" 2>/dev/null || true
+    TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
+fi
+
+if [ -z "$TARGET_SERIAL" ]; then
+    echo "Error: No emulator found after setup. Run android-test manually first."
+    exit 1
+fi
+
+ADB_CMD=("$ADB" -s "$TARGET_SERIAL")
+APP_DATA="/data/data/$PKG/.lantern"
+
+echo "Pushing user's config files to emulator..."
+
+# Root the emulator (Google APIs images)
+"${ADB_CMD[@]}" root 2>/dev/null || true
+sleep 2
+"${ADB_CMD[@]}" wait-for-device
+
+# Push config files
+for file in config.json servers.json split-tunnel.json; do
+    SRC="$TICKET_DIR/$file"
+    if [ -f "$SRC" ]; then
+        "${ADB_CMD[@]}" push "$SRC" "/data/local/tmp/$file"
+        "${ADB_CMD[@]}" shell "mkdir -p $APP_DATA && cp /data/local/tmp/$file $APP_DATA/$file && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/$file" 2>/dev/null
+        echo "  Pushed $file"
+    fi
+done
+
+# Push .env with overrides
+if [ ${#ENV_OVERRIDES[@]} -gt 0 ]; then
+    ENV_FILE=$(mktemp)
+    trap 'rm -f "${ENV_FILE:-}"' EXIT INT TERM
+    for kv in "${ENV_OVERRIDES[@]}"; do
+        echo "$kv" >> "$ENV_FILE"
+    done
+    "${ADB_CMD[@]}" push "$ENV_FILE" /data/local/tmp/.env
+    "${ADB_CMD[@]}" shell "cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/.env" 2>/dev/null
+    echo "  Pushed .env (RADIANCE_COUNTRY=$COUNTRY)"
+fi
+
+# Unroot
+"${ADB_CMD[@]}" unroot 2>/dev/null || true
+sleep 1
+"${ADB_CMD[@]}" wait-for-device
+
+# Install APK (if not already done)
+echo "Installing $APK..."
+"${ADB_CMD[@]}" install -r -t "$APK" 2>&1 | tail -1
+
+# Force-restart the app
+echo "Restarting Lantern with user's config..."
+"${ADB_CMD[@]}" shell am force-stop "$PKG" 2>/dev/null || true
+sleep 1
+"${ADB_CMD[@]}" shell am start -n "$PKG/org.getlantern.lantern.MainActivity" 2>/dev/null || \
+    "${ADB_CMD[@]}" shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 2>/dev/null
+
+echo ""
+echo "=== Reproducing ticket with user's exact config ==="
+echo "  Country: ${COUNTRY:-unknown}"
+echo "  Config:  $CONFIG_JSON"
+echo "  APK:     $APK"
+echo "=== Streaming logs (Ctrl+C to stop) ==="
+echo ""
+
+"${ADB_CMD[@]}" logcat -c
+exec "${ADB_CMD[@]}" logcat -v time \
+    -s "GoLog:*" "radiance:*" "sing-box:*" "lantern:*" "flutter:*" \
+       "LanternService:*" "VpnService:*" "System.err:*" \
+       "AndroidRuntime:*" "lantern-box:*"

--- a/scripts/android/android-reproduce
+++ b/scripts/android/android-reproduce
@@ -28,7 +28,6 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PKG="org.getlantern.lantern"
 
 # --- Parse args ---
@@ -93,22 +92,30 @@ fi
 # --- Extract device info from flutter.log ---
 SDK_INT=""
 DEVICE_MODEL=""
+OS_VERSION=""
 if command -v python3 >/dev/null 2>&1; then
-    eval "$(python3 -c "
+    mapfile -t _DEVICE_INFO < <(python3 -c "
 import os, re, glob
+sdk_int = ''; model = ''; osver = ''
 for log_dir in ['$TICKET_DIR/logs/logs', '$TICKET_DIR/logs', '$TICKET_DIR']:
     for f in glob.glob(os.path.join(log_dir, 'flutter.log')):
         with open(f) as fh:
             for line in fh:
                 if 'Device info:' in line:
                     m = re.search(r'sdkInt:\s*(\d+)', line)
-                    if m: print(f'SDK_INT={m.group(1)}')
+                    if m: sdk_int = m.group(1)
                     m = re.search(r'model:\s*(\S+)', line)
-                    if m: print(f'DEVICE_MODEL={m.group(1).rstrip(\",\")}')
+                    if m: model = m.group(1).rstrip(',')
                     m = re.search(r'osVersion:\s*(\S+)', line)
-                    if m: print(f'OS_VERSION={m.group(1).rstrip(\",\")}')
+                    if m: osver = m.group(1).rstrip(',')
                     break
-" 2>/dev/null)"
+print(sdk_int)
+print(model)
+print(osver)
+" 2>/dev/null)
+    SDK_INT="${_DEVICE_INFO[0]:-}"
+    DEVICE_MODEL="${_DEVICE_INFO[1]:-}"
+    OS_VERSION="${_DEVICE_INFO[2]:-}"
 fi
 
 if [ -n "$SDK_INT" ]; then
@@ -193,10 +200,10 @@ cr = cfg.get('ConfigResponse', cfg)
 locs = cr.get('outbound_locations', cr.get('servers', {}))
 if isinstance(locs, dict):
     cities = sorted(set(v.get('city', '?') for v in locs.values()))
-    print(f'Locations:  {', '.join(cities)}')
+    print('Locations:  ' + ', '.join(cities))
 elif isinstance(locs, list):
     cities = sorted(set(s.get('city', '?') for s in locs))
-    print(f'Locations:  {', '.join(cities)}')
+    print('Locations:  ' + ', '.join(cities))
 " 2>/dev/null || true
 fi
 echo "APK:        $APK"
@@ -304,6 +311,15 @@ fi
 ADB_CMD=("$ADB" -s "$TARGET_SERIAL")
 APP_DATA="/data/data/$PKG/.lantern"
 
+# Install APK FIRST so the app's data directory exists before we push configs.
+echo "Installing $APK..."
+"${ADB_CMD[@]}" install -r -t "$APK" 2>&1 | tail -1
+
+# Launch once briefly so the data directory is fully created, then stop.
+"${ADB_CMD[@]}" shell am start -n "$PKG/org.getlantern.lantern.MainActivity" 2>/dev/null || true
+sleep 3
+"${ADB_CMD[@]}" shell am force-stop "$PKG" 2>/dev/null || true
+
 echo "Pushing user's config files to emulator..."
 
 # Root the emulator (Google APIs images)
@@ -311,13 +327,21 @@ echo "Pushing user's config files to emulator..."
 sleep 2
 "${ADB_CMD[@]}" wait-for-device
 
+# Determine the base directory where config files live in the ticket dir.
+# /analyze-ticket puts them directly in the ticket dir, but they may also
+# be inside a logs/ subdirectory.
+CONFIG_BASE="$(dirname "$CONFIG_JSON")"
+
 # Push config files
 for file in config.json servers.json split-tunnel.json; do
-    SRC="$TICKET_DIR/$file"
-    if [ -f "$SRC" ]; then
+    SRC=""
+    for candidate in "$CONFIG_BASE/$file" "$TICKET_DIR/$file"; do
+        if [ -f "$candidate" ]; then SRC="$candidate"; break; fi
+    done
+    if [ -n "$SRC" ]; then
         "${ADB_CMD[@]}" push "$SRC" "/data/local/tmp/$file"
         "${ADB_CMD[@]}" shell "mkdir -p $APP_DATA && cp /data/local/tmp/$file $APP_DATA/$file && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/$file" 2>/dev/null
-        echo "  Pushed $file"
+        echo "  Pushed $file (from $SRC)"
     fi
 done
 
@@ -329,7 +353,7 @@ if [ ${#ENV_OVERRIDES[@]} -gt 0 ]; then
         echo "$kv" >> "$ENV_FILE"
     done
     "${ADB_CMD[@]}" push "$ENV_FILE" /data/local/tmp/.env
-    "${ADB_CMD[@]}" shell "cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/.env" 2>/dev/null
+    "${ADB_CMD[@]}" shell "mkdir -p $APP_DATA && cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/.env" 2>/dev/null
     echo "  Pushed .env (RADIANCE_COUNTRY=$COUNTRY)"
 fi
 
@@ -338,11 +362,7 @@ fi
 sleep 1
 "${ADB_CMD[@]}" wait-for-device
 
-# Install APK (if not already done)
-echo "Installing $APK..."
-"${ADB_CMD[@]}" install -r -t "$APK" 2>&1 | tail -1
-
-# Force-restart the app
+# Restart the app with the user's config
 echo "Restarting Lantern with user's config..."
 "${ADB_CMD[@]}" shell am force-stop "$PKG" 2>/dev/null || true
 sleep 1

--- a/scripts/android/android-reproduce
+++ b/scripts/android/android-reproduce
@@ -209,57 +209,63 @@ if [ -n "$COUNTRY" ]; then
     ENV_OVERRIDES+=("RADIANCE_COUNTRY=$COUNTRY")
 fi
 
-# --- Ensure emulator with matching API level ---
-# Find tools (same logic as android-test)
+# --- Find Android SDK tools ---
 if [ -n "${ANDROID_HOME:-}" ]; then
     ADB="${ANDROID_HOME}/platform-tools/adb"
-elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
-    ADB="${ANDROID_SDK_ROOT}/platform-tools/adb"
-else
-    ADB="$(command -v adb 2>/dev/null || true)"
-fi
-
-if [ -z "$ADB" ] || [ ! -x "$ADB" ]; then
-    echo "Error: adb not found. Set ANDROID_HOME or add Android SDK to PATH."
-    exit 1
-fi
-
-# Determine target API level — use user's sdkInt if available, otherwise default to 35
-TARGET_API="${SDK_INT:-35}"
-# Clamp to available range (Google APIs images exist for 21-35+)
-if [ "$TARGET_API" -gt 35 ] 2>/dev/null; then
-    # API 36+ may not have a Google APIs image yet; fall back to 35
-    echo "Note: API $TARGET_API image may not be available, using API 35"
-    TARGET_API=35
-fi
-
-AVD_NAME="lantern-api${TARGET_API}"
-EMULATOR=""
-SDKMANAGER=""
-AVDMANAGER=""
-if [ -n "${ANDROID_HOME:-}" ]; then
     EMULATOR="${ANDROID_HOME}/emulator/emulator"
     SDKMANAGER="${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager"
     AVDMANAGER="${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager"
 elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+    ADB="${ANDROID_SDK_ROOT}/platform-tools/adb"
     EMULATOR="${ANDROID_SDK_ROOT}/emulator/emulator"
     SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
     AVDMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/avdmanager"
 else
+    ADB="$(command -v adb 2>/dev/null || true)"
     EMULATOR="$(command -v emulator 2>/dev/null || true)"
     SDKMANAGER="$(command -v sdkmanager 2>/dev/null || true)"
     AVDMANAGER="$(command -v avdmanager 2>/dev/null || true)"
 fi
+for tool in ADB EMULATOR SDKMANAGER AVDMANAGER; do
+    if [ -z "${!tool}" ] || [ ! -x "${!tool}" ]; then
+        echo "Error: $(echo $tool | tr A-Z a-z) not found. Set ANDROID_HOME or add Android SDK to PATH."
+        exit 1
+    fi
+done
 
-# Create API-matched AVD if it doesn't exist
-if ! "$EMULATOR" -list-avds 2>/dev/null | grep -q "^${AVD_NAME}$"; then
-    ARCH=$(uname -m)
-    case "$ARCH" in
-        arm64|aarch64) IMG_ABI="arm64-v8a" ;;
-        x86_64)        IMG_ABI="x86_64" ;;
-        *)             IMG_ABI="arm64-v8a" ;;
-    esac
+# --- Ensure emulator with matching API level ---
+# Each unique API level gets its own AVD (e.g. lantern-api29, lantern-api34).
+# AVDs accumulate over time as you reproduce tickets from different Android versions.
+TARGET_API="${SDK_INT:-35}"
+
+ARCH=$(uname -m)
+case "$ARCH" in
+    arm64|aarch64) IMG_ABI="arm64-v8a" ;;
+    x86_64)        IMG_ABI="x86_64" ;;
+    *)             IMG_ABI="arm64-v8a" ;;
+esac
+
+# Find the closest available Google APIs image (step down if exact isn't available)
+ORIGINAL_API="$TARGET_API"
+while [ "$TARGET_API" -ge 21 ]; do
     IMAGE="system-images;android-${TARGET_API};google_apis;${IMG_ABI}"
+    if "$SDKMANAGER" --list 2>/dev/null | grep -q "$IMAGE"; then
+        break
+    fi
+    TARGET_API=$((TARGET_API - 1))
+done
+if [ "$TARGET_API" -lt 21 ]; then
+    echo "Error: No Google APIs system image found for any API level." >&2
+    exit 1
+fi
+if [ "$TARGET_API" != "$ORIGINAL_API" ]; then
+    echo "Note: API $ORIGINAL_API image not available, using closest: API $TARGET_API"
+fi
+
+AVD_NAME="lantern-api${TARGET_API}"
+
+# Download image + create AVD if it doesn't exist yet
+if ! "$EMULATOR" -list-avds 2>/dev/null | grep -q "^${AVD_NAME}$"; then
     echo "Creating AVD '$AVD_NAME' (API $TARGET_API) to match user's device..."
     "$SDKMANAGER" "$IMAGE" 2>&1 | tail -3
     echo "no" | "$AVDMANAGER" create avd -n "$AVD_NAME" -k "$IMAGE" --force 2>&1 | tail -2

--- a/scripts/android/android-reproduce
+++ b/scripts/android/android-reproduce
@@ -90,6 +90,34 @@ else
     echo "Country:    (not detected — config will still be pushed)"
 fi
 
+# --- Extract device info from flutter.log ---
+SDK_INT=""
+DEVICE_MODEL=""
+if command -v python3 >/dev/null 2>&1; then
+    eval "$(python3 -c "
+import os, re, glob
+for log_dir in ['$TICKET_DIR/logs/logs', '$TICKET_DIR/logs', '$TICKET_DIR']:
+    for f in glob.glob(os.path.join(log_dir, 'flutter.log')):
+        with open(f) as fh:
+            for line in fh:
+                if 'Device info:' in line:
+                    m = re.search(r'sdkInt:\s*(\d+)', line)
+                    if m: print(f'SDK_INT={m.group(1)}')
+                    m = re.search(r'model:\s*(\S+)', line)
+                    if m: print(f'DEVICE_MODEL={m.group(1).rstrip(\",\")}')
+                    m = re.search(r'osVersion:\s*(\S+)', line)
+                    if m: print(f'OS_VERSION={m.group(1).rstrip(\",\")}')
+                    break
+" 2>/dev/null)"
+fi
+
+if [ -n "$SDK_INT" ]; then
+    echo "Android:    API $SDK_INT (Android ${OS_VERSION:-?})"
+fi
+if [ -n "$DEVICE_MODEL" ]; then
+    echo "Device:     $DEVICE_MODEL"
+fi
+
 # --- Extract version and auto-download APK if needed ---
 if [ -z "$APK" ]; then
     # Try to find the version from config.json metadata or ticket files
@@ -181,39 +209,7 @@ if [ -n "$COUNTRY" ]; then
     ENV_OVERRIDES+=("RADIANCE_COUNTRY=$COUNTRY")
 fi
 
-# --- Run android-test to handle emulator setup + install ---
-echo "Starting android-test..."
-echo ""
-
-# We need to intercept after install but before app start to push configs.
-# Instead, run android-test and then push configs separately.
-# First, start android-test in a way that we can push configs before the app restarts.
-
-# Actually, the cleanest approach: call android-test which handles everything,
-# then ALSO push the config files. The app will pick them up on the next config
-# cycle (or we force-restart it after pushing).
-
-# Run android-test (it installs, pushes .env, restarts, streams logs).
-# We pipe to tee so we can capture logs while also monitoring.
-# But first, we need to push the config files AFTER install but BEFORE the app starts.
-# android-test does: install → push .env → restart → stream logs.
-# We want:           install → push .env + configs → restart → stream logs.
-
-# The simplest approach: run android-test but tell it to skip log streaming,
-# then push configs, restart, and stream ourselves. But android-test doesn't
-# have that option. So let's just:
-# 1. Run android-test (which handles everything including streaming)
-# 2. In a separate terminal or after Ctrl+C, the configs are already there
-
-# Actually, the BEST approach: push configs as part of the .env push.
-# We can do this by running android-test, which sets up emulator + installs + pushes .env,
-# then we push the config files to the same data dir, force-restart, and stream.
-
-# Let's just do it all ourselves, reusing android-test's emulator/AVD setup.
-
-# Source android-test's tool-finding logic by running it with --help
-# Actually let's just duplicate the minimal setup and push everything together.
-
+# --- Ensure emulator with matching API level ---
 # Find tools (same logic as android-test)
 if [ -n "${ANDROID_HOME:-}" ]; then
     ADB="${ANDROID_HOME}/platform-tools/adb"
@@ -228,41 +224,75 @@ if [ -z "$ADB" ] || [ ! -x "$ADB" ]; then
     exit 1
 fi
 
-# Run android-test for emulator setup + APK install (it will stream logs at the end)
-# We intercept by running it in background briefly, then pushing configs.
-# Actually, the simplest correct approach: just call android-test with the env
-# overrides, then in a post-hook push the config files.
-
-# BUT android-test ends with `exec` for log streaming, so we can't run code after it.
-# So instead: do the full flow ourselves.
-
-# Step 1: Call android-test WITHOUT log streaming — just setup + install + .env
-# We can't do that with the current script, so let's use it for setup and
-# handle the config push ourselves.
-
-# The pragmatic solution: run android-test in background, wait for "Restarting Lantern",
-# then push configs and let it continue.
-
-# ACTUALLY — the simplest: just run the same steps inline.
-
-# Detect emulator serial
-TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
-if [ -z "$TARGET_SERIAL" ]; then
-    echo "No emulator running. Starting one via android-test..."
-    # Run android-test just to get the emulator up and APK installed, skip log streaming
-    # by backgrounding and killing after install
-    "$SCRIPT_DIR/android-test" "$APK" "${ENV_OVERRIDES[@]}" &
-    TEST_PID=$!
-    # Wait for "Restarting Lantern" to appear (means install + .env push done)
-    sleep 30  # generous wait for emulator boot + install
-    kill "$TEST_PID" 2>/dev/null || true
-    wait "$TEST_PID" 2>/dev/null || true
-    TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
+# Determine target API level — use user's sdkInt if available, otherwise default to 35
+TARGET_API="${SDK_INT:-35}"
+# Clamp to available range (Google APIs images exist for 21-35+)
+if [ "$TARGET_API" -gt 35 ] 2>/dev/null; then
+    # API 36+ may not have a Google APIs image yet; fall back to 35
+    echo "Note: API $TARGET_API image may not be available, using API 35"
+    TARGET_API=35
 fi
 
+AVD_NAME="lantern-api${TARGET_API}"
+EMULATOR=""
+SDKMANAGER=""
+AVDMANAGER=""
+if [ -n "${ANDROID_HOME:-}" ]; then
+    EMULATOR="${ANDROID_HOME}/emulator/emulator"
+    SDKMANAGER="${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager"
+    AVDMANAGER="${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager"
+elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+    EMULATOR="${ANDROID_SDK_ROOT}/emulator/emulator"
+    SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
+    AVDMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/avdmanager"
+else
+    EMULATOR="$(command -v emulator 2>/dev/null || true)"
+    SDKMANAGER="$(command -v sdkmanager 2>/dev/null || true)"
+    AVDMANAGER="$(command -v avdmanager 2>/dev/null || true)"
+fi
+
+# Create API-matched AVD if it doesn't exist
+if ! "$EMULATOR" -list-avds 2>/dev/null | grep -q "^${AVD_NAME}$"; then
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        arm64|aarch64) IMG_ABI="arm64-v8a" ;;
+        x86_64)        IMG_ABI="x86_64" ;;
+        *)             IMG_ABI="arm64-v8a" ;;
+    esac
+    IMAGE="system-images;android-${TARGET_API};google_apis;${IMG_ABI}"
+    echo "Creating AVD '$AVD_NAME' (API $TARGET_API) to match user's device..."
+    "$SDKMANAGER" "$IMAGE" 2>&1 | tail -3
+    echo "no" | "$AVDMANAGER" create avd -n "$AVD_NAME" -k "$IMAGE" --force 2>&1 | tail -2
+fi
+
+# Detect or start emulator
+APPEAR_TIMEOUT="${APPEAR_TIMEOUT:-120}"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-300}"
+
+TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
 if [ -z "$TARGET_SERIAL" ]; then
-    echo "Error: No emulator found after setup. Run android-test manually first."
-    exit 1
+    echo "Starting emulator: $AVD_NAME (API $TARGET_API)..."
+    "$EMULATOR" -avd "$AVD_NAME" -no-snapshot-load -no-audio -gpu host &
+    START_TIME=$(date +%s)
+    while :; do
+        TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
+        if [ -n "$TARGET_SERIAL" ]; then break; fi
+        if [ $(( $(date +%s) - START_TIME )) -ge "$APPEAR_TIMEOUT" ]; then
+            echo "Error: Timed out waiting for emulator." >&2; exit 1
+        fi
+        sleep 2
+    done
+    "$ADB" -s "$TARGET_SERIAL" wait-for-device
+    START_TIME=$(date +%s)
+    while [ "$("$ADB" -s "$TARGET_SERIAL" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+        if [ $(( $(date +%s) - START_TIME )) -ge "$BOOT_TIMEOUT" ]; then
+            echo "Error: Timed out waiting for boot." >&2; exit 1
+        fi
+        sleep 2
+    done
+    echo "Emulator booted: $TARGET_SERIAL"
+else
+    echo "Emulator already running: $TARGET_SERIAL"
 fi
 
 ADB_CMD=("$ADB" -s "$TARGET_SERIAL")

--- a/scripts/android/android-test
+++ b/scripts/android/android-test
@@ -118,9 +118,11 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
     echo "====================="
     echo ""
 
-    # Push the .env to the app's data directory.
-    # Strategy: try adb root first (Google APIs emulator images), then
-    # run-as (debug APKs), then su (user-rooted devices).
+    # Push the .env to the app's .lantern data directory. On Android, the
+    # Go code's cwd is "/" so the init()-time .env read fails. radiance's
+    # common.Init calls env.LoadFromDir(dataDir) which reads from the
+    # .lantern subdir instead.
+    APP_DATA="/data/data/$PKG/.lantern"
     $ADB_CMD push "$ENV_FILE" /data/local/tmp/.env
     PUSHED=false
 
@@ -129,8 +131,8 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
         if $ADB_CMD root 2>/dev/null | grep -q "already running\|restarting"; then
             sleep 2  # wait for adbd to restart
             $ADB_CMD wait-for-device
-            if $ADB_CMD shell "cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) /data/data/$PKG/.env" 2>/dev/null; then
-                echo ".env pushed via adb root"
+            if $ADB_CMD shell "mkdir -p $APP_DATA && cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/.env" 2>/dev/null; then
+                echo ".env pushed to $APP_DATA via adb root"
                 PUSHED=true
                 $ADB_CMD unroot 2>/dev/null || true
                 sleep 1
@@ -141,16 +143,16 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
 
     # Method 2: run-as (debug/debuggable APKs)
     if ! $PUSHED; then
-        if $ADB_CMD shell "run-as $PKG cp /data/local/tmp/.env /data/data/$PKG/.env" 2>/dev/null; then
-            echo ".env pushed via run-as (debug APK)"
+        if $ADB_CMD shell "run-as $PKG mkdir -p .lantern && run-as $PKG cp /data/local/tmp/.env .lantern/.env" 2>/dev/null; then
+            echo ".env pushed to $APP_DATA via run-as (debug APK)"
             PUSHED=true
         fi
     fi
 
     # Method 3: su (user-rooted devices)
     if ! $PUSHED; then
-        if $ADB_CMD shell "su -c \"cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c %u:%g /data/data/$PKG/) /data/data/$PKG/.env\"" 2>/dev/null; then
-            echo ".env pushed via su"
+        if $ADB_CMD shell "su -c \"mkdir -p $APP_DATA && cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c %u:%g /data/data/$PKG) $APP_DATA/.env\"" 2>/dev/null; then
+            echo ".env pushed to $APP_DATA via su"
             PUSHED=true
         fi
     fi

--- a/scripts/android/android-test
+++ b/scripts/android/android-test
@@ -66,14 +66,50 @@ fi
 APK="$1"; shift
 ENV_ARGS=("$@")
 
-# --- Pick an AVD ---
+# --- Ensure we have a rootable AVD ---
 # Prefer lantern-test (Google APIs, rootable), fall back to first available.
 AVD=$("$EMULATOR" -list-avds 2>/dev/null | grep "^lantern-test$" || "$EMULATOR" -list-avds 2>/dev/null | head -1)
 if [ -z "$AVD" ]; then
-    echo "Error: No AVDs found. Create one with Android Studio or:"
-    echo "  sdkmanager 'system-images;android-35;google_apis;arm64-v8a'"
-    echo "  avdmanager create avd -n lantern-test -k 'system-images;android-35;google_apis;arm64-v8a'"
-    exit 1
+    echo "No AVDs found. Setting up lantern-test automatically..."
+
+    # Find sdkmanager and avdmanager
+    if [ -n "${ANDROID_HOME:-}" ]; then
+        SDKMANAGER="${ANDROID_HOME}/cmdline-tools/latest/bin/sdkmanager"
+        AVDMANAGER="${ANDROID_HOME}/cmdline-tools/latest/bin/avdmanager"
+    elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+        SDKMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/sdkmanager"
+        AVDMANAGER="${ANDROID_SDK_ROOT}/cmdline-tools/latest/bin/avdmanager"
+    else
+        SDKMANAGER="$(command -v sdkmanager 2>/dev/null || true)"
+        AVDMANAGER="$(command -v avdmanager 2>/dev/null || true)"
+    fi
+
+    if [ -z "$SDKMANAGER" ] || [ ! -x "$SDKMANAGER" ]; then
+        echo "Error: sdkmanager not found. Install Android SDK command-line tools first."
+        exit 1
+    fi
+    if [ -z "$AVDMANAGER" ] || [ ! -x "$AVDMANAGER" ]; then
+        echo "Error: avdmanager not found. Install Android SDK command-line tools first."
+        exit 1
+    fi
+
+    # Detect host architecture for the system image
+    ARCH=$(uname -m)
+    case "$ARCH" in
+        arm64|aarch64) IMG_ABI="arm64-v8a" ;;
+        x86_64)        IMG_ABI="x86_64" ;;
+        *)             IMG_ABI="arm64-v8a" ;;
+    esac
+
+    IMAGE="system-images;android-35;google_apis;${IMG_ABI}"
+    echo "Installing system image: $IMAGE"
+    "$SDKMANAGER" "$IMAGE"
+
+    echo "Creating AVD: lantern-test"
+    echo "no" | "$AVDMANAGER" create avd -n lantern-test -k "$IMAGE" --force
+
+    AVD="lantern-test"
+    echo "AVD created: $AVD"
 fi
 
 # --- Select / start emulator target ---

--- a/scripts/android/android-test
+++ b/scripts/android/android-test
@@ -114,31 +114,45 @@ fi
 
 # --- Select / start emulator target ---
 # Use -s <serial> throughout so multiple connected devices don't break adb.
+# The emulator is intentionally left running after the script exits so
+# subsequent runs don't pay the boot cost again.
+APPEAR_TIMEOUT="${APPEAR_TIMEOUT:-120}"
+BOOT_TIMEOUT="${BOOT_TIMEOUT:-300}"
+
 TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
 if [ -z "$TARGET_SERIAL" ]; then
     echo "Starting emulator: $AVD"
     "$EMULATOR" -avd "$AVD" -no-snapshot-load -no-audio -gpu host &
-    EMULATOR_PID=$!
     echo "Waiting for emulator to appear..."
+    START_TIME=$(date +%s)
     while :; do
         TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
         if [ -n "$TARGET_SERIAL" ]; then break; fi
+        if [ $(( $(date +%s) - START_TIME )) -ge "$APPEAR_TIMEOUT" ]; then
+            echo "Error: Timed out after ${APPEAR_TIMEOUT}s waiting for emulator to appear." >&2
+            exit 1
+        fi
         sleep 2
     done
     echo "Waiting for emulator to boot..."
     "$ADB" -s "$TARGET_SERIAL" wait-for-device
+    START_TIME=$(date +%s)
     while [ "$("$ADB" -s "$TARGET_SERIAL" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+        if [ $(( $(date +%s) - START_TIME )) -ge "$BOOT_TIMEOUT" ]; then
+            echo "Error: Timed out after ${BOOT_TIMEOUT}s waiting for emulator to boot." >&2
+            exit 1
+        fi
         sleep 2
     done
     echo "Emulator booted: $TARGET_SERIAL"
 else
     echo "Emulator already running: $TARGET_SERIAL"
 fi
-ADB_CMD="$ADB -s $TARGET_SERIAL"
+ADB_CMD=("$ADB" -s "$TARGET_SERIAL")
 
 # --- Install APK ---
 echo "Installing $APK..."
-$ADB_CMD install -r -t "$APK" 2>&1 | tail -1
+"${ADB_CMD[@]}" install -r -t "$APK" 2>&1 | tail -1
 
 # --- Push .env file ---
 if [ ${#ENV_ARGS[@]} -gt 0 ]; then
@@ -159,27 +173,27 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
     # common.Init calls env.LoadFromDir(dataDir) which reads from the
     # .lantern subdir instead.
     APP_DATA="/data/data/$PKG/.lantern"
-    $ADB_CMD push "$ENV_FILE" /data/local/tmp/.env
+    "${ADB_CMD[@]}" push "$ENV_FILE" /data/local/tmp/.env
     PUSHED=false
 
     # Method 1: adb root (Google APIs emulator images — no Play Store)
     if ! $PUSHED; then
-        if $ADB_CMD root 2>/dev/null | grep -q "already running\|restarting"; then
+        if "${ADB_CMD[@]}" root 2>/dev/null | grep -q "already running\|restarting"; then
             sleep 2  # wait for adbd to restart
-            $ADB_CMD wait-for-device
-            if $ADB_CMD shell "mkdir -p $APP_DATA && cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/.env" 2>/dev/null; then
+            "${ADB_CMD[@]}" wait-for-device
+            if "${ADB_CMD[@]}" shell "mkdir -p $APP_DATA && cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) $APP_DATA/.env" 2>/dev/null; then
                 echo ".env pushed to $APP_DATA via adb root"
                 PUSHED=true
-                $ADB_CMD unroot 2>/dev/null || true
+                "${ADB_CMD[@]}" unroot 2>/dev/null || true
                 sleep 1
-                $ADB_CMD wait-for-device
+                "${ADB_CMD[@]}" wait-for-device
             fi
         fi
     fi
 
     # Method 2: run-as (debug/debuggable APKs)
     if ! $PUSHED; then
-        if $ADB_CMD shell "run-as $PKG mkdir -p .lantern && run-as $PKG cp /data/local/tmp/.env .lantern/.env" 2>/dev/null; then
+        if "${ADB_CMD[@]}" shell "run-as $PKG mkdir -p .lantern && run-as $PKG cp /data/local/tmp/.env .lantern/.env" 2>/dev/null; then
             echo ".env pushed to $APP_DATA via run-as (debug APK)"
             PUSHED=true
         fi
@@ -187,7 +201,7 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
 
     # Method 3: su (user-rooted devices)
     if ! $PUSHED; then
-        if $ADB_CMD shell "su -c \"mkdir -p $APP_DATA && cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c %u:%g /data/data/$PKG) $APP_DATA/.env\"" 2>/dev/null; then
+        if "${ADB_CMD[@]}" shell "su -c \"mkdir -p $APP_DATA && cp /data/local/tmp/.env $APP_DATA/.env && chown \$(stat -c %u:%g /data/data/$PKG) $APP_DATA/.env\"" 2>/dev/null; then
             echo ".env pushed to $APP_DATA via su"
             PUSHED=true
         fi
@@ -208,17 +222,17 @@ fi
 
 # --- Restart app ---
 echo "Restarting Lantern..."
-$ADB_CMD shell am force-stop "$PKG" 2>/dev/null || true
+"${ADB_CMD[@]}" shell am force-stop "$PKG" 2>/dev/null || true
 sleep 1
-$ADB_CMD shell am start -n "$PKG/$ACTIVITY" 2>/dev/null || \
-    $ADB_CMD shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 2>/dev/null
+"${ADB_CMD[@]}" shell am start -n "$PKG/$ACTIVITY" 2>/dev/null || \
+    "${ADB_CMD[@]}" shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 2>/dev/null
 
 # --- Stream logs ---
 echo ""
 echo "=== Streaming logs (Ctrl+C to stop) ==="
 echo ""
-$ADB_CMD logcat -c  # clear old logs
-exec $ADB_CMD logcat -v time \
+"${ADB_CMD[@]}" logcat -c  # clear old logs
+exec "${ADB_CMD[@]}" logcat -v time \
     -s "GoLog:*" "radiance:*" "sing-box:*" "lantern:*" "flutter:*" \
        "LanternService:*" "VpnService:*" "System.err:*" \
        "AndroidRuntime:*" "lantern-box:*"

--- a/scripts/android/android-test
+++ b/scripts/android/android-test
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# android-test — Quick Android emulator test harness for Lantern
+#
+# Usage:
+#   android-test <apk-path> [ENV_KEY=VALUE ...]
+#
+# Examples:
+#   android-test ~/Downloads/lantern-9.0.25.apk RADIANCE_COUNTRY=BG
+#   android-test ~/Downloads/lantern.apk RADIANCE_COUNTRY=CN RADIANCE_FEATURE_OVERRIDES=dns_ruleset_host_bypass
+#   android-test ~/Downloads/lantern.apk  # no overrides, just install + logs
+#
+# Prerequisites:
+#   - Android SDK at ~/Library/Android/sdk (or $ANDROID_HOME)
+#   - At least one AVD created (run: avdmanager list avd)
+#
+# What it does:
+#   1. Starts the emulator (if not already running)
+#   2. Waits for boot
+#   3. Installs the APK
+#   4. Pushes a .env file with your overrides to the app's data dir
+#   5. Force-stops and restarts the app so it picks up the .env
+#   6. Streams logcat filtered to Lantern/radiance/sing-box output
+#
+# The .env file is read by radiance/common/env/env.go init() from the
+# app's working directory. On Android this requires either a debug APK
+# (run-as works) or root. If run-as fails, the script falls back to
+# using /sdcard/ and hopes the app reads from there (it won't — but
+# the error message will tell you).
+
+set -euo pipefail
+
+PKG="org.getlantern.lantern"
+ACTIVITY="org.getlantern.lantern.MainActivity"
+
+# Find tools — prefer $ANDROID_HOME, fall back to $PATH
+if [ -n "${ANDROID_HOME:-}" ]; then
+    ADB="${ANDROID_HOME}/platform-tools/adb"
+    EMULATOR="${ANDROID_HOME}/emulator/emulator"
+elif [ -n "${ANDROID_SDK_ROOT:-}" ]; then
+    ADB="${ANDROID_SDK_ROOT}/platform-tools/adb"
+    EMULATOR="${ANDROID_SDK_ROOT}/emulator/emulator"
+else
+    ADB="$(command -v adb 2>/dev/null || true)"
+    EMULATOR="$(command -v emulator 2>/dev/null || true)"
+fi
+
+if [ -z "$ADB" ] || [ ! -x "$ADB" ]; then
+    echo "Error: adb not found. Set ANDROID_HOME or add Android SDK to PATH."
+    exit 1
+fi
+if [ -z "$EMULATOR" ] || [ ! -x "$EMULATOR" ]; then
+    echo "Error: emulator not found. Set ANDROID_HOME or add Android SDK to PATH."
+    exit 1
+fi
+
+# --- Parse args ---
+if [ $# -lt 1 ]; then
+    echo "Usage: android-test <apk-path> [ENV_KEY=VALUE ...]"
+    echo ""
+    echo "Examples:"
+    echo "  android-test lantern.apk RADIANCE_COUNTRY=BG"
+    echo "  android-test lantern.apk RADIANCE_COUNTRY=CN RADIANCE_FEATURE_OVERRIDES=dns_ruleset_host_bypass"
+    exit 1
+fi
+
+APK="$1"; shift
+ENV_ARGS=("$@")
+
+# --- Pick an AVD ---
+# Prefer lantern-test (Google APIs, rootable), fall back to first available.
+AVD=$("$EMULATOR" -list-avds 2>/dev/null | grep "^lantern-test$" || "$EMULATOR" -list-avds 2>/dev/null | head -1)
+if [ -z "$AVD" ]; then
+    echo "Error: No AVDs found. Create one with Android Studio or:"
+    echo "  sdkmanager 'system-images;android-35;google_apis;arm64-v8a'"
+    echo "  avdmanager create avd -n lantern-test -k 'system-images;android-35;google_apis;arm64-v8a'"
+    exit 1
+fi
+
+# --- Start emulator if needed ---
+if ! "$ADB" devices 2>/dev/null | grep -q "emulator-"; then
+    echo "Starting emulator: $AVD"
+    "$EMULATOR" -avd "$AVD" -no-snapshot-load -no-audio -gpu host &
+    EMULATOR_PID=$!
+    echo "Waiting for emulator to boot..."
+    "$ADB" wait-for-device
+    # Wait for boot_completed
+    while [ "$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+        sleep 2
+    done
+    echo "Emulator booted."
+else
+    echo "Emulator already running."
+fi
+
+# --- Install APK ---
+echo "Installing $APK..."
+"$ADB" install -r -t "$APK" 2>&1 | tail -1
+
+# --- Push .env file ---
+if [ ${#ENV_ARGS[@]} -gt 0 ]; then
+    ENV_FILE=$(mktemp)
+    for kv in "${ENV_ARGS[@]}"; do
+        echo "$kv" >> "$ENV_FILE"
+    done
+    echo ""
+    echo "=== .env contents ==="
+    cat "$ENV_FILE"
+    echo "====================="
+    echo ""
+
+    # Push the .env to the app's data directory.
+    # Strategy: try adb root first (Google APIs emulator images), then
+    # run-as (debug APKs), then su (user-rooted devices).
+    "$ADB" push "$ENV_FILE" /data/local/tmp/.env
+    PUSHED=false
+
+    # Method 1: adb root (Google APIs emulator images — no Play Store)
+    if ! $PUSHED; then
+        if "$ADB" root 2>/dev/null | grep -q "already running\|restarting"; then
+            sleep 2  # wait for adbd to restart
+            "$ADB" wait-for-device
+            if "$ADB" shell "cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) /data/data/$PKG/.env" 2>/dev/null; then
+                echo ".env pushed via adb root"
+                PUSHED=true
+                "$ADB" unroot 2>/dev/null || true
+                sleep 1
+                "$ADB" wait-for-device
+            fi
+        fi
+    fi
+
+    # Method 2: run-as (debug/debuggable APKs)
+    if ! $PUSHED; then
+        if "$ADB" shell "run-as $PKG cp /data/local/tmp/.env /data/data/$PKG/.env" 2>/dev/null; then
+            echo ".env pushed via run-as (debug APK)"
+            PUSHED=true
+        fi
+    fi
+
+    # Method 3: su (user-rooted devices)
+    if ! $PUSHED; then
+        if "$ADB" shell "su -c 'cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c %u /data/data/$PKG/) /data/data/$PKG/.env'" 2>/dev/null; then
+            echo ".env pushed via su"
+            PUSHED=true
+        fi
+    fi
+
+    if ! $PUSHED; then
+        echo ""
+        echo "ERROR: Cannot push .env — APK is not debuggable and device is not rooted."
+        echo "Options:"
+        echo "  1. Use a debug APK build"
+        echo "  2. Use a Google APIs emulator image (rootable, no Play Store):"
+        echo "     sdkmanager 'system-images;android-35;google_apis;arm64-v8a'"
+        echo "     avdmanager create avd -n lantern-test -k 'system-images;android-35;google_apis;arm64-v8a'"
+        echo ""
+        echo "Continuing without overrides..."
+    fi
+    rm -f "$ENV_FILE"
+fi
+
+# --- Restart app ---
+echo "Restarting Lantern..."
+"$ADB" shell am force-stop "$PKG" 2>/dev/null || true
+sleep 1
+"$ADB" shell am start -n "$PKG/$ACTIVITY" 2>/dev/null || \
+    "$ADB" shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 2>/dev/null
+
+# --- Stream logs ---
+echo ""
+echo "=== Streaming logs (Ctrl+C to stop) ==="
+echo ""
+"$ADB" logcat -c  # clear old logs
+exec "$ADB" logcat -v time \
+    -s "GoLog:*" "radiance:*" "sing-box:*" "lantern:*" "flutter:*" \
+       "LanternService:*" "VpnService:*" "System.err:*" \
+       "AndroidRuntime:*" "lantern-box:*"

--- a/scripts/android/android-test
+++ b/scripts/android/android-test
@@ -11,7 +11,8 @@
 #
 # Prerequisites:
 #   - Android SDK (set $ANDROID_HOME, $ANDROID_SDK_ROOT, or have adb/emulator in $PATH)
-#   - At least one AVD created (run: avdmanager list avd)
+#   - If no AVDs exist, the script auto-creates "lantern-test" (requires sdkmanager/avdmanager;
+#     downloads a ~2GB Google APIs system image on first run)
 #
 # What it does:
 #   1. Starts the emulator (if not already running)

--- a/scripts/android/android-test
+++ b/scripts/android/android-test
@@ -10,7 +10,7 @@
 #   android-test ~/Downloads/lantern.apk  # no overrides, just install + logs
 #
 # Prerequisites:
-#   - Android SDK at ~/Library/Android/sdk (or $ANDROID_HOME)
+#   - Android SDK (set $ANDROID_HOME, $ANDROID_SDK_ROOT, or have adb/emulator in $PATH)
 #   - At least one AVD created (run: avdmanager list avd)
 #
 # What it does:
@@ -23,9 +23,9 @@
 #
 # The .env file is read by radiance/common/env/env.go init() from the
 # app's working directory. On Android this requires either a debug APK
-# (run-as works) or root. If run-as fails, the script falls back to
-# using /sdcard/ and hopes the app reads from there (it won't — but
-# the error message will tell you).
+# (run-as works) or root (adb root on Google APIs images, or su on
+# user-rooted devices). If none of these work, the script reports the
+# failure and continues without overrides.
 
 set -euo pipefail
 
@@ -76,29 +76,39 @@ if [ -z "$AVD" ]; then
     exit 1
 fi
 
-# --- Start emulator if needed ---
-if ! "$ADB" devices 2>/dev/null | grep -q "emulator-"; then
+# --- Select / start emulator target ---
+# Use -s <serial> throughout so multiple connected devices don't break adb.
+TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
+if [ -z "$TARGET_SERIAL" ]; then
     echo "Starting emulator: $AVD"
     "$EMULATOR" -avd "$AVD" -no-snapshot-load -no-audio -gpu host &
     EMULATOR_PID=$!
-    echo "Waiting for emulator to boot..."
-    "$ADB" wait-for-device
-    # Wait for boot_completed
-    while [ "$("$ADB" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+    echo "Waiting for emulator to appear..."
+    while :; do
+        TARGET_SERIAL=$("$ADB" devices 2>/dev/null | awk '/^emulator-/{print $1; exit}')
+        if [ -n "$TARGET_SERIAL" ]; then break; fi
         sleep 2
     done
-    echo "Emulator booted."
+    echo "Waiting for emulator to boot..."
+    "$ADB" -s "$TARGET_SERIAL" wait-for-device
+    while [ "$("$ADB" -s "$TARGET_SERIAL" shell getprop sys.boot_completed 2>/dev/null | tr -d '\r')" != "1" ]; do
+        sleep 2
+    done
+    echo "Emulator booted: $TARGET_SERIAL"
 else
-    echo "Emulator already running."
+    echo "Emulator already running: $TARGET_SERIAL"
 fi
+ADB_CMD="$ADB -s $TARGET_SERIAL"
 
 # --- Install APK ---
 echo "Installing $APK..."
-"$ADB" install -r -t "$APK" 2>&1 | tail -1
+$ADB_CMD install -r -t "$APK" 2>&1 | tail -1
 
 # --- Push .env file ---
 if [ ${#ENV_ARGS[@]} -gt 0 ]; then
     ENV_FILE=$(mktemp)
+    trap 'rm -f "${ENV_FILE:-}"' EXIT INT TERM
+
     for kv in "${ENV_ARGS[@]}"; do
         echo "$kv" >> "$ENV_FILE"
     done
@@ -111,27 +121,27 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
     # Push the .env to the app's data directory.
     # Strategy: try adb root first (Google APIs emulator images), then
     # run-as (debug APKs), then su (user-rooted devices).
-    "$ADB" push "$ENV_FILE" /data/local/tmp/.env
+    $ADB_CMD push "$ENV_FILE" /data/local/tmp/.env
     PUSHED=false
 
     # Method 1: adb root (Google APIs emulator images — no Play Store)
     if ! $PUSHED; then
-        if "$ADB" root 2>/dev/null | grep -q "already running\|restarting"; then
+        if $ADB_CMD root 2>/dev/null | grep -q "already running\|restarting"; then
             sleep 2  # wait for adbd to restart
-            "$ADB" wait-for-device
-            if "$ADB" shell "cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) /data/data/$PKG/.env" 2>/dev/null; then
+            $ADB_CMD wait-for-device
+            if $ADB_CMD shell "cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c '%U:%G' /data/data/$PKG) /data/data/$PKG/.env" 2>/dev/null; then
                 echo ".env pushed via adb root"
                 PUSHED=true
-                "$ADB" unroot 2>/dev/null || true
+                $ADB_CMD unroot 2>/dev/null || true
                 sleep 1
-                "$ADB" wait-for-device
+                $ADB_CMD wait-for-device
             fi
         fi
     fi
 
     # Method 2: run-as (debug/debuggable APKs)
     if ! $PUSHED; then
-        if "$ADB" shell "run-as $PKG cp /data/local/tmp/.env /data/data/$PKG/.env" 2>/dev/null; then
+        if $ADB_CMD shell "run-as $PKG cp /data/local/tmp/.env /data/data/$PKG/.env" 2>/dev/null; then
             echo ".env pushed via run-as (debug APK)"
             PUSHED=true
         fi
@@ -139,7 +149,7 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
 
     # Method 3: su (user-rooted devices)
     if ! $PUSHED; then
-        if "$ADB" shell "su -c 'cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c %u /data/data/$PKG/) /data/data/$PKG/.env'" 2>/dev/null; then
+        if $ADB_CMD shell "su -c \"cp /data/local/tmp/.env /data/data/$PKG/.env && chown \$(stat -c %u:%g /data/data/$PKG/) /data/data/$PKG/.env\"" 2>/dev/null; then
             echo ".env pushed via su"
             PUSHED=true
         fi
@@ -156,22 +166,21 @@ if [ ${#ENV_ARGS[@]} -gt 0 ]; then
         echo ""
         echo "Continuing without overrides..."
     fi
-    rm -f "$ENV_FILE"
 fi
 
 # --- Restart app ---
 echo "Restarting Lantern..."
-"$ADB" shell am force-stop "$PKG" 2>/dev/null || true
+$ADB_CMD shell am force-stop "$PKG" 2>/dev/null || true
 sleep 1
-"$ADB" shell am start -n "$PKG/$ACTIVITY" 2>/dev/null || \
-    "$ADB" shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 2>/dev/null
+$ADB_CMD shell am start -n "$PKG/$ACTIVITY" 2>/dev/null || \
+    $ADB_CMD shell monkey -p "$PKG" -c android.intent.category.LAUNCHER 1 2>/dev/null
 
 # --- Stream logs ---
 echo ""
 echo "=== Streaming logs (Ctrl+C to stop) ==="
 echo ""
-"$ADB" logcat -c  # clear old logs
-exec "$ADB" logcat -v time \
+$ADB_CMD logcat -c  # clear old logs
+exec $ADB_CMD logcat -v time \
     -s "GoLog:*" "radiance:*" "sing-box:*" "lantern:*" "flutter:*" \
        "LanternService:*" "VpnService:*" "System.err:*" \
        "AndroidRuntime:*" "lantern-box:*"


### PR DESCRIPTION
## Summary

Two scripts for Android emulator testing:

### `scripts/android/android-test` — Quick emulator test harness

```bash
android-test lantern.apk RADIANCE_COUNTRY=BG RADIANCE_FEATURE_OVERRIDES=dns_ruleset_host_bypass
```

- Starts emulator (auto-creates rootable Google APIs AVD if none exists)
- Installs APK
- Pushes `.env` with overrides to the app's `.lantern` data dir (via `adb root` / `run-as` / `su`)
- Streams filtered logcat

### `scripts/android/android-reproduce` — Reproduce Freshdesk tickets on emulator

```bash
# After /analyze-ticket downloads config to /tmp/ticket-<id>/
android-reproduce /tmp/ticket-172722
```

- Extracts country, Android version (sdkInt), device model from the ticket's `flutter.log`
- Auto-downloads matching APK from GitHub releases (`gh release download`)
- Creates an API-matched AVD (e.g. `lantern-api34` for Android 14) — builds up a catalog over time, reused across tickets
- Pushes the user's exact `config.json`, `servers.json`, `split-tunnel.json` to the emulator
- Sets `RADIANCE_COUNTRY` to match the user's region
- Installs, restarts, streams logs

Integrated with `/analyze-ticket` — when diagnosing an Android ticket, it now offers "Reproduce on Android emulator" as a next action.

## Companion PRs

- getlantern/radiance#421 — `env.LoadFromDir(dataDir)` so the Go code reads `.env` from the data directory on Android
- getlantern/lantern-cloud#2588 — DNS bypass rule for rule-set downloads (the fix being verified)

## Features

- Auto-detects host arch (arm64 vs x86_64) for system image selection
- Auto-installs system images and creates AVDs on first use
- Dynamically finds the closest available API image (steps down from user's sdkInt)
- Uses `-s <serial>` for all adb invocations (safe with multiple devices)
- Configurable timeouts (`APPEAR_TIMEOUT`, `BOOT_TIMEOUT`)
- Temp file cleanup via trap

🤖 Generated with [Claude Code](https://claude.com/claude-code)