### PR TITLE
split tunneling: treat FFI "ok" response as success, not error

### DIFF
--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -488,14 +488,28 @@ class LanternFFIService implements LanternCoreService {
           : _ffiService.removeSplitTunnelItem;
 
       final result = fn(tPtr.cast<Char>(), vPtr.cast<Char>());
-      if (result != nullptr) {
-        final error = result.cast<Utf8>().toDartString();
-        malloc.free(result);
-        appLogger.error('$action split tunnel error: $error');
-        return left(Failure(error: error, localizedErrorMessage: error));
+      if (result == nullptr) {
+        return right(unit);
       }
-
-      return right(unit);
+      final resultStr = result.cast<Utf8>().toDartString();
+      malloc.free(result);
+      // The Go FFI returns "ok" (a non-null C string) on success. Treat that
+      // as a successful call rather than an error message.
+      if (resultStr == 'ok') {
+        return right(unit);
+      }
+      // Errors may arrive as raw strings or as JSON {"error": "..."}.
+      var errMsg = resultStr;
+      try {
+        final decoded = jsonDecode(resultStr);
+        if (decoded is Map && decoded['error'] != null) {
+          errMsg = decoded['error'].toString();
+        }
+      } catch (_) {
+        // Not JSON — fall through with the raw string.
+      }
+      appLogger.error('$action split tunnel error: $errMsg');
+      return left(Failure(error: errMsg, localizedErrorMessage: errMsg));
     } catch (e) {
       return left(
         Failure(

--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -493,9 +493,9 @@ class LanternFFIService implements LanternCoreService {
       }
       final resultStr = result.cast<Utf8>().toDartString();
       malloc.free(result);
-      // The Go FFI returns "ok" (a non-null C string) on success. Treat that
-      // as a successful call rather than an error message.
-      if (resultStr == 'ok') {
+      // The Go FFI returns a non-null C string like "ok" on success; only
+      // treat unexpected payloads as errors.
+      if (_ffiOkResults.contains(resultStr)) {
         return right(unit);
       }
       // Errors may arrive as raw strings or as JSON {"error": "..."}.


### PR DESCRIPTION
## Summary
- `_runSplitTunnelCall` was checking `result != nullptr` and treating any non-null FFI return as an error. But the Go side returns `C.CString("ok")` on success (a non-null C string), so every successful add/remove was reported to the UI as a failure with the message `"ok"`.
- Fix: mirror the `checkAPIError` convention — treat literal `"ok"` as success, parse JSON `{"error": "..."}` bodies for the error message, and fall back to the raw string otherwise.

## User-visible effect
Reported in [getlantern/engineering#3291](https://github.com/getlantern/engineering/issues/3291) against Windows 9.0.29 build 481 (Freshdesk [#173656](https://lantern.freshdesk.com/a/tickets/173656)):

- Adding a website in split tunneling showed an unstyled default snackbar reading **"OK"** (Material's default `SnackBar` rendering `failure.localizedErrorMessage`).
- The website appeared to not be saved — but it actually was. The provider's `reloaded` flag was never set, so the on-screen list never re-fetched.
- Re-clicking "Add" with the same domain created a duplicate entry on disk (visible as repeated items in the user's `split-tunnel.json`) because the provider's local "already-added" check worked against a stale copy.

One root-cause fix addresses all three symptoms.

## Test plan
- [ ] Add a website in split tunneling → no snackbar, website appears in "websites bypassing the VPN" list immediately
- [ ] Add the same website again → handled gracefully (provider short-circuits, no duplicate on disk)
- [ ] Remove a website → list refreshes, no spurious snackbar
- [ ] Trigger a real error (e.g. malformed input that makes it past validation) → error message surfaces correctly (no longer hidden behind "OK")

🤖 Generated with [Claude Code](https://claude.com/claude-code)