### PR TITLE
split tunneling: use design-system error snackbar on add

### DIFF
--- a/lib/features/split_tunneling/website_domain_input.dart
+++ b/lib/features/split_tunneling/website_domain_input.dart
@@ -18,9 +18,10 @@ class WebsiteDomainInput extends HookConsumerWidget {
         ref.watch(splitTunnelingWebsitesProvider).value ?? const <Website>{};
 
     void showSnackbar(String message) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(message)));
+      // All call sites below surface validation or backend errors; use the
+      // design-system error snackbar rather than Material's default unstyled
+      // SnackBar.
+      context.showSnackBarError(message);
     }
 
     // validate URL and extract the domain before adding it to the


### PR DESCRIPTION
## Summary
Follow-up to #8691. The local `showSnackbar` helper in `website_domain_input.dart` was using Material's default `ScaffoldMessenger.showSnackBar(SnackBar(content: Text(message)))`, producing the unstyled grey/dark snackbar Derek flagged in [getlantern/engineering#3291](https://github.com/getlantern/engineering/issues/3291). Every call site in this file is an error path (empty input, invalid domain, already-added, backend failure), so route them through `context.showSnackBarError` — the rounded, floating, red-background error snackbar from `lib/core/extensions/context.dart`.

## Why a separate PR
#8691 fixed the functional bug (the snackbar was firing with `"ok"` on success). But any legitimate error (e.g. `"Invalid domain"`) still renders in Flutter's default snackbar style. This PR closes that gap.

## Test plan
- [ ] Leave the input empty and click "Add" → floating red error snackbar with "Please enter a URL or domain."
- [ ] Enter an invalid domain like `not a url` → floating red error snackbar with "Invalid domain"
- [ ] Enter a domain already in the list → floating red error snackbar with "$domain already added"
- [ ] Successful add → no snackbar (behavior unchanged from #8691)

🤖 Generated with [Claude Code](https://claude.com/claude-code)