### PR TITLE
android: detach connect() scope + single-flight gate (port of #8689)

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -4,13 +4,13 @@ import android.content.Intent
 import android.net.VpnService
 import android.os.Build
 import android.os.ParcelFileDescriptor
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -59,6 +59,15 @@ class LanternVpnService :
         // #173507, where /service/start hung and the UI appeared frozen until
         // a phone reboot). Without this timeout the coroutine could wait forever.
         private const val VPN_START_TIMEOUT_MS = 60_000L
+
+        // Single-flight gate: when we time out the connect() call, we detach
+        // the coroutine rather than waiting for the JNI call to honor
+        // cancellation (it doesn't). The orphan keeps a Dispatchers.IO thread
+        // pinned until Go eventually returns. To prevent multiple rapid
+        // retries from accumulating orphans and pressuring the IO pool, reject
+        // new connect attempts while a previous one is still in flight. The
+        // flag clears when the orphan's coroutine actually completes.
+        private val connectInFlight = AtomicBoolean(false)
 
         lateinit var instance: LanternVpnService
     }
@@ -306,21 +315,44 @@ class LanternVpnService :
             // Bound the Mobile.startVPN / connectToServer call with a wall-clock
             // timeout. These are blocking JNI calls with no suspension points,
             // so withTimeout around a direct invocation wouldn't fire — we run
-            // the call in a child coroutine on Dispatchers.IO and await it,
-            // which gives withTimeout a real cancellation point. On timeout we
-            // abandon the awaited Deferred (the underlying JNI call keeps
-            // running in the background; we accept that leak — once Go
-            // eventually completes or the process exits, it will settle) so
-            // the UI gets unstuck with a clear error instead of a frozen
-            // button that only a phone reboot can clear (Freshdesk #173507).
-            coroutineScope {
-                val deferred = async(Dispatchers.IO) { connect() }
+            // the call in async() and await it so withTimeout has a real
+            // cancellation point.
+            //
+            // Run it in a DETACHED CoroutineScope (not a structured
+            // coroutineScope { } / the enclosing withContext), because on
+            // timeout structured concurrency would cancel the deferred and
+            // then wait for it to complete — and since the JNI call doesn't
+            // honor cooperative cancellation, that wait is exactly the hang
+            // we're trying to prevent. A detached SupervisorJob scope lets
+            // us stop awaiting without joining; the orphan coroutine keeps
+            // running until Go returns (or the process exits), but the
+            // caller is unblocked and the UI surfaces a clear error instead
+            // of a frozen button only a phone reboot can clear
+            // (Freshdesk #173507).
+            //
+            // Reject concurrent attempts with connectInFlight so repeated
+            // retries while a previous call is stuck in JNI don't accumulate
+            // orphan coroutines on Dispatchers.IO. The flag clears in the
+            // async block's finally, which runs when the JNI call eventually
+            // returns (coroutine cancellation alone won't break it out).
+            if (!connectInFlight.compareAndSet(false, true)) {
+                throw IllegalStateException("previous VPN connect attempt still in flight")
+            }
+            val connectScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+            val deferred = connectScope.async {
                 try {
-                    withTimeout(VPN_START_TIMEOUT_MS) { deferred.await() }
-                } catch (e: TimeoutCancellationException) {
-                    deferred.cancel()
-                    throw e
+                    connect()
+                } finally {
+                    connectInFlight.set(false)
                 }
+            }
+            try {
+                withTimeout(VPN_START_TIMEOUT_MS) { deferred.await() }
+            } catch (e: TimeoutCancellationException) {
+                deferred.cancel()
+                throw e
+            } finally {
+                connectScope.cancel()
             }
             VpnStatusManager.postVPNStatus(VPNStatus.Connected)
             notificationHelper.showVPNConnectedNotification(this@LanternVpnService)

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -332,19 +332,16 @@ class LanternVpnService :
             //
             // Reject concurrent attempts with connectInFlight so repeated
             // retries while a previous call is stuck in JNI don't accumulate
-            // orphan coroutines on Dispatchers.IO. The flag clears in the
-            // async block's finally, which runs when the JNI call eventually
-            // returns (coroutine cancellation alone won't break it out).
+            // orphan coroutines on Dispatchers.IO. Clear the flag from the
+            // Deferred completion path so early cancellation before the async
+            // body starts can't wedge future attempts.
             if (!connectInFlight.compareAndSet(false, true)) {
                 throw IllegalStateException("previous VPN connect attempt still in flight")
             }
             val connectScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-            val deferred = connectScope.async {
-                try {
-                    connect()
-                } finally {
-                    connectInFlight.set(false)
-                }
+            val deferred = connectScope.async { connect() }
+            deferred.invokeOnCompletion {
+                connectInFlight.set(false)
             }
             try {
                 withTimeout(VPN_START_TIMEOUT_MS) { deferred.await() }


### PR DESCRIPTION
## Summary

Port of [#8689](https://github.com/getlantern/lantern/pull/8689) from `garmr/radiance-daemon-refactor` to `main`.

[#8688](https://github.com/getlantern/lantern/pull/8688) shipped `withTimeout` wrapping, but wrapped the connect() `async` in a structured `coroutineScope { }`. Structured scopes cancel their children on timeout **and then wait for them to finish**. Since `Mobile.startVPN` / `connectToServer` is a blocking JNI call with no suspension points, cooperative cancellation never triggers — the outer `coroutineScope` blocks on the orphan and the UI hangs anyway, defeating the timeout (which is what Freshdesk #173507 reported originally).

## Change

1. **Detached `CoroutineScope(SupervisorJob() + Dispatchers.IO)`** around the connect async. Its Job is not a child of the enclosing coroutine, so cancelling it signals but doesn't join. The orphan keeps running the JNI call in the background until Go returns (or the process exits), but the caller is unblocked and the UI surfaces `${errorCode}_timeout` through the existing `runCatching.onFailure` path.

2. **`AtomicBoolean` single-flight gate** to prevent orphan accumulation across retries. `compareAndSet` rejects concurrent attempts with `IllegalStateException` while a previous one is still in flight; the flag clears in the async block's `try/finally` when the JNI call actually returns. So once Go unsticks, a future retry is admitted. (Copilot's original suggestion was `Dispatchers.IO.limitedParallelism(1)` but that would queue retries behind the stuck orphan — turning the retry into another 60s hang. Fast rejection is the cleaner trade-off.)

## History on the refactor branch
- [#8689](https://github.com/getlantern/lantern/pull/8689) landed the detach in one commit and the single-flight gate in a review-driven follow-up. This PR squashes them into one commit for main.

## Test plan
- [ ] Normal VPN start — timeout never fires, connect completes, status → Connected
- [ ] Simulated deadlock (e.g. `time.Sleep(90s)` in Go `/service/start`) — UI unfreezes after 60s with `*_timeout` error
- [ ] Retry while orphan still running — fails fast with `IllegalStateException("previous VPN connect attempt still in flight")`, not a second 60s hang
- [ ] Orphan eventually completes → future retry succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)