### PR TITLE
android: harden detached connect timeout gate (refactor branch port of #8696)

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -367,19 +367,16 @@ class LanternVpnService :
             //
             // Reject concurrent attempts with connectInFlight so repeated
             // retries while a previous call is stuck in JNI don't accumulate
-            // orphan coroutines on Dispatchers.IO. The flag clears in the
-            // async block's finally, which runs when the JNI call eventually
-            // returns (coroutine cancellation alone won't break it out).
+            // orphan coroutines on Dispatchers.IO. Clear the flag from the
+            // Deferred completion path so early cancellation before the async
+            // body starts can't wedge future attempts.
             if (!connectInFlight.compareAndSet(false, true)) {
                 throw IllegalStateException("previous VPN connect attempt still in flight")
             }
             val connectScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
-            val deferred = connectScope.async {
-                try {
-                    connect()
-                } finally {
-                    connectInFlight.set(false)
-                }
+            val deferred = connectScope.async { connect() }
+            deferred.invokeOnCompletion {
+                connectInFlight.set(false)
             }
             try {
                 withTimeout(VPN_START_TIMEOUT_MS) { deferred.await() }


### PR DESCRIPTION
Cherry-pick of #8696 (`8998d94ac`) onto the refactor branch.

The refactor branch already includes #8689 (`0540dc9ab`), which introduced the `connectInFlight` single-flight gate with the `try { connect() } finally { connectInFlight.set(false) }` pattern. That pattern leaves the gate permanently wedged if the coroutine body never starts (pre-dispatch cancellation) — after which every future connect attempt is rejected with `IllegalStateException` until the process is killed.

#8696 moves the reset to `deferred.invokeOnCompletion { ... }`, which fires on every terminal `Deferred` state, including immediate cancellation. Happy path and JNI-still-running timeout path are unchanged.

Clean cherry-pick, no conflicts. Diff is identical to what landed on main.

## Test plan

- [ ] Android build passes on refactor
- [ ] Covered by same manual reproduction as #8696 (connect / timeout / retry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)