### PR TITLE
lantern-core: dispatch ConnectVPN/StartVPN to SelectServer on live tunnel

### DIFF
--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -280,12 +280,41 @@ func (lc *LanternCore) listenDataCapEvents() {
 //     VPN     //
 /////////////////
 
+// ConnectVPN routes a connect request to radiance, translating it into a
+// server-swap on a live tunnel. When the tunnel is already up, radiance's
+// /vpn/connect endpoint rejects the request with ErrTunnelAlreadyConnected —
+// so dispatch to /server/selected instead, matching the dispatch ffi.go's
+// connectToServer does but applying it to every caller of LanternCore.
+// ConnectVPN. This is load-bearing for the Smart-from-connected flow: Jigar's
+// onSmartLocation rewrite (server_selection.dart) routes "switch back to auto"
+// through startVPN(force: true), which lands in ffi.go:startVPN →
+// c.ConnectVPN(""). Without this dispatch the call 500s with "tunnel already
+// connected" and the user sees a snackbar instead of the smart mode returning.
+//
+// The Flutter UI sends an empty tag to mean "auto" (see ServerLocationType.
+// auto). Radiance recognizes only the literal vpn.AutoSelectTag ("auto") — an
+// empty tag falls into the manual-outbound branch in radiance/vpn/vpn.go
+// SelectServer and strands Clash in manual mode with an empty selector.
+// Normalize so the Dart→FFI "" convention keeps working on both dispatch sides.
+//
+// Fixes getlantern/engineering#3291 issue 3.
 func (lc *LanternCore) ConnectVPN(tag string) error {
+	tag = normalizeAutoTag(tag)
+	if status, err := lc.client.VPNStatus(lc.ctx); err == nil && status == vpn.Connected {
+		return lc.client.SelectServer(lc.ctx, tag)
+	}
 	return lc.client.ConnectVPN(lc.ctx, tag)
 }
 
 func (lc *LanternCore) SelectServer(tag string) error {
-	return lc.client.SelectServer(lc.ctx, tag)
+	return lc.client.SelectServer(lc.ctx, normalizeAutoTag(tag))
+}
+
+func normalizeAutoTag(tag string) string {
+	if tag == "" {
+		return vpn.AutoSelectTag
+	}
+	return tag
 }
 
 func (lc *LanternCore) DisconnectVPN() error {

--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -22,6 +22,7 @@ import (
 	"github.com/getlantern/lantern/lantern-core/apps"
 	privateserver "github.com/getlantern/lantern/lantern-core/private-server"
 	"github.com/getlantern/lantern/lantern-core/utils"
+	"github.com/getlantern/lantern/lantern-core/vpn_tunnel"
 )
 
 type EventType = string
@@ -280,32 +281,27 @@ func (lc *LanternCore) listenDataCapEvents() {
 //     VPN     //
 /////////////////
 
-// ConnectVPN routes a connect request to radiance, translating it into a
-// server-swap on a live tunnel. When the tunnel is already up, radiance's
-// /vpn/connect endpoint rejects the request with ErrTunnelAlreadyConnected —
-// so dispatch to /server/selected instead, matching the dispatch ffi.go's
-// connectToServer does but applying it to every caller of LanternCore.
-// ConnectVPN. This is load-bearing for the Smart-from-connected flow: Jigar's
-// onSmartLocation rewrite (server_selection.dart) routes "switch back to auto"
-// through startVPN(force: true), which lands in ffi.go:startVPN →
-// c.ConnectVPN(""). Without this dispatch the call 500s with "tunnel already
-// connected" and the user sees a snackbar instead of the smart mode returning.
-//
-// The Flutter UI sends an empty tag to mean "auto" (see ServerLocationType.
-// auto). Radiance recognizes only the literal vpn.AutoSelectTag ("auto") — an
-// empty tag falls into the manual-outbound branch in radiance/vpn/vpn.go
-// SelectServer and strands Clash in manual mode with an empty selector.
-// Normalize so the Dart→FFI "" convention keeps working on both dispatch sides.
+// ConnectVPN routes a connect request through vpn_tunnel.ConnectToServer,
+// which picks between /vpn/connect (fresh tunnel) and /server/selected
+// (live-tunnel outbound swap) based on VPNStatus. This is load-bearing for
+// the Smart-from-connected flow: Jigar's onSmartLocation rewrite
+// (server_selection.dart) routes "switch back to auto" through
+// startVPN(force: true) → ffi.go:startVPN → c.ConnectVPN(""). Without the
+// dispatch the call 500s with ErrTunnelAlreadyConnected from
+// radiance/vpn/vpn.go:130 and the user sees a snackbar.
 //
 // Fixes getlantern/engineering#3291 issue 3.
 func (lc *LanternCore) ConnectVPN(tag string) error {
-	tag = normalizeAutoTag(tag)
-	if status, err := lc.client.VPNStatus(lc.ctx); err == nil && status == vpn.Connected {
-		return lc.client.SelectServer(lc.ctx, tag)
-	}
-	return lc.client.ConnectVPN(lc.ctx, tag)
+	return vpn_tunnel.ConnectToServer(lc.client, tag)
 }
 
+// SelectServer sends a server-selection request. Radiance's VPNClient.
+// SelectServer treats the literal vpn.AutoSelectTag ("auto") as the
+// auto-select signal; an empty tag falls into the manual-outbound branch
+// and strands Clash in manual mode with an empty selector. Normalize so
+// the Dart→FFI "" convention survives callers that reach SelectServer
+// directly (radiance fac9089 fixes this server-side too, but we still
+// pin a pre-fac9089 radiance here).
 func (lc *LanternCore) SelectServer(tag string) error {
 	return lc.client.SelectServer(lc.ctx, normalizeAutoTag(tag))
 }

--- a/lantern-core/core_test.go
+++ b/lantern-core/core_test.go
@@ -1,0 +1,26 @@
+package lanterncore
+
+import (
+	"testing"
+
+	"github.com/getlantern/radiance/vpn"
+)
+
+func TestNormalizeAutoTag(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty tag (Smart from UI) normalizes to auto-select", "", vpn.AutoSelectTag},
+		{"named tag passes through", "samizdat-out-samizdat-free-oci-v2-4b2a5569", "samizdat-out-samizdat-free-oci-v2-4b2a5569"},
+		{"explicit auto tag passes through", vpn.AutoSelectTag, vpn.AutoSelectTag},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := normalizeAutoTag(tc.in); got != tc.want {
+				t.Errorf("normalizeAutoTag(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/lantern-core/ffi/ffi.go
+++ b/lantern-core/ffi/ffi.go
@@ -567,23 +567,11 @@ func connectToServer(_tag *C.char) *C.char {
 			return SendError(err)
 		}
 
-		// Switch outbounds on the live tunnel when already connected;
-		// otherwise start the tunnel with the chosen tag.
-		status, err := c.VPNStatus()
-		if err != nil {
-			return SendError(fmt.Errorf("get VPN status failed: %w", err))
-		}
-		if status == vpn.Connected {
-			if err := c.SelectServer(tag); err != nil {
-				return SendError(fmt.Errorf("select server failed: %w", err))
-			}
-			return C.CString("ok")
-		}
-
+		// LanternCore.ConnectVPN picks between /vpn/connect and /server/selected
+		// based on VPNStatus — no dispatch needed here.
 		if err := c.ConnectVPN(tag); err != nil {
 			return SendError(fmt.Errorf("start service failed: %w", err))
 		}
-
 		return C.CString("ok")
 	})
 }

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -29,8 +29,21 @@ func StopVPN(client *ipc.Client) error {
 	return client.DisconnectVPN(ctx)
 }
 
+// ConnectToServer switches the live tunnel to a specific server or, when the
+// caller passes an empty tag, back to auto-select. The Flutter UI sends an
+// empty tag to mean "Smart/auto" (see onSmartLocation in
+// lib/features/vpn/server_selection.dart, which routes through
+// connectToServer with ServerLocationType.auto). This path is reached from
+// the gomobile bindings via lantern-core/mobile/mobile.go's ConnectToServer,
+// which bypasses lanterncore.Core — so normalize the same empty→AutoSelectTag
+// mapping lanterncore does, otherwise radiance's VPNClient.SelectServer
+// falls into the manual-outbound branch and strands Clash in manual mode
+// with an empty selector.
 func ConnectToServer(client *ipc.Client, tag string) error {
 	ctx := context.Background()
+	if tag == "" {
+		tag = vpn.AutoSelectTag
+	}
 	slog.Debug("Connecting to VPN server", "tag", tag)
 
 	// Switch outbounds on the live tunnel when already connected;

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -19,21 +19,11 @@ const (
 // MainActivity / iOS VPNManager). It is also reached from Jigar's
 // onSmartLocation rewrite in server_selection.dart via startVPN(force: true)
 // → lantern.startVPN() → Mobile.StartVPN, which expects "switch back to
-// auto" to work on a live tunnel. Dispatch the same way ConnectToServer
-// does: when the tunnel is already up, swap outbounds via /server/selected
-// instead of hitting /vpn/connect (which would 500 with
-// ErrTunnelAlreadyConnected and surface a snackbar error).
+// auto" to work on a live tunnel. Delegate to ConnectToServer so the
+// VPNStatus → /server/selected dispatch handles that case.
 func StartVPN(client *ipc.Client) error {
 	slog.Info("StartVPN called")
-	ctx := context.Background()
-	if status, err := client.VPNStatus(ctx); err == nil && status == vpn.Connected {
-		slog.Debug("VPN is already connected, switching to auto")
-		return client.SelectServer(ctx, vpn.AutoSelectTag)
-	}
-	if err := client.ConnectVPN(ctx, vpn.AutoSelectTag); err != nil {
-		return fmt.Errorf("failed to start VPN: %w", err)
-	}
-	return nil
+	return ConnectToServer(client, vpn.AutoSelectTag)
 }
 
 func StopVPN(client *ipc.Client) error {

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -15,9 +15,21 @@ const (
 	InternalTagAutoAll InternalTag = "auto-all"
 )
 
+// StartVPN is the gomobile entry point for Mobile.StartVPN (Android
+// MainActivity / iOS VPNManager). It is also reached from Jigar's
+// onSmartLocation rewrite in server_selection.dart via startVPN(force: true)
+// → lantern.startVPN() → Mobile.StartVPN, which expects "switch back to
+// auto" to work on a live tunnel. Dispatch the same way ConnectToServer
+// does: when the tunnel is already up, swap outbounds via /server/selected
+// instead of hitting /vpn/connect (which would 500 with
+// ErrTunnelAlreadyConnected and surface a snackbar error).
 func StartVPN(client *ipc.Client) error {
 	slog.Info("StartVPN called")
 	ctx := context.Background()
+	if status, err := client.VPNStatus(ctx); err == nil && status == vpn.Connected {
+		slog.Debug("VPN is already connected, switching to auto")
+		return client.SelectServer(ctx, vpn.AutoSelectTag)
+	}
 	if err := client.ConnectVPN(ctx, vpn.AutoSelectTag); err != nil {
 		return fmt.Errorf("failed to start VPN: %w", err)
 	}


### PR DESCRIPTION
## Summary

Clicking **Smart** at the top of the server-selection screen, while already connected to a manually-picked server, surfaces a "failed to start service: ... tunnel already connected" snackbar and leaves the tunnel pinned to the manual server. Reproduced on 9.0.30 beta (internal tester, [Freshdesk #173763](https://lantern.freshdesk.com/a/tickets/173763), build from `405468954` which already includes Jigar's `289507280` UI rewrite and garmr's `5078d2390` / `405468954` dispatch work).

## Design context (from Slack with Patrick)

> "Both `ConnectVPN` and `SelectServer` were supposed to treat the empty string as `AutoSelectTag` but only `ConnectVPN` was. `ConnectVPN` is only intended to start the tunnel and connect. That PR [radiance#439] was changing it to also switch servers if already connected, which is what `SelectServer` is for."

Patrick's radiance design is strict:
- `ConnectVPN` = start a tunnel. Errors with `ErrTunnelAlreadyConnected` if the tunnel is already up.
- `SelectServer` = swap outbound on a live tunnel.
- Callers pick the right primitive.
- `fac9089` completed the symmetric empty-tag → `AutoSelectTag` normalization on both primitives; `radiance#439` (which overloaded `ConnectVPN` to also swap outbound) was rejected.

This PR is the **Lantern-side** complement to that design: the caller — `ffi.go:startVPN` and `vpn_tunnel.StartVPN` — now picks the right primitive based on `VPNStatus()` before dispatching.

## Root cause

Jigar's `289507280` rewrote `onSmartLocation` to call `startVPN(force: true)` regardless of VPN state. On Windows that lands in `ffi.go:startVPN` → `c.ConnectVPN("")`; on Android/iOS it lands in `Mobile.StartVPN` → `vpn_tunnel.StartVPN(client)` → `client.ConnectVPN(ctx, AutoSelectTag)`. Both call `ConnectVPN` on a live tunnel, which — per Patrick's design — must error with `ErrTunnelAlreadyConnected`. `lantern.log` is silent for the whole roundtrip (neither `LocalBackend.ConnectVPN` nor `VPNClient.Connect` slogs that path); only the Dart snackbar signals the failure.

## Call sequence

```mermaid
sequenceDiagram
    autonumber
    participant User as User clicks Smart<br/>(tunnel already up, on Bogotá)
    participant UI as Flutter<br/>server_selection.dart + vpn_notifier.dart
    participant Entry as Native entry (platform split)<br/>ffi.go:startVPN (Win)<br/>vpn_tunnel.go:StartVPN (mobile)
    participant Rad as Radiance<br/>vpn/vpn.go + backend/radiance.go

    Note over Rad: Patrick's primitive split (Slack):<br/>ConnectVPN = start tunnel, errors if live<br/>SelectServer = swap outbound on live tunnel<br/>Callers pick the right primitive

    User->>UI: server_selection.dart:223<br/>startVPN(force: true)
    UI->>Entry: vpn_notifier.dart:104 force=true → lantern.startVPN()

    rect rgba(200, 255, 200, 0.3)
        Note over Entry: ✅ this PR: pick the primitive based on status<br/>Windows: core.go:301-306 LanternCore.ConnectVPN<br/>  → VPNStatus() == Connected → SelectServer(AutoSelectTag)<br/>  → otherwise → ConnectVPN(tag)<br/>Mobile: vpn_tunnel.go:26-34 StartVPN<br/>  (same dispatch pattern)
    end

    alt tunnel already up (the user's case)
        Entry->>Rad: ipc/client.go:147<br/>POST /server/selected {Tag: "auto"}
        Rad->>Rad: vpn/vpn.go:294<br/>tag == AutoSelectTag → tunnel.selectMode(AutoSelectTag)
        Rad-->>UI: 200 OK, Clash back to auto
    else tunnel not up
        Entry->>Rad: POST /vpn/connect {Tag: "auto"}
        Rad->>Rad: vpn/vpn.go:110 VPNClient.Connect<br/>→ backend/radiance.go:641 LocalBackend.ConnectVPN<br/>→ bootstraps tunnel
        Rad-->>UI: 200 OK, tunnel up in auto
    end

    rect rgba(255, 200, 200, 0.3)
        Note over Entry,Rad: 🐛 Without this PR (the 9.0.30 snackbar):<br/>Entry calls c.ConnectVPN("") unconditionally.<br/>On a live tunnel → backend/radiance.go:651 r.vpnClient.Connect(bOptions)<br/>→ vpn/vpn.go:128-130 case Connected: return ErrTunnelAlreadyConnected<br/>→ HTTP 500 back to Dart → snackbar, no slog trace anywhere.
    end
```

## Change

**`lantern-core/core.go`** — `LanternCore.ConnectVPN` routes to `SelectServer` on a live tunnel; `SelectServer` stays as-is. Shared empty-tag normalization so any caller reaching `SelectServer` with `""` also gets `AutoSelectTag` (defense in depth, even though `fac9089` now handles this server-side too):

```go
func (lc *LanternCore) ConnectVPN(tag string) error {
    tag = normalizeAutoTag(tag)
    if status, err := lc.client.VPNStatus(lc.ctx); err == nil && status == vpn.Connected {
        return lc.client.SelectServer(lc.ctx, tag)
    }
    return lc.client.ConnectVPN(lc.ctx, tag)
}

func (lc *LanternCore) SelectServer(tag string) error {
    return lc.client.SelectServer(lc.ctx, normalizeAutoTag(tag))
}

func normalizeAutoTag(tag string) string {
    if tag == "" {
        return vpn.AutoSelectTag
    }
    return tag
}
```

**`lantern-core/vpn_tunnel/vpn_tunnel.go`** — mirror the dispatch garmr already added to `vpn_tunnel.ConnectToServer` (`405468954`) on `vpn_tunnel.StartVPN`, which is the gomobile entry:

```go
func StartVPN(client *ipc.Client) error {
    slog.Info("StartVPN called")
    ctx := context.Background()
    if status, err := client.VPNStatus(ctx); err == nil && status == vpn.Connected {
        slog.Debug("VPN is already connected, switching to auto")
        return client.SelectServer(ctx, vpn.AutoSelectTag)
    }
    if err := client.ConnectVPN(ctx, vpn.AutoSelectTag); err != nil {
        return fmt.Errorf("failed to start VPN: %w", err)
    }
    return nil
}
```

Normalization is duplicated across `core.go` and `vpn_tunnel.go` because they are sibling packages; a shared helper would require widening `lanterncore`'s exported API or adding a utility package for a one-line mapping.

## Related prior work on this branch

- `5078d2390` (garmr) — added FFI dispatch in `ffi.go:connectToServer` + `LanternCore.SelectServer`. Fixed the `connectToServer` side of the "tunnel already connected" bug; `startVPN` untouched.
- `405468954` (garmr) — moved the `connectToServer` dispatch into `vpn_tunnel.ConnectToServer` (unified FFI + gomobile for that primitive). Again, `StartVPN` untouched.
- `289507280` (Jigar) — rewrote `onSmartLocation` to use `startVPN(force: true)` instead of `connectToServer(auto, '')`. Eliminated the old `""`-to-`SelectServer` caller but exposed this unpatched half via `startVPN`.
- `fac9089` (Patrick, in radiance) — made `SelectServer("")` equivalent to `SelectServer("auto")`, completing the symmetric normalization on both radiance primitives. Lands independent of this PR.
- `485bf5a00` (fisk, on `fisk/connect-dispatch-select-when-connected`, not on this branch) — earlier attempt at `LanternCore.ConnectVPN` dispatch. This PR lands that fix on the refactor branch and extends it to the gomobile `StartVPN` path.

## Test plan

- [x] `go build ./lantern-core/...` clean
- [x] `go vet ./lantern-core/...` clean
- [x] `go test ./lantern-core/...` — `TestNormalizeAutoTag` covers empty/named/explicit-auto cases
- [x] `gofmt -l` clean
- [ ] Windows smoke: manually pick a server, click "Smart" at top of server-selection screen → expect tunnel to stay up, Clash to return to auto (`updated mode: auto` in logs), urltest to resume — no snackbar.
- [ ] Android smoke: same flow.
- [ ] iOS smoke: same flow.

Fixes issue 3 of getlantern/engineering#3291.

🤖 Generated with [Claude Code](https://claude.com/claude-code)