### PR TITLE
main: don't block first paint on Updater.init()

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,8 +47,12 @@ Future<void> main() async {
   }
 
   // Auto-updater is desktop-only (no-op on mobile) and already guarded
-  // internally by kDebugMode and platform checks.
-  await sl<Updater>().init();
+  // internally by kDebugMode and platform checks. Do not await: Sparkle's
+  // setFeedURL / setScheduledCheckInterval are synchronous bridge calls that
+  // can block first paint when the feed URL is slow to resolve or the
+  // framework is touching keychain state. The first actual update check is
+  // already deferred 45 s inside init().
+  unawaited(sl<Updater>().init());
 
   runApp(
     ProviderScope(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -52,7 +52,19 @@ Future<void> main() async {
   // can block first paint when the feed URL is slow to resolve or the
   // framework is touching keychain state. The first actual update check is
   // already deferred 45 s inside init().
-  unawaited(sl<Updater>().init());
+  //
+  // Guard the sl<Updater>() lookup: if injectServices() threw above, Updater
+  // (registered at injection_container.dart:40) may not be in the registry,
+  // and the synchronous lookup would throw and prevent runApp.
+  try {
+    if (sl.isRegistered<Updater>()) {
+      unawaited(sl<Updater>().init());
+    } else {
+      appLogger.warning('Updater not registered, skipping init');
+    }
+  } catch (e, st) {
+    appLogger.error('Failed to start Updater.init', e, st);
+  }
 
   runApp(
     ProviderScope(


### PR DESCRIPTION
## Summary

- Move `sl<Updater>().init()` off the `await` critical path to `runApp`, by wrapping it in `unawaited(...)`.
- First paint should not depend on Sparkle being reachable.
- Inside `Updater.init()`, the actual update check is already deferred 45 s via `Future.delayed` + `unawaited` — but `setFeedURL` and `setScheduledCheckInterval` were awaited, and those bridge into Sparkle natively and can stall on first launch.

## Context

Investigating a one-shot black-screen-on-startup I hit locally today on a refactor-branch macOS dev build (9.0.29 build 487). `flutter.log` stopped at the last pre-`runApp` log line. No Dart exception, no crash report, and the Go side kept logging normally for another 6 seconds — so the process was alive and Dart wasn't throwing, it was blocked in a native bridge call.

The only awaited call between the last Flutter log and `runApp` is `Updater.init()`. That maps into Sparkle via the `auto_updater` plugin. Sparkle is well-known to stall on first use (feed URL resolution, keychain access, a previous-launch background worker still holding a lock) — any of which produces exactly the observed symptom: main isolate stuck, no exception, no crash.

## Test plan

- [x] Manual smoke on macOS: cold launch renders UI immediately.
- [ ] Verify auto-update still fires after ~45 s in a release build.
- [ ] No regression on Windows (other supported updater platform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)