### PR TITLE
lantern-core: dispatch ConnectVPN to SelectServer when tunnel is up

### DIFF
--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -279,7 +279,26 @@ func (lc *LanternCore) listenDataCapEvents() {
 //     VPN     //
 /////////////////
 
+// ConnectVPN asks radiance to bring the tunnel up or switch its active
+// outbound. When the Flutter UI picks a server (or "auto") while already
+// connected, it routes through this call expecting a seamless swap — but
+// radiance's /vpn/connect endpoint rejects a duplicate start with
+// ErrTunnelAlreadyConnected. When the tunnel is up, dispatch to
+// /server/selected instead (empty tag → AutoSelectTag) so the outbound
+// switches in place without tearing down the tunnel.
+//
+// getlantern/engineering#3291 issues 1 & 2. radiance#439 attempted the
+// same dispatch inside radiance and was correctly reverted — radiance's
+// ConnectVPN / SelectServer are distinct primitives and the caller
+// (Lantern) is the right place to pick between them.
 func (lc *LanternCore) ConnectVPN(tag string) error {
+	if status, err := lc.client.VPNStatus(lc.ctx); err == nil && status == vpn.Connected {
+		selectTag := tag
+		if selectTag == "" {
+			selectTag = vpn.AutoSelectTag
+		}
+		return lc.client.SelectServer(lc.ctx, selectTag)
+	}
 	return lc.client.ConnectVPN(lc.ctx, tag)
 }
 


### PR DESCRIPTION
## Summary

When the Flutter UI picks a new server (or Smart Routing → auto) while the tunnel is already up, it routes through `connectToServer` / `ConnectVPN` expecting a seamless outbound swap. Radiance's `/vpn/connect` endpoint rejects that as `ErrTunnelAlreadyConnected`, which the user sees as:

> `start service failed: ipc: status 500: failed to connect VPN: tunnel already connected`

This was Derek's issues 1 & 2 in [getlantern/engineering#3291](https://github.com/getlantern/engineering/issues/3291) (Freshdesk [#173656](https://lantern.freshdesk.com/a/tickets/173656)).

## Why on the Lantern side

[radiance#439](https://github.com/getlantern/radiance/pull/439) tried the same dispatch inside radiance's `ConnectVPN` and was [correctly reverted by @garmr-ulfr](https://github.com/getlantern/radiance/pull/439#issuecomment-4305479315):

> "As for selecting a new server, this is actually a bug in lantern. Lantern should be calling `SelectServer`, not `ConnectVPN` to switch while connected."

Radiance's `ConnectVPN` and `SelectServer` are distinct primitives by design. The caller (Lantern) is the right place to pick between them. This PR moves the dispatch to `LanternCore.ConnectVPN` — still on the Lantern side — so:

- The Flutter API surface is unchanged
- Works for every platform (FFI and mobile) with a single change
- No FFI regeneration (`dart run ffigen`) required
- No `SelectServer` exposure through the C FFI / mobile wrappers needed

An alternative is to expose `SelectServer` all the way up to Flutter and have `server_selection.dart` call the right primitive based on status. That's a bigger change and can follow if the team prefers explicit dispatch at the UI layer.

## Change

`lantern-core/core.go` `LanternCore.ConnectVPN`: when `VPNStatus() == Connected`, POST `/server/selected` with the tag (empty tag maps to `vpn.AutoSelectTag`, matching radiance's existing `ConnectVPN` behavior). Otherwise fall through to `/vpn/connect`.

## Test plan
- [ ] Start disconnected → click any server / Smart Routing → tunnel establishes (existing path)
- [ ] Start connected to auto → pick a specific server → outbound swaps in place, no error, UI returns to main
- [ ] Start connected to a specific server → click Smart Routing → tunnel stays up in auto mode, UI returns to main
- [ ] Start connected to a specific server → pick a different specific server → outbound swaps, UI returns to main
- [ ] `go build ./lantern-core/...` ✅ (local)

🤖 Generated with [Claude Code](https://claude.com/claude-code)