### PR TITLE
deps: bump radiance to refactor tip

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260423150254-e20a238c08fa
+	github.com/getlantern/radiance v0.0.0-20260423230548-9703bcf723c1
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260423150254-e20a238c08fa h1:KS9Rp+/xNse+E4Nx175hRlx48G4Hsc2geDUvRdZhmJ0=
-github.com/getlantern/radiance v0.0.0-20260423150254-e20a238c08fa/go.mod h1:VbFkioh4iA56VZY2095NDAnBRXkQ0Fgn5/tMTPGFUjc=
+github.com/getlantern/radiance v0.0.0-20260423230548-9703bcf723c1 h1:F2pGsKVyIqVdccudFiVE4uY3eOY/Y6aZmeTrZy++WG8=
+github.com/getlantern/radiance v0.0.0-20260423230548-9703bcf723c1/go.mod h1:VbFkioh4iA56VZY2095NDAnBRXkQ0Fgn5/tMTPGFUjc=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Bumps `github.com/getlantern/radiance` from `e20a238` (the revert commit) to `9703bcf` (tip of refactor).

## Picks up

- [1ee1163](https://github.com/getlantern/radiance/commit/1ee1163) refactor(vpn): own VPN status on the client so restarts span tunnels — moves `setStatus` calls out of the tunnel and onto `VPNClient` so a restart transitions Restarting → Disconnecting → Disconnected → Connecting → Connected cleanly instead of the old mid-restart state sniff
- getlantern/radiance#443 — instrumentation on `tunnel.start` / `init` / `connect` with child spans around `libbox.Setup`, `libbox.NewServiceWithContext`, `libbox.BoxService.Start`, `newMutableGroupManager`, plus a wrapping span on `VPNClient.Restart`. Addresses getlantern/engineering#3299 (10s+ tail on `/service/start` observed in Freshdesk #173696)

## Test plan

- [x] `go build ./...` on darwin/arm64
- [x] `go mod tidy` — no extra churn

🤖 Generated with [Claude Code](https://claude.com/claude-code)