### PR TITLE
android: init Go logging early so lantern-core/radiance debug logs aren't lost

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
@@ -23,7 +23,9 @@ import org.getlantern.lantern.service.LanternVpnService
 import org.getlantern.lantern.service.QuickTileService
 import org.getlantern.lantern.utils.AppLogger
 import org.getlantern.lantern.utils.VpnStatusManager
+import org.getlantern.lantern.utils.initConfigDir
 import org.getlantern.lantern.utils.isServiceRunning
+import org.getlantern.lantern.utils.logDir
 import org.getlantern.lantern.utils.setupDirs
 
 
@@ -62,6 +64,17 @@ class MainActivity : FlutterFragmentActivity() {
         Log.d(TAG, "Config directories set up")
         AppLogger.init()
         AppLogger.d(TAG, "AppLogger initialized")
+        // Wire up Go-side logging before any Mobile.* call. Without this, every
+        // lantern-core / radiance slog call that fires before LanternVpnService's
+        // ACTION_START_RADIANCE coroutine reaches common.Init falls through to
+        // the stdlib default (text → stderr → logcat at INFO), so DEBUG logs
+        // disappear and the format diverges from the rest. common.Init is
+        // idempotent — the later call from backend.NewLocalBackend is a no-op.
+        try {
+            Mobile.initLogging(initConfigDir(), logDir(), "trace")
+        } catch (e: Exception) {
+            Log.e(TAG, "Failed to init Go logging: ${e.message}")
+        }
         ///Setup handler
         flutterEngine.plugins.add(EventHandler())
         flutterEngine.plugins.add(MethodHandler())

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -88,6 +88,29 @@ func getClient() (*ipc.Client, error) {
 	return core.Client(), nil
 }
 
+// InitLogging wires the global slog handler (file + stdout) before any other
+// Mobile.* call. On Android the entire app runs in a single process, so once
+// common.Init runs `slog.SetDefault` covers all Go code — but it normally
+// only runs deep inside SetupRadiance / StartIPCServer, which the Android
+// side launches asynchronously from LanternVpnService after an intent. Any
+// lantern-core or radiance log emitted in the meantime (Flutter MethodChannel
+// handlers reach a wide surface before the VPN service is up) falls through
+// to the stdlib default — text → stderr → logcat at INFO — so debug logs
+// vanish and the format diverges from the rest. Calling this from
+// MainActivity.configureFlutterEngine before startLanternService closes that
+// gap.
+//
+// The first call wins: dataDir/logDir/logLevel here are what take effect.
+// Pass the same values that the later backend.NewLocalBackend → common.Init
+// will see (in practice both derive from LanternVpnService.opts()), otherwise
+// the early values silently override.
+func InitLogging(dataDir, logDir, logLevel string) error {
+	_, err := utils.RunOffCgoStack(func() (struct{}, error) {
+		return struct{}{}, common.Init(dataDir, logDir, logLevel)
+	})
+	return err
+}
+
 func SetupRadiance(opts *utils.Opts, eventEmitter utils.FlutterEventEmitter) error {
 	_, err := utils.RunOffCgoStack(func() (struct{}, error) {
 		slog.Info("Setting up Radiance", "opts", opts)


### PR DESCRIPTION
## Summary
- On Android the entire app runs in a single process, so once `common.Init` runs `slog.SetDefault` covers all Go code. But `common.Init` only runs deep inside `SetupRadiance` / `StartIPCServer`, which `LanternVpnService.startRadiance` launches asynchronously from an intent fired by `MainActivity.startLanternService`. Any `slog` call emitted in the gap — including any of the wide `MethodHandler` surface that Flutter can reach before the VPN service is up — falls through to the stdlib default (text → stderr → logcat at INFO), so DEBUG logs vanish and the format diverges from what we use everywhere else.
- Add `Mobile.InitLogging` as a thin gomobile-exposed wrapper around `common.Init`, and call it from `MainActivity.configureFlutterEngine` before `startLanternService()`. `common.Init` is guarded by an `atomic.Bool`, so the later call from `backend.NewLocalBackend` is a no-op.
- Mirrors PR #8709 (Windows UI process never had `common.Init`; this is the Android analog where it does run, just late).

Reported on [Slack](https://wdynhnkxvsdx.slack.com/archives/C04T8M4AB1Q/p1777070939275929) by Jigar — lantern-core logs (mostly) missing in logcat while radiance logs and Flutter logs work fine. The "mostly" matches expectation: anything emitted *after* the async `startRadiance` coroutine finishes routes through the configured handler, but earlier calls (and DEBUG calls in particular) hit the stdlib default.

## Call flow (before this PR)

```mermaid
sequenceDiagram
    autonumber
    participant MA as MainActivity<br/>MainActivity.kt
    participant LVS as LanternVpnService<br/>LanternVpnService.kt
    participant Mob as Mobile (gomobile)<br/>lantern-core/mobile/mobile.go
    participant LC as lanterncore.New<br/>lantern-core/core.go
    participant CI as common.Init<br/>radiance/common/init.go

    MA->>MA: MainActivity.kt:64<br/>setupDirs() + AppLogger.init()
    Note over MA: any slog call here ⚠️<br/>handler = stdlib default<br/>(text → stderr → logcat INFO)
    MA->>LVS: MainActivity.kt:96<br/>startService(ACTION_START_RADIANCE)
    MA->>MA: MainActivity.kt:67<br/>add MethodHandler / EventHandler
    Note over MA: MethodChannel handlers can fire NOW ⚠️
    rect rgba(255, 200, 200, 0.3)
        LVS->>LVS: LanternVpnService.kt:115<br/>serviceScope.launch { startRadiance() } 🐛
        Note over LVS: async — racy with MethodHandler calls
        LVS->>Mob: LanternVpnService.kt:286-287<br/>Mobile.startIPCServer + setupRadiance
        Mob->>LC: mobile.go:71<br/>lanterncore.New
        LC->>CI: backend.NewLocalBackend → init.go:57<br/>common.Init
        Note over CI: init.go:100<br/>slog.SetDefault(logger) ⚠️
    end
    Note over CI: only NOW are file/JSON logs wired up
```

## Call flow (with this PR)

```mermaid
sequenceDiagram
    autonumber
    participant MA as MainActivity<br/>MainActivity.kt
    participant Mob as Mobile (gomobile)<br/>lantern-core/mobile/mobile.go
    participant CI as common.Init<br/>radiance/common/init.go
    participant LVS as LanternVpnService<br/>LanternVpnService.kt

    MA->>MA: MainActivity.kt:64<br/>setupDirs() + AppLogger.init()
    MA->>Mob: MainActivity.kt:73<br/>Mobile.initLogging(dataDir, logDir, "trace")
    Mob->>CI: mobile.go:88<br/>common.Init
    Note over CI: init.go:100<br/>slog.SetDefault(logger) ⚠️
    Note over CI: file + stdout multi-writer wired<br/>before any other Mobile.* call
    MA->>LVS: MainActivity.kt:98<br/>startService(ACTION_START_RADIANCE)
    LVS->>CI: backend.NewLocalBackend → init.go:57<br/>common.Init (idempotent — atomic.Bool guard, no-op)
```

## Idempotency

`common.Init` returns immediately if already initialized:

```go
// radiance/common/init.go:57-61
func Init(dataDir, logDir, logLevel string) (err error) {
    slog.Info("Initializing common package")
    if initialized.Swap(true) {
        return nil
    }
    ...
```

The first call wins — its `dataDir`/`logDir`/`logLevel` are what take effect. Both call sites here derive from `LanternVpnService.opts()` (via `initConfigDir()` / `logDir()` in `utils.kt`) and pass `"trace"`, so they agree.

## Test plan
- [ ] Build a nightly with this branch and verify `lantern.log` (under `<filesDir>/.lantern/logs/`) has Go-side entries from before the VPN service starts (e.g. lantern-core init lines).
- [ ] In logcat, confirm previously-missing DEBUG-level lantern-core/radiance lines now appear (look for `level=DEBUG` JSON lines through the `GoLog` tag).
- [ ] Verify VPN connect / disconnect still works (regression check that the early `common.Init` doesn't interact badly with the later `backend.NewLocalBackend`).
- [ ] Verify a fresh install (no existing `.lantern` dir) still initializes cleanly — `setupDirs()` runs first so the dirs exist before `Mobile.initLogging`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)