### PR TITLE
ffi + lantern-core: drop non-Linux preflight; bound IPC calls with per-operation timeouts

### DIFF
--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -281,6 +281,20 @@ func (lc *LanternCore) listenDataCapEvents() {
 //     VPN     //
 /////////////////
 
+// Per-call IPC timeouts. These bound the worst case if lanternd is hung
+// (pipe open, no replies). They're long enough to never fire during normal
+// operation — the connect path involves real DNS / TLS / sing-box bring-up
+// that can take many seconds, while a /vpn/status query should be near-
+// instant — but tight enough that a stuck daemon surfaces as a UI error
+// instead of an indefinite spinner. The dialer already has a 10 s connect
+// timeout (radiance/ipc/conn_windows.go), so these only matter once the
+// pipe is established.
+const (
+	ipcConnectTimeout     = 60 * time.Second
+	ipcStateChangeTimeout = 30 * time.Second
+	ipcStatusTimeout      = 10 * time.Second
+)
+
 // ConnectVPN routes a connect request through vpn_tunnel.ConnectToServer,
 // which picks between /vpn/connect (fresh tunnel) and /server/selected
 // (live-tunnel outbound swap) based on VPNStatus. This is load-bearing for
@@ -292,23 +306,31 @@ func (lc *LanternCore) listenDataCapEvents() {
 //
 // Fixes getlantern/engineering#3291 issue 3.
 func (lc *LanternCore) ConnectVPN(tag string) error {
-	return vpn_tunnel.ConnectToServer(lc.client, tag)
+	ctx, cancel := context.WithTimeout(lc.ctx, ipcConnectTimeout)
+	defer cancel()
+	return vpn_tunnel.ConnectToServer(ctx, lc.client, tag)
 }
 
 func (lc *LanternCore) SelectServer(tag string) error {
-	return lc.client.SelectServer(lc.ctx, tag)
+	ctx, cancel := context.WithTimeout(lc.ctx, ipcStateChangeTimeout)
+	defer cancel()
+	return lc.client.SelectServer(ctx, tag)
 }
 
 func (lc *LanternCore) DisconnectVPN() error {
-	return lc.client.DisconnectVPN(lc.ctx)
+	ctx, cancel := context.WithTimeout(lc.ctx, ipcStateChangeTimeout)
+	defer cancel()
+	return lc.client.DisconnectVPN(ctx)
 }
 
 func (lc *LanternCore) VPNStatus() (vpn.VPNStatus, error) {
-	return lc.client.VPNStatus(lc.ctx)
+	ctx, cancel := context.WithTimeout(lc.ctx, ipcStatusTimeout)
+	defer cancel()
+	return lc.client.VPNStatus(ctx)
 }
 
 func (lc *LanternCore) IsVPNRunning() (bool, error) {
-	status, err := lc.client.VPNStatus(lc.ctx)
+	status, err := lc.VPNStatus()
 	if err != nil {
 		return false, err
 	}

--- a/lantern-core/ffi/ffi_nonlinux.go
+++ b/lantern-core/ffi/ffi_nonlinux.go
@@ -3,15 +3,29 @@
 package main
 
 import (
-	"fmt"
-
 	lanterncore "github.com/getlantern/lantern/lantern-core"
 )
 
-// checkDaemonReachable verifies that the radiance daemon is reachable via IPC.
+// checkDaemonReachable is a no-op on Windows / macOS / mobile. The
+// fast-probe-then-diagnose pattern this preflight came from (PR #8494,
+// `requireLanternServiceAvailable` in ffi_linux.go) only pays off on
+// platforms with a service-management diagnostic to fall back to —
+// `systemctl is-active` on Linux. On other platforms there is no
+// equivalent fallback, so the 300 ms `CheckDaemonReachable` timeout
+// in lantern-core/core.go just caps the cold-start IPC roundtrip
+// below what it can reliably hit (named-pipe dial + impersonation +
+// H2c preface + cold goroutine scheduling regularly run >300 ms on
+// the first request after lanternd has been idle).
+//
+// `ConnectVPN` itself surfaces "lanternd not reachable" with the same
+// precision when the daemon really is dead. The preflight on these
+// platforms was strictly an artificial guillotine in front of that
+// real call. See getlantern/engineering#3382 and Freshdesk #173696 /
+// #173932 for the user-visible regression this skip resolves.
+//
+// If we add Windows (`sc query LanternSvc`) or macOS (`launchctl
+// list`) diagnostics later, restore the preflight and call them from
+// here.
 func checkDaemonReachable(c lanterncore.Core) error {
-	if err := c.CheckDaemonReachable(); err != nil {
-		return fmt.Errorf("lanternd not reachable: %w", err)
-	}
 	return nil
 }

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	_ "golang.org/x/mobile/bind"
 
@@ -212,7 +213,9 @@ func StartVPN() error {
 		if err != nil {
 			return struct{}{}, err
 		}
-		if err := vpn_tunnel.StartVPN(client); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := vpn_tunnel.StartVPN(ctx, client); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
@@ -227,7 +230,9 @@ func StopVPN() error {
 		if err != nil {
 			return struct{}{}, err
 		}
-		if err := vpn_tunnel.StopVPN(client); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := vpn_tunnel.StopVPN(ctx, client); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil
@@ -305,7 +310,9 @@ func ConnectToServer(tag string) error {
 		if err != nil {
 			return struct{}{}, err
 		}
-		if err := vpn_tunnel.ConnectToServer(client, tag); err != nil {
+		ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+		defer cancel()
+		if err := vpn_tunnel.ConnectToServer(ctx, client, tag); err != nil {
 			return struct{}{}, err
 		}
 		return struct{}{}, nil

--- a/lantern-core/vpn_tunnel/vpn_tunnel.go
+++ b/lantern-core/vpn_tunnel/vpn_tunnel.go
@@ -21,13 +21,12 @@ const (
 // → lantern.startVPN() → Mobile.StartVPN, which expects "switch back to
 // auto" to work on a live tunnel. Delegate to ConnectToServer so the
 // VPNStatus → /server/selected dispatch handles that case.
-func StartVPN(client *ipc.Client) error {
+func StartVPN(ctx context.Context, client *ipc.Client) error {
 	slog.Info("StartVPN called")
-	return ConnectToServer(client, vpn.AutoSelectTag)
+	return ConnectToServer(ctx, client, vpn.AutoSelectTag)
 }
 
-func StopVPN(client *ipc.Client) error {
-	ctx := context.Background()
+func StopVPN(ctx context.Context, client *ipc.Client) error {
 	return client.DisconnectVPN(ctx)
 }
 
@@ -35,8 +34,12 @@ func StopVPN(client *ipc.Client) error {
 // caller passes an empty tag or vpn.AutoSelectTag, back to auto-select.
 // Radiance normalizes the empty-tag case server-side (fac9089) for both
 // ConnectVPN and SelectServer.
-func ConnectToServer(client *ipc.Client, tag string) error {
-	ctx := context.Background()
+//
+// The caller is responsible for putting a deadline on ctx — the connect
+// path involves real network work (DNS, TLS, sing-box bring-up) and we
+// don't want a hung lanternd to stall the UI forever. LanternCore.ConnectVPN
+// uses 60 s.
+func ConnectToServer(ctx context.Context, client *ipc.Client, tag string) error {
 	slog.Debug("Connecting to VPN server", "tag", tag)
 
 	// Switch outbounds on the live tunnel when already connected;


### PR DESCRIPTION
## Summary

Two changes that together fix the recurring "lanternd not reachable" first-click bug without introducing the indefinite-hang failure mode that would result from the first change alone.

1. **Drop `checkDaemonReachable` on Windows / macOS / mobile.** The preflight is a vestigial relic of the Linux+systemd flow — its 300 ms timeout was tuned for *fast probe → systemd-rich-error*, and the systemd half only exists on Linux. On other platforms the preflight is just an artificial guillotine in front of `ConnectVPN`. The cold-start IPC path on Windows (named-pipe dial + winio impersonation + H2c connection preface + cold goroutine scheduling) regularly exceeds 300 ms, so the first VPN toggle after every launch trips the timeout and shows the user a spurious error. Linux is unchanged; if we add Windows (`sc query LanternSvc`) or macOS (`launchctl list`) diagnostics later, restore the preflight and call them from there.

2. **Bound per-operation IPC calls with explicit timeouts.** Commit `bd89bea7e` removed the per-call timeouts that used to live on the FFI layer (e.g. `5*time.Second` on `DisconnectVPN`, `8*time.Second` on `ConnectVPN`) at the same time it introduced the bare 300 ms preflight. After that change, the only IPC call with *any* deadline at all was the preflight; every other operation flowed `lc.ctx` (which is `context.WithCancel(context.Background())`) straight through. Drop the preflight without restoring per-call timeouts and a hung lanternd would freeze the UI indefinitely. Restore them at the `LanternCore` layer with values sized for the inherent work each operation does:

| Operation | Timeout | Rationale |
|---|---|---|
| `ConnectVPN` | 60 s | DNS + TLS + sing-box bring-up; can legitimately take many seconds |
| `SelectServer`, `DisconnectVPN` | 30 s | Live-tunnel mutations |
| `VPNStatus`, `IsVPNRunning` | 10 s | Atomic load on the server side; should be near-instant |

The dialer already has a 10 s connect timeout (`radiance/ipc/conn_windows.go`) which covers the lanternd-crashed case. These guard the lanternd-hung case (pipe open, no replies).

Reproduces: same Windows machine across two consecutive beta builds — Freshdesk [#173696](https://lantern.freshdesk.com/a/tickets/173696) (9.0.29) and [#173932](https://lantern.freshdesk.com/a/tickets/173932) (9.0.30). Full archaeology: getlantern/engineering#3382.

## Files

- **`lantern-core/ffi/ffi_nonlinux.go`** — `checkDaemonReachable` becomes a no-op with an explanatory comment about why and a pointer to where to restore it if Windows / macOS get diagnostic equivalents.
- **`lantern-core/core.go`** — adds three timeout constants + wraps `ConnectVPN` / `SelectServer` / `DisconnectVPN` / `VPNStatus` / `IsVPNRunning` with `context.WithTimeout(lc.ctx, ...)`. `CheckDaemonReachable`'s 300 ms is left untouched — Linux's `ffi_linux.go` still calls it for the `systemctl is-active` fallback that's the whole point of the fast probe.
- **`lantern-core/vpn_tunnel/vpn_tunnel.go`** — `StartVPN` / `StopVPN` / `ConnectToServer` take `ctx context.Context` through their signatures instead of building their own `context.Background()`. Caller stays in charge of deadlines.
- **`lantern-core/mobile/mobile.go`** — `Mobile.{StartVPN, StopVPN, ConnectToServer}` set 60 s / 30 s / 60 s contexts on the three gomobile entry points.

## Test plan

- [x] `gofmt` clean on changed files.
- [ ] CI green on Windows + macOS + mobile builds.
- [ ] Manual: install the resulting build, click VPN toggle for the first time after launch — should connect on the first try instead of erroring with "lanternd not reachable". (Was the user-reported regression in #173696 / #173932.)
- [ ] Sanity: simulate a hung lanternd (e.g., add a `time.Sleep(2*time.Minute)` to one of the IPC handlers); verify the UI surfaces an error within the relevant per-call timeout instead of hanging.

## References

- Freshdesk [#173696](https://lantern.freshdesk.com/a/tickets/173696), [#173932](https://lantern.freshdesk.com/a/tickets/173932)
- Engineering issue with full archaeology: getlantern/engineering#3382
- Origin of the preflight: PR getlantern/lantern#8494 (commit `bf054f4ea`, Linux-only at first)
- Generalization that broke it for non-Linux + removed per-call timeouts: commit `bd89bea7e`
- Refactor that hoisted the timeout into LanternCore: PR getlantern/lantern#8578 (commit `4d4e06d9d`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)