### PR TITLE
deps: bump radiance to refactor tip (e20a238)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260423110003-2c7b22f8839f
+	github.com/getlantern/radiance v0.0.0-20260423150254-e20a238c08fa
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260423110003-2c7b22f8839f h1:XGtwpbalocAAAjn6CekCld7wo+b6UQN6WEac5Sk+G5s=
-github.com/getlantern/radiance v0.0.0-20260423110003-2c7b22f8839f/go.mod h1:VbFkioh4iA56VZY2095NDAnBRXkQ0Fgn5/tMTPGFUjc=
+github.com/getlantern/radiance v0.0.0-20260423150254-e20a238c08fa h1:KS9Rp+/xNse+E4Nx175hRlx48G4Hsc2geDUvRdZhmJ0=
+github.com/getlantern/radiance v0.0.0-20260423150254-e20a238c08fa/go.mod h1:VbFkioh4iA56VZY2095NDAnBRXkQ0Fgn5/tMTPGFUjc=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Bump `github.com/getlantern/radiance` from `2c7b22f` to `e20a238c` on the `refactor` branch. `go mod tidy` run before commit per the repo's Go-bump convention.

## What's in the delta

Between the currently pinned commit and the new tip, the only two commits are:
- `42d491c` — merge of [radiance#439](https://github.com/getlantern/radiance/pull/439) (ConnectVPN-while-connected server-swap)
- `e20a238` — revert of the above (the tip)

Net effect on radiance code: no-op. @garmr-ulfr reverted #439 with the correct observation that the fix belongs on the Lantern side — the Flutter UI should call `SelectServer` rather than `ConnectVPN` when switching servers while the tunnel is up (and Smart Routing toggles should go through the restart path, which they already do in `radianceSettingsProvider`). Follow-up Flutter PR coming for the server-selection flow in [getlantern/engineering#3291](https://github.com/getlantern/engineering/issues/3291).

## Test plan
- [x] \`go build ./lantern-core/...\` succeeds locally
- [ ] CI passes on this branch