### PR TITLE
bump radiance to d5a1872 (LocalBackend.SelectServer empty-tag fix)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260424174024-fac9089a191e
+	github.com/getlantern/radiance v0.0.0-20260424202001-d5a18726afbc
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -263,8 +263,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260424174024-fac9089a191e h1:xaqlPNgDNWvF3hSnfX1eOqABtTINFqfazil+QignYiA=
-github.com/getlantern/radiance v0.0.0-20260424174024-fac9089a191e/go.mod h1:VbFkioh4iA56VZY2095NDAnBRXkQ0Fgn5/tMTPGFUjc=
+github.com/getlantern/radiance v0.0.0-20260424202001-d5a18726afbc h1:Ayl2+N8T7B1wOLAutt/oGwW43daGsdBb/NK1wtjcIQ0=
+github.com/getlantern/radiance v0.0.0-20260424202001-d5a18726afbc/go.mod h1:VbFkioh4iA56VZY2095NDAnBRXkQ0Fgn5/tMTPGFUjc=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Bumps radiance pin from `fac9089a191e` → `d5a18726afbc` (radiance refactor tip). Single commit in the delta: [radiance#444](https://github.com/getlantern/radiance/pull/444) `fix(backend): treat empty tag as AutoSelect in LocalBackend.SelectServer`.

Finishes fac9089's empty-string normalization. fac9089 handled the `VPNClient.SelectServer` layer but the outer `LocalBackend.SelectServer` wrapper kept its own `tag == vpn.AutoSelectTag` check against the literal `"auto"`; `tag == ""` slipped past and fell through to the `srvManager.GetServerByTag("")` lookup, producing `"no server found with tag "` (HTTP 500 → Dart snackbar).

Reported on 9.0.30 beta by internal tester via [Freshdesk #173773](https://lantern.freshdesk.com/a/tickets/173773) — Smart-from-connected surfaced that exact snackbar after #8703 removed the client-side empty-tag normalization on the assumption radiance owned it.

## Change

`go.mod` + `go.sum` only:

```diff
-github.com/getlantern/radiance v0.0.0-20260424174024-fac9089a191e
+github.com/getlantern/radiance v0.0.0-20260424202001-d5a18726afbc
```

No lantern code changes.

## Test plan

- [x] `go build ./lantern-core/...` clean
- [x] `go vet ./lantern-core/...` clean
- [x] `go test ./lantern-core/...` clean
- [x] `go mod tidy` — no other drift; go.sum hashes update for the new radiance rev only
- [ ] Smoke: rerun the 9.0.30 Smart-from-connected flow — expected to succeed cleanly (no snackbar, mode flips to auto, settings persist with `AutoConnectKey=true`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)