### PR TITLE
android: make restartService block until restart completes

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -223,10 +223,25 @@ class LanternVpnService :
 
     override fun restartService() {
         AppLogger.i(TAG, "restartService called")
-        serviceScope.launch {
+        // Radiance's Restart() sets the tunnel status to Restarting, then
+        // calls us synchronously and treats a successful return as "restart
+        // complete." If we fire-and-forget via serviceScope.launch and return,
+        // radiance thinks it succeeded but the tunnel is still in Restarting —
+        // and if the Android service is torn down (onDestroy, process
+        // pressure) before the launched coroutine completes, the tunnel
+        // wedges in Restarting forever. Every subsequent Connect fails with
+        // "tunnel is currently Restarting" (getlantern/engineering#3297
+        // issues 1-3, Freshdesk #173681).
+        //
+        // Block until stopVPNTunnel + startVPN finish so the return actually
+        // reflects the state radiance observes. c.mu is released on the Go
+        // side before RestartService is invoked, so synchronous callbacks
+        // into Mobile.* from this thread don't deadlock.
+        runBlocking(Dispatchers.IO) {
             stopVPNTunnel()
             startVPN()
         }
+        AppLogger.i(TAG, "restartService completed")
     }
 
     override fun sendNotification(notification: Notification?) {
@@ -397,9 +412,16 @@ class LanternVpnService :
     private suspend fun stopVPNTunnel() {
         try {
             closeTunInterface()
+            // Unconditionally call Mobile.stopVPN() as long as radiance is up.
+            // The old isVPNConnected() guard looked at status == Connected,
+            // which is wrong during a restart: radiance sets the tunnel to
+            // Restarting before calling back into the platform, so the check
+            // would skip stopVPN and leave the tunnel wedged in Restarting
+            // (getlantern/engineering#3297). Mobile.stopVPN() itself is a
+            // no-op when c.tunnel is nil, so the guard is unnecessary.
             runCatching {
-                if (!Mobile.isVPNConnected()) {
-                    AppLogger.d(TAG, "VPN is not connected, skipping stopVPN")
+                if (!Mobile.isRadianceConnected()) {
+                    AppLogger.d(TAG, "Radiance IPC not running, skipping stopVPN")
                     return@runCatching
                 }
                 Mobile.stopVPN()

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -168,13 +168,17 @@ class LanternVpnService :
             closeTunInterface()
             // Clean up synchronously — cannot use serviceScope here because
             // it is cancelled in the finally block below.
+            //
+            // Call Mobile.stopVPN() as long as radiance is up. The previous
+            // isVPNConnected() guard (status == Connected) was wrong — if the
+            // tunnel is in any non-Connected state (Restarting, Connecting,
+            // Disconnecting, Error), c.tunnel is still non-nil on the Go side
+            // and needs to be closed so the next process lifetime starts clean.
+            // Mobile.stopVPN() itself is a no-op when c.tunnel is nil.
             val radianceConnected = Mobile.isRadianceConnected()
-            val vpnConnected = Mobile.isVPNConnected()
-            AppLogger.d(TAG, "onDestroy — radianceConnected=$radianceConnected vpnConnected=$vpnConnected")
+            AppLogger.d(TAG, "onDestroy — radianceConnected=$radianceConnected")
             if (!radianceConnected) {
                 AppLogger.d(TAG, "Skipping stopVPN — Radiance IPC not running")
-            } else if (!vpnConnected) {
-                AppLogger.d(TAG, "Skipping stopVPN — VPN tunnel was never started")
             } else {
                 runCatching { Mobile.stopVPN() }
                     .onSuccess { AppLogger.d(TAG, "stopVPN completed during destroy") }

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -244,6 +244,20 @@ class LanternVpnService :
         runBlocking(Dispatchers.IO) {
             stopVPNTunnel()
             startVPN()
+            // launchVPN (wrapping startVPN) catches failures via
+            // runCatching { ... }.onFailure { ... } and returns normally,
+            // so a nil return from startVPN doesn't mean the restart
+            // succeeded. Verify the postcondition on the Go side and
+            // throw if it's not met — the exception propagates through
+            // runBlocking → restartService → radiance's Restart() as a
+            // non-nil error, which is what tells the caller the restart
+            // actually failed and the tunnel needs healing rather than
+            // wedging forever in Restarting.
+            if (!Mobile.isVPNConnected()) {
+                val msg = "restartService failed: VPN not connected after stopVPNTunnel + startVPN"
+                AppLogger.e(TAG, msg)
+                throw IllegalStateException(msg)
+            }
         }
         AppLogger.i(TAG, "restartService completed")
     }


### PR DESCRIPTION
## Summary

Kotlin-side bug that wedges the tunnel in `Restarting` on Android — every subsequent Connect fails with `Error in VPN operation` ([getlantern/engineering#3297](https://github.com/getlantern/engineering/issues/3297), Freshdesk #173681). The **proximate cause** is one misplaced status check in `stopVPNTunnel()`; the other two changes fix adjacent correctness issues that have the same shape and would make the state machine fragile in related scenarios.

## The actual root cause (bug #1)

```mermaid
sequenceDiagram
    autonumber
    participant UI as Flutter UI
    participant R as radiance<br/>vpn.go
    participant K as Kotlin<br/>LanternVpnService.kt
    participant V as vpnClient<br/>vpn.go

    UI->>R: SetSmartRoutingEnabled(false)
    R->>R: maybeRestartVPN → Restart()
    Note over R: vpn.go:193<br/>t.setStatus(Restarting, nil) ⚠️<br/>BEFORE platform callback
    R->>K: vpn.go:196<br/>platformIfce.RestartService()

    rect rgba(255, 200, 200, 0.3)
        K->>K: LanternVpnService.kt:397<br/>stopVPNTunnel()
        K->>V: LanternVpnService.kt:401<br/>Mobile.isVPNConnected()?
        Note over V: status == Connected?<br/>status is Restarting → false
        V-->>K: false
        Note over K: LanternVpnService.kt:402<br/>"VPN is not connected,<br/>skipping stopVPN" 🐛
        Note over K: Mobile.stopVPN() NEVER RUNS<br/>c.tunnel stays non-nil<br/>status stays Restarting
    end

    K->>K: LanternVpnService.kt:265<br/>startVPN()
    K->>V: mobile.go:214<br/>Mobile.startVPN() → vpn_tunnel.StartVPN()
    V->>V: vpn_tunnel.go:21<br/>client.ConnectVPN("auto")
    V->>V: vpn.go:99<br/>vpnClient.Connect()
    Note over V: vpn.go:120<br/>c.tunnel != nil<br/>c.tunnel.Status() == Restarting
    V-->>K: error: "tunnel is currently Restarting"
    K->>UI: "Error in VPN operation (start_vpn)"
```

`stopVPNTunnel()` skipped the real stop when `!Mobile.isVPNConnected()`:

```kotlin
if (!Mobile.isVPNConnected()) {
    AppLogger.d(TAG, "VPN is not connected, skipping stopVPN")
    return@runCatching
}
Mobile.stopVPN()
```

`Mobile.isVPNConnected()` is `status == Connected`. By the time `restartService` runs, radiance has **already** set the status to `Restarting` before calling back into the platform:

```go
// vpn/vpn.go
t := c.tunnel
t.setStatus(Restarting, nil)
if c.platformIfce != nil {
    c.mu.Unlock()
    if err := c.platformIfce.RestartService(); err != nil { ... }
}
```

So this guard **always** fires true on the restart path → `Mobile.stopVPN()` is skipped → `c.tunnel` on the Go side is never closed → the tunnel stays at `Restarting`. Then `startVPN()` runs, calls `ConnectVPN("auto")` → `vpnClient.Connect()` → the `c.tunnel != nil && status == Restarting` branch returns `"tunnel is currently Restarting"`, surfaced to the UI as `Error in VPN operation (start_vpn)` within a few ms.

### Timeline from Freshdesk #173681

| Time | Event |
|------|---|
| 15:17:34.826 | radiance logs `Restarting tunnel`, sets `status=Restarting`, calls platformIfce |
| 15:17:34.828 | Kotlin `restartService called` |
| **15:17:34.831** | **`VPN is not connected, skipping stopVPN` ← the actual bug** |
| 15:17:34.834 | `startVPN()` proceeds anyway, shows notification |
| 15:17:34.839 | POST `/vpn/connect` |
| 15:17:34.841 | `Error in VPN operation (start_vpn)` — 2ms after the IPC request, consistent with radiance's in-process fast-fail |

### Fix

Swap the guard for `!Mobile.isRadianceConnected()` (skip only when the IPC server isn't even up). `Mobile.stopVPN()` is a no-op when `c.tunnel` is nil on the Go side, so the original guard was redundant even in the happy case — it just happened to also hide the non-Connected-but-non-nil case that's load-bearing during restart.

## Adjacent issues fixed in the same PR

### Bug #2: `restartService()` was fire-and-forget

```kotlin
override fun restartService() {                // :224
    AppLogger.i(TAG, "restartService called")
    serviceScope.launch {                       // :226 — returns immediately
        stopVPNTunnel()
        startVPN()
    }
}
```

Radiance's `Restart()` calls `platformIfce.RestartService()` **synchronously** and treats the nil return as "restart complete." `serviceScope.launch { ... }` schedules the coroutine and returns, so radiance sees success 2ms after asking for a restart — before any real work.

This doesn't cause Derek's specific failure (the coroutine did run to completion; it just no-op'd due to bug #1). But it makes the state machine fragile: if the service is torn down mid-coroutine (onDestroy, process pressure), the stop+start never completes and the tunnel is wedged even though radiance thinks the restart succeeded.

Fix: wrap the work in `runBlocking(Dispatchers.IO)` so the return actually reflects completion. Radiance's `c.mu` is released before `RestartService` is invoked, so synchronous `Mobile.*` callbacks from this thread don't deadlock.

### Bug #3: `onDestroy()` had the same `!vpnConnected` skip

Same pattern: if the tunnel is in any non-Connected state (Restarting after a failed restart, Connecting, Error), `onDestroy` logged `Skipping stopVPN — VPN tunnel was never started` and left the radiance tunnel dangling across service destroy. Derek's log shows this firing at `15:19:10` while the tunnel was actually alive at `Restarting`.

Fix: drop the `!vpnConnected` branch. Keep the `!radianceConnected` check; always call `Mobile.stopVPN()` otherwise.

## Related
- [getlantern/radiance#441](https://github.com/getlantern/radiance/pull/441) — radiance-side defense-in-depth heal. Less needed now that bug #1 is fixed here, but still covers the case where the platform coroutine is genuinely interrupted.
- [getlantern/engineering#3297](https://github.com/getlantern/engineering/issues/3297) issues 1–3

## Test plan
- [ ] Connect on Android, toggle Smart Routing → new tunnel establishes, no "Error in VPN operation"
- [ ] Connect, toggle routing mode → same
- [ ] If a restart is mid-flight and the service is killed, the next Connect succeeds (state not wedged across process lifecycle)
- [ ] Compiles in the Android build

🤖 Generated with [Claude Code](https://claude.com/claude-code)
