### PR TITLE
lantern-core: fix empty Windows split-tunnel apps list + UI-process logging

### DIFF
--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -187,6 +190,27 @@ func New(opts *utils.Opts, eventEmitter utils.FlutterEventEmitter) (Core, error)
 }
 
 func (lc *LanternCore) initialize(opts *utils.Opts, eventEmitter utils.FlutterEventEmitter) error {
+	// Wire up slog for the host process according to how the backend is
+	// hosted on each platform:
+	//
+	//   - windows/linux: the UI is a separate process talking to a daemon
+	//     over IPC, so it needs its own full common.Init.
+	//   - darwin/ios: the UI shares its logDir with the tunnel extension,
+	//     which is the process that called common.Init. Re-running it here
+	//     would collide; instead we set up app-process-only logging into a
+	//     distinct file so the two lumberjacks don't race on rotation.
+	//   - android: the backend is embedded in the same process as the UI
+	//     (see init_mobile.go), and Mobile.SetupRadiance has already called
+	//     common.Init by the time we reach here. Fall through with no
+	//     additional setup.
+	switch runtime.GOOS {
+	case "windows", "linux":
+		if err := common.Init(opts.DataDir, opts.LogDir, opts.LogLevel); err != nil {
+			return fmt.Errorf("common.Init: %w", err)
+		}
+	case "darwin", "ios":
+		setupAppLogging(opts.LogDir, opts.LogLevel)
+	}
 	slog.Debug("Starting LanternCore initialization")
 
 	if opts.Env == "stage" || opts.Env == "staging" {
@@ -578,8 +602,12 @@ func (lc *LanternCore) GetEnabledApps() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	// Return all process-based items as enabled apps
-	var enabledApps []string
+	// Initialize as empty slice so json.Marshal emits "[]" rather than
+	// "null" when no items are enabled — Dart's jsonDecode("null") returns
+	// null and the receiver does `as List`, which throws. Was the actual
+	// cause of "Failed to fetch installed apps" empty list in
+	// Freshdesk #173774 / #173778 / #173826.
+	enabledApps := []string{}
 	enabledApps = append(enabledApps, filter.ProcessPath...)
 	enabledApps = append(enabledApps, filter.ProcessPathRegex...)
 	enabledApps = append(enabledApps, filter.PackageName...)
@@ -597,10 +625,48 @@ func (lc *LanternCore) GetEnabledApps() (string, error) {
 func (lc *LanternCore) ReportIssue(email, issueType, description, device, model, logFilePath string) error {
 	it := parseIssueType(issueType)
 	var attachments []string
+	// Windows + Linux have separate UI and daemon logDirs, so the daemon's
+	// own archive glob misses UI-process logs — pass them through as paths.
+	// Mobile + macOS already share the directory; no pass-through needed.
+	// Relies on the UI logDir being readable by the daemon (SYSTEM on
+	// Windows); %PUBLIC%\Lantern\logs is chosen for that.
+	if runtime.GOOS == "windows" || runtime.GOOS == "linux" {
+		attachments = collectLocalLogs(settings.GetString(settings.LogPathKey))
+	}
 	if logFilePath != "" {
 		attachments = append(attachments, logFilePath)
 	}
 	return lc.client.ReportIssue(lc.ctx, it, description, email, attachments)
+}
+
+// collectLocalLogs returns every *.log directly under dir, with paths shaped
+// however filepath.Glob returns them (relative if dir is relative; the
+// daemon-side ReportIssue path on windows/linux passes the absolute
+// settings.LogPathKey so this is absolute in practice).
+//
+// Files we can't os.Stat from the UI process are dropped. That's a
+// best-effort screen, not a guarantee — the daemon runs as SYSTEM on
+// Windows and may be able to read files this process can't, and vice
+// versa. The drop avoids attaching obviously-broken paths to issue
+// reports; the daemon's own readability check is authoritative.
+func collectLocalLogs(dir string) []string {
+	if dir == "" {
+		return nil
+	}
+	matches, err := filepath.Glob(filepath.Join(dir, "*.log"))
+	if err != nil {
+		slog.Warn("ReportIssue: unable to glob local logs", "dir", dir, "err", err)
+		return nil
+	}
+	out := matches[:0]
+	for _, p := range matches {
+		if _, err := os.Stat(p); err != nil {
+			slog.Warn("ReportIssue: skipping log (unreadable from this process)", "path", p, "err", err)
+			continue
+		}
+		out = append(out, p)
+	}
+	return out
 }
 
 func parseIssueType(s string) issue.IssueType {

--- a/lantern-core/logging.go
+++ b/lantern-core/logging.go
@@ -1,0 +1,40 @@
+package lanterncore
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+
+	rlog "github.com/getlantern/radiance/log"
+)
+
+// AppLogFileName is the basename used for main-app-side slog output on
+// platforms where the tunnel extension owns lantern.log. Distinct from the
+// extension's lantern.log so two lumberjack writers aren't racing on
+// rotation of the same file.
+const AppLogFileName = "lantern-app.log"
+
+// setupAppLogging installs a file-based default slog handler writing to
+// <logDir>/lantern-app.log. Used on iOS and macOS where the main app shares
+// its logDir with the tunnel extension (which runs its own common.Init).
+// Best-effort — any failure leaves the default stderr handler in place.
+func setupAppLogging(logDir, level string) {
+	if logDir == "" {
+		slog.Warn("setupAppLogging: empty logDir, sticking with default handler")
+		return
+	}
+	if err := os.MkdirAll(logDir, 0o755); err != nil {
+		slog.Warn("setupAppLogging: unable to create logDir", "logDir", logDir, "err", err)
+		return
+	}
+	if level == "" {
+		level = DefaultLogLevel
+	}
+	logger := rlog.NewLogger(rlog.Config{
+		LogPath:          filepath.Join(logDir, AppLogFileName),
+		Level:            level,
+		Prod:             true,
+		DisablePublisher: true,
+	})
+	slog.SetDefault(logger)
+}


### PR DESCRIPTION
Split out from #8706 — the **base-bug fix** half. The companion PR with the broader Windows app-discovery rework is at #8710.

## Summary

Two narrow changes that together resolve Freshdesk [#173774](https://lantern.freshdesk.com/a/tickets/173774) / [#173778](https://lantern.freshdesk.com/a/tickets/173778) / [#173826](https://lantern.freshdesk.com/a/tickets/173826) (Derek's *"Failed to fetch installed apps"* on Windows split tunneling):

### 1. `GetEnabledApps` returns `[]string{}` instead of `nil`

When no apps are split-tunneled the previous code returned `nil`, which `json.Marshal` serializes as `"null"`. Dart's `jsonDecode("null")` returns `null`; the receiving Flutter code does `as List`, which **throws** and the UI shows *"Failed to fetch installed apps"*. Initializing as an empty slice serializes to `"[]"` — Dart parses that as an empty list, no exception, no error UI.

**This is the actual root cause** of the empty-list reports we've been chasing. The apps-discovery scanner work in the companion PR was investigating a different (also-real but secondary) symptom.

### 2. UI-process slog wired up via `common.Init`

On the refactor branch the UI process never called `common.Init`. `slog` wrote to stderr (= nowhere on a GUI host), settings were uninitialized, no `lantern.log` was produced outside the daemon process. Patrick caught this — it was a one-line miss in the refactor.

Platform-aware so we don't double-init where the backend embeds in-process:

- **windows/linux** — full `common.Init` (separate UI + daemon procs)
- **darwin/ios** — `setupAppLogging` into a distinct `lantern-app.log` so the main-app slog doesn't race the tunnel extension's `lantern.log` on lumberjack rotation
- **android** — `Mobile.SetupRadiance` already ran `common.Init` upstream; fall through

### 3. Auto-attach UI-process `*.log` to ReportIssue (windows/linux only)

Without it, the daemon's archive glob only sees the daemon's logDir; UI-side `lantern.log` + `flutter.log` never reach the issue bundle. The daemon runs as SYSTEM on Windows; UI logDir at `%PUBLIC%\Lantern\logs` is chosen so SYSTEM can read it. `collectLocalLogs` does a best-effort `os.Stat` screen but the daemon's own readability check is authoritative.

## Files

- `lantern-core/core.go` (+68 / -2): platform switch in `initialize`, `enabledApps := []string{}` change, `collectLocalLogs` + ReportIssue platform-gate.
- `lantern-core/logging.go` (new, +40): `setupAppLogging` for darwin/ios.

Diff stat: **2 files, 108 insertions, 2 deletions**.

## Test plan

- [x] `gofmt` clean on changed files.
- [x] `GOOS=windows go vet ./lantern-core/...` clean.
- [ ] CI green.
- [ ] Manual: build a nightly, install on Windows, hit "Show Apps" in split-tunnel — list populates instead of erroring "Failed to fetch installed apps".
- [ ] Manual: hit Report Issue on Windows — bundle should include `lantern.log` + `flutter.log` from the UI logDir alongside the daemon's archive.

## What's NOT here (lives in #8710)

- App Paths registry scanner
- Run keys scanner (Squirrel apps)
- `%LOCALAPPDATA%\<App>\Update.exe` pattern fallback
- `isAppPathsNoise` heuristic filter
- `ParentKeyName` filter removal in `isNonUserFacingUninstallEntry`
- COM-failure log promotion in Start Menu scanner
- Per-filter scan-summary tallies
- Constant-data hoisting in `isAppPathsNoise`
- Test coverage for the new heuristics

Those are split into #8710 because they're heuristic / behavioral changes to app discovery that warrant independent review and don't depend on (or block) the base-bug fix above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)