### PR TITLE
bump radiance to main + go mod tidy

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,6 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260428181046-e312570c7aea h1:/4xvoM2+9+bBvJqcJWw5JwcquSpCzFn7f5KWITJfgeg=
-github.com/getlantern/radiance v0.0.0-20260428181046-e312570c7aea/go.mod h1:6ZSihNGPq0aVAgPjAgaL2vHiednNcKXEmlYQYGQ5ZBE=
 github.com/getlantern/radiance v0.0.0-20260429122120-a1539181aaf7 h1:R1/Au+1zOeaQDVb92r5YK1Z0tK5FrILVWsTQKiZnMYY=
 github.com/getlantern/radiance v0.0.0-20260429122120-a1539181aaf7/go.mod h1:6ZSihNGPq0aVAgPjAgaL2vHiednNcKXEmlYQYGQ5ZBE=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=


### PR DESCRIPTION
## Summary

- `go.mod` was already pinned at radiance main (`a153918`); no version change.
- `go mod tidy` drops two stale `go.sum` lines for the prior radiance pseudo-version (`e312570c`) carried over from PR #8578.

## Verified

- Radiance main pins kindling at `6143132aaf40`, which is also kindling's `main` HEAD — full chain is current.
- `go build ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)