### PR TITLE
Makefile: fix empty common.Version on Windows CI (missing app version 400)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ FFI_DIR := $(LANTERN_CORE)/ffi
 ## Local builds fall back to reading pubspec.yaml directly, with a PowerShell
 ## branch so Windows devs without Git Bash / WSL still get a working build.
 ifeq ($(OS),Windows_NT)
-APP_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "(Select-String -Path 'pubspec.yaml' -Pattern '^version:\s*(.+)$$').Matches[0].Groups[1].Value.Trim()")
+APP_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command '(Select-String -Path "pubspec.yaml" -Pattern "^version:\s*(.+)$$").Matches[0].Groups[1].Value.Trim()')
 else
 APP_VERSION ?= $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
 endif
@@ -153,7 +153,7 @@ TAGS=with_gvisor,with_quic,with_wireguard,with_utls,with_clash_api,with_grpc,wit
 WINDOWS_CGO_LDFLAGS=-static-libgcc -static-libstdc++ -static -lwinpthread
 
 ifeq ($(OS),Windows_NT)
-GO_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "$$line=(Select-String -Path 'go.mod' -Pattern '^go\s+(.+)$$').Matches[0].Groups[1].Value.Trim(); Write-Output ('go'+$$line)")
+GO_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command '$$line=(Select-String -Path "go.mod" -Pattern "^go\s+(.+)$$").Matches[0].Groups[1].Value.Trim(); Write-Output ("go"+$$line)')
 GO_SOURCES := go.mod go.sum
 UNAME_S := Windows
 else

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,21 @@ LANTERN_LIB_NAME := liblantern
 LANTERN_CORE := lantern-core
 RADIANCE_REPO := github.com/getlantern/radiance
 FFI_DIR := $(LANTERN_CORE)/ffi
-## APP_VERSION is the full version defined in pubspec.yaml (e.g. 9.0.25+459).
-## CI may export APP_VERSION via the environment; otherwise fall back to the
-## file. `?=` lets the env value win over the shell-out, which matters on
-## Windows CI where grep/sed are not reliably on PATH (see build-windows.yml
-## "Read app version from pubspec.yaml" which writes APP_VERSION to GITHUB_ENV).
+## APP_VERSION is the full version from pubspec.yaml (e.g. 9.0.25+459).
+## Precedence: environment > pubspec.yaml. CI must export APP_VERSION — on
+## Windows CI, `$(shell …)` runs under cmd.exe which mangles the Unix-style
+## quoting in the grep|sed pipeline and returns empty, producing an empty
+## `common.Version` ldflag and a 400 "missing app version" at /v1/config-new.
+## Local builds fall back to reading pubspec.yaml directly, with a PowerShell
+## branch so Windows devs without Git Bash / WSL still get a working build.
+ifeq ($(OS),Windows_NT)
+APP_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "(Select-String -Path 'pubspec.yaml' -Pattern '^version:\s*(.+)$$').Matches[0].Groups[1].Value.Trim()")
+else
 APP_VERSION ?= $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
-## APP_VERSION_PUBSPEC strips the +buildnumber for the Go linker. Using Make
-## built-ins keeps this portable across hosts without grep/sed/awk/powershell.
+endif
+## Strip the +buildnumber for the Go linker. Done with Make built-ins so no
+## shell tools are required — this is the part that has to work in every
+## environment `make` might invoke the linker in.
 APP_VERSION_PUBSPEC := $(firstword $(subst +, ,$(APP_VERSION)))
 EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'
 

--- a/Makefile
+++ b/Makefile
@@ -13,14 +13,15 @@ LANTERN_LIB_NAME := liblantern
 LANTERN_CORE := lantern-core
 RADIANCE_REPO := github.com/getlantern/radiance
 FFI_DIR := $(LANTERN_CORE)/ffi
-## APP_VERSION is the version defined in pubspec.yaml
-ifeq ($(OS),Windows_NT)
-APP_VERSION := $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "$$v=(Select-String -Path 'pubspec.yaml' -Pattern '^version:\s*(.+)$$').Matches[0].Groups[1].Value.Trim(); Write-Output $$v")
-APP_VERSION_PUBSPEC := $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "$$v=(Select-String -Path 'pubspec.yaml' -Pattern '^version:\s*(.+)$$').Matches[0].Groups[1].Value.Trim(); Write-Output ($$v.Split('+')[0])")
-else
-APP_VERSION := $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
-APP_VERSION_PUBSPEC := $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/+.*//;s/ //g')
-endif
+## APP_VERSION is the full version defined in pubspec.yaml (e.g. 9.0.25+459).
+## CI may export APP_VERSION via the environment; otherwise fall back to the
+## file. `?=` lets the env value win over the shell-out, which matters on
+## Windows CI where grep/sed are not reliably on PATH (see build-windows.yml
+## "Read app version from pubspec.yaml" which writes APP_VERSION to GITHUB_ENV).
+APP_VERSION ?= $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
+## APP_VERSION_PUBSPEC strips the +buildnumber for the Go linker. Using Make
+## built-ins keeps this portable across hosts without grep/sed/awk/powershell.
+APP_VERSION_PUBSPEC := $(firstword $(subst +, ,$(APP_VERSION)))
 EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'
 
 DARWIN_APP_NAME := $(CAPITALIZED_APP).app

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ endif
 ## shell tools are required — this is the part that has to work in every
 ## environment `make` might invoke the linker in.
 APP_VERSION_PUBSPEC := $(firstword $(subst +, ,$(APP_VERSION)))
+## Fail loudly at parse time if we couldn't resolve a version — this was the
+## exact failure mode of the bug this file fixes, where an empty value silently
+## produced a broken binary that 400s at /v1/config-new.
+ifeq ($(strip $(APP_VERSION_PUBSPEC)),)
+$(error APP_VERSION_PUBSPEC is empty; export APP_VERSION (e.g. "9.0.25+459") or ensure pubspec.yaml contains a `version:` line)
+endif
 EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'
 
 DARWIN_APP_NAME := $(CAPITALIZED_APP).app

--- a/lantern-core/cmd/lanternsvc/main.go
+++ b/lantern-core/cmd/lanternsvc/main.go
@@ -58,9 +58,12 @@ func main() {
 	}
 
 	if *consoleMode || !isService {
+		slog.Info("Starting Windows service executable", "service", common.WindowsServiceName, "version", rcommon.Version, "mode", "console")
 		runConsole()
 		return
 	}
+
+	slog.Info("Starting Windows service executable", "service", common.WindowsServiceName, "version", rcommon.Version, "mode", "service")
 
 	// let SCM specify the service name
 	if err := svc.Run(common.WindowsServiceName, &lanternHandler{}); err != nil {


### PR DESCRIPTION
## Summary

On Windows CI, `common.Version` in radiance is linked as an empty string. Radiance copies it into the `X-Lantern-App-Version` header on `/v1/config-new`, and `lantern-cloud` rejects an empty value with `400 "missing app version"`. No config comes back, the client falls back to the embedded server list, and Windows users get no bandit tracks / no Samizdat / no smart routing.

## Root cause

The ldflag `-X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'` only works if `APP_VERSION_PUBSPEC` resolves to something non-empty. Previously:

```make
APP_VERSION := $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
APP_VERSION_PUBSPEC := $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/+.*//;s/ //g')
```

Under GNU Make on the Windows runner, `$(shell …)` runs via `cmd.exe`, which does not treat `'…'` as quoting. The pipeline `grep '^version:' pubspec.yaml | sed …` fails silently: `grep` looks for the literal string `'^version:'` (including the quotes), matches nothing, and `sed` has nothing to transform. `APP_VERSION_PUBSPEC` comes out empty, `common.Version=""`, header is empty, server returns 400.

An earlier attempt (#8666) added a `ifeq ($(OS),Windows_NT)` branch using a PowerShell one-liner, but the outer-double / inner-single quoting gets mangled when Make expands `$$` and cmd.exe passes the resulting string on to PowerShell. Separately, `:=` (immediate assignment) clobbered whatever `APP_VERSION` was already in the environment — `build-windows.yml` at `100-108` *does* read the version correctly with PowerShell and writes it to `$GITHUB_ENV`, but Make was ignoring that.

Diagnosed from Freshdesk [#172794](https://lantern.freshdesk.com/a/tickets/172794) (Derek, Windows 9.0.26 nightly). `lantern.log`:

```
service=radiance source.func=(*ConfigHandler).fetchLoop
msg="Failed to fetch config. Retrying"
error="... unexpected status code: 400. \b\x90\x03\x12\x13missing app version"
```

`flutter.log` shows `{version: 9.0.26}` — Flutter reads pubspec.yaml at runtime, so the UI has the right version; only the Go ldflag path was broken.

## Fix

Combines the small-but-real PowerShell-quoting fix from @atavism's [#8676](https://github.com/getlantern/lantern/pull/8676) (now closed in favor of this PR) with a more structural change so CI doesn't depend on shell-outs working on Windows:

1. **Respect the environment.** Change `APP_VERSION :=` → `APP_VERSION ?=` so the value exported by `build-windows.yml` to `$GITHUB_ENV` actually propagates into Make. This is the CI path — zero shell-out dependency.
2. **Compute `APP_VERSION_PUBSPEC` with Make built-ins.** Replace the second `$(shell grep | sed …)` with `$(firstword $(subst +, ,$(APP_VERSION)))`. No shell, no quoting issues, works identically on every host — and only this value feeds the ldflag, so the brittle thing is out of the path entirely.
3. **Fix the Windows PowerShell local-dev fallback quoting.** Swap outer-double / inner-single to outer-single / inner-double (the fix from #8676) so local Windows builds without `APP_VERSION` in env also succeed. Same fix applied to `GO_VERSION` further down.
4. **Parse-time guard.** `ifeq ($(strip $(APP_VERSION_PUBSPEC)),)` + `$(error …)` fails the build loudly if the version can't be resolved — the exact failure mode of the bug this PR is fixing.
5. **Windows service startup log.** Also from #8676 — log the service name, version, and mode on startup so it's visible in triage.

Result:

| Environment | APP_VERSION source | APP_VERSION_PUBSPEC |
|---|---|---|
| CI (any OS) | env from `$GITHUB_ENV` (or similar) | Make built-in `+`-split |
| Local Mac/Linux | `grep \| sed` of pubspec.yaml | Make built-in `+`-split |
| Local Windows (no Git Bash/WSL) | PowerShell `Select-String` (fixed quoting) | Make built-in `+`-split |
| Missing pubspec / any empty | — | `$(error)` fails the build |

## Verification

```
$ unset APP_VERSION && make -s -p | grep -E '^APP_VERSION'
APP_VERSION = $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
APP_VERSION_PUBSPEC := 9.0.21

$ APP_VERSION=9.0.25+459 make -s -p | grep -E '^APP_VERSION'
APP_VERSION = 9.0.25+459
APP_VERSION_PUBSPEC := 9.0.25

$ APP_VERSION= make help
Makefile:36: *** APP_VERSION_PUBSPEC is empty; export APP_VERSION ... Stop.
```

## Test plan

- [x] Make probe: env override splits `9.0.25+459` → `9.0.25`
- [x] Make probe: no-env fallback reads pubspec.yaml on Mac
- [x] Make probe: parse-time guard fires on empty
- [x] `GOOS=windows go build ./lantern-core/cmd/lanternsvc` clean (service log line change)
- [ ] Next Windows nightly build: `lantern.log` should show the client successfully fetching config (no `missing app version` 400 loop), and the Windows server list should include bandit tracks
- [ ] Inspect the built Windows DLL to confirm `common.Version` is non-empty
- [ ] Local `make windows-release` on a Windows machine without Git Bash still produces a binary with the correct version string