### PR TITLE
deps: bump sing-box-minimal to v1.12.21-lantern on refactor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ go 1.25.4
 
 replace github.com/sagernet/sing => github.com/getlantern/sing v0.7.18-lantern
 
-replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.19-lantern
+replace github.com/sagernet/sing-box => github.com/getlantern/sing-box-minimal v1.12.21-lantern
 
 replace github.com/sagernet/wireguard-go => github.com/getlantern/wireguard-go v0.0.1-beta.7.0.20251208214020-d78e69f1eff4
 

--- a/go.sum
+++ b/go.sum
@@ -267,8 +267,8 @@ github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=
 github.com/getlantern/sing v0.7.18-lantern/go.mod h1:ARkL0gM13/Iv5VCZmci/NuoOlePoIsW0m7BWfln/Hak=
-github.com/getlantern/sing-box-minimal v1.12.19-lantern h1:Tntq+Udsvyv6A/mjxfSoZ8NhvhXRSX6i/CICKGPFhAY=
-github.com/getlantern/sing-box-minimal v1.12.19-lantern/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
+github.com/getlantern/sing-box-minimal v1.12.21-lantern h1:DUlwWDHrU60hd/83mvU/fR9aASiq4KaN5Z1wa8gaRtM=
+github.com/getlantern/sing-box-minimal v1.12.21-lantern/go.mod h1:LzlFRel9E92gX0HXWCdsxgeg+kuAEPzLR+Znixk9EI4=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 h1:VTNjZxSuAHUzu13lYpEVB8gc3xz5hZePGNHG5enHYLY=
 github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9/go.mod h1:7uvbzuoOr3uYGHZx5QWlI8/C52XEf/aTb/tJFEe41Ak=
 github.com/getlantern/waitforserver v1.0.1 h1:xBjqJ3GgEk9JMWnDgRSiNHXINi6Lv2tGNjJR0hCkHFY=


### PR DESCRIPTION
## Summary

Companion to [#8678](https://github.com/getlantern/lantern/pull/8678). The refactor branch still pins `sing-box-minimal v1.12.19-lantern`, which is missing [`9c79c311`](https://github.com/getlantern/sing-box-minimal/commit/9c79c311) ("fix: make initial remote rule-set fetch non-fatal", shipped in `v1.12.21-lantern`).

Without that fix, Android builds from this branch hit the bootstrap deadlock (`"no available network interface"` during initial rule-set fetch) that breaks connection on smart-routing countries — see Freshdesk [#172722](https://lantern.freshdesk.com/a/tickets/172722) (broken, `rule_set_remote.go:235`) vs [#172795](https://lantern.freshdesk.com/a/tickets/172795) (working, `rule_set_remote.go:113`) for the before/after evidence.

Only diff is the `replace` line + the matching `go.sum` hashes.

## Test plan

- [x] `go mod tidy` clean
- [ ] Android build from refactor with smart-routing country: tunnel connects on first launch