### PR TITLE
android: bound Mobile.startVPN with withTimeout(60s)

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -8,7 +8,9 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
+import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -301,9 +303,25 @@ class LanternVpnService :
             // Without this, some Android 10+ devices report only the VPN network,
             // causing sing-box to see no physical interface and blocking all traffic.
             updateUnderlyingNetworks()
-            // Bound connect() so a Go-side deadlock can't leave the UI button
-            // frozen. TimeoutCancellationException falls through to runCatching.
-            withTimeout(VPN_START_TIMEOUT_MS) { connect() }
+            // Bound the Mobile.startVPN / connectToServer call with a wall-clock
+            // timeout. These are blocking JNI calls with no suspension points,
+            // so withTimeout around a direct invocation wouldn't fire — we run
+            // the call in a child coroutine on Dispatchers.IO and await it,
+            // which gives withTimeout a real cancellation point. On timeout we
+            // abandon the awaited Deferred (the underlying JNI call keeps
+            // running in the background; we accept that leak — once Go
+            // eventually completes or the process exits, it will settle) so
+            // the UI gets unstuck with a clear error instead of a frozen
+            // button that only a phone reboot can clear (Freshdesk #173507).
+            coroutineScope {
+                val deferred = async(Dispatchers.IO) { connect() }
+                try {
+                    withTimeout(VPN_START_TIMEOUT_MS) { deferred.await() }
+                } catch (e: TimeoutCancellationException) {
+                    deferred.cancel()
+                    throw e
+                }
+            }
             VpnStatusManager.postVPNStatus(VPNStatus.Connected)
             notificationHelper.showVPNConnectedNotification(this@LanternVpnService)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
@@ -323,7 +341,7 @@ class LanternVpnService :
                 .onFailure { stopErr -> AppLogger.e(TAG, "DefaultNetworkMonitor.stop() failed in error path", stopErr) }
             VpnStatusManager.postVPNError(
                 errorCode = if (timedOut) "${errorCode}_timeout" else errorCode,
-                errorMessage = if (timedOut) "VPN start timed out" else "Error in VPN operation",
+                errorMessage = if (timedOut) "VPN operation timed out" else "Error in VPN operation",
                 error = e,
             )
             if (cleanUpOnFailure) serviceCleanUp()

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -7,10 +7,12 @@ import android.os.ParcelFileDescriptor
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
+import kotlinx.coroutines.withTimeout
 import lantern.io.libbox.Notification
 import lantern.io.libbox.StringIterator
 import lantern.io.libbox.TunOptions
@@ -48,6 +50,14 @@ class LanternVpnService :
         const val ACTION_CONNECT_TO_SERVER = "org.getlantern.CONNECT_TO_SERVER"
         const val ACTION_STOP_VPN = "org.getlantern.START_STOP"
         const val ACTION_TILE_START = "org.getlantern.TILE_START"
+
+        // Hard ceiling on how long Mobile.startVPN / connectToServer can block.
+        // Radiance + sing-box + TUN establish usually finishes in under 15 s;
+        // anything above 60 s means the Go side has deadlocked (see Freshdesk
+        // #173507, where /service/start hung and the UI appeared frozen until
+        // a phone reboot). Without this timeout the coroutine could wait forever.
+        private const val VPN_START_TIMEOUT_MS = 60_000L
+
         lateinit var instance: LanternVpnService
     }
 
@@ -291,22 +301,29 @@ class LanternVpnService :
             // Without this, some Android 10+ devices report only the VPN network,
             // causing sing-box to see no physical interface and blocking all traffic.
             updateUnderlyingNetworks()
-            connect()
+            // Bound connect() so a Go-side deadlock can't leave the UI button
+            // frozen. TimeoutCancellationException falls through to runCatching.
+            withTimeout(VPN_START_TIMEOUT_MS) { connect() }
             VpnStatusManager.postVPNStatus(VPNStatus.Connected)
             notificationHelper.showVPNConnectedNotification(this@LanternVpnService)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 QuickTileService.triggerUpdateTileState(this@LanternVpnService, true)
             }
         }.onFailure { e ->
-            AppLogger.e(TAG, "Error in VPN operation ($errorCode)", e)
+            val timedOut = e is TimeoutCancellationException
+            if (timedOut) {
+                AppLogger.e(TAG, "VPN operation ($errorCode) timed out after ${VPN_START_TIMEOUT_MS}ms — Go side likely deadlocked", e)
+            } else {
+                AppLogger.e(TAG, "Error in VPN operation ($errorCode)", e)
+            }
             // Clear the network change callback to avoid leaking this service
             // instance through the static DefaultNetworkMonitor singleton.
             DefaultNetworkMonitor.setNetworkChangeCallback(null)
             runCatching { runBlocking { DefaultNetworkMonitor.stop() } }
                 .onFailure { stopErr -> AppLogger.e(TAG, "DefaultNetworkMonitor.stop() failed in error path", stopErr) }
             VpnStatusManager.postVPNError(
-                errorCode = errorCode,
-                errorMessage = "Error in VPN operation",
+                errorCode = if (timedOut) "${errorCode}_timeout" else errorCode,
+                errorMessage = if (timedOut) "VPN start timed out" else "Error in VPN operation",
                 error = e,
             )
             if (cleanUpOnFailure) serviceCleanUp()


### PR DESCRIPTION
Safety net for Go-side VPN start deadlocks. Freshdesk #173507's user had to reboot their phone because the UI button stayed frozen for 20+ seconds after Go returned EOF. Wrapping `connect()` in `withTimeout(60_000)` surfaces a clear error + allows retry instead.

## Change

- 60-second ceiling on `Mobile.startVPN()` / `connectToServer()` via `withTimeout`
- `TimeoutCancellationException` routes through existing `runCatching.onFailure` path
- Distinct error code `${errorCode}_timeout` + message so operators can tell it apart from other failures

## Context

The sing-box-minimal [#41](https://github.com/getlantern/sing-box-minimal/pull/41) (in v1.12.22-lantern) already fixes the root cause of #173507's deadlock. This PR is defense-in-depth — if any future regression reintroduces a Go-side hang, users see an error instead of a frozen button.

## Test plan

- [x] Compiles locally
- [ ] Manual: trigger a simulated hang (e.g. sleep in the Go /service/start handler) and verify UI shows error after 60s instead of freezing