### PR TITLE
trace: log VPN status hop timestamps (Freshdesk #174072)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260429171416-08e8d202d60d
+	github.com/getlantern/radiance v0.0.0-20260429214604-2eb58db5ed82
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260429171416-08e8d202d60d h1:q5IXtFaaUszI5umFyO0h4FKPX0z1YRI5cTJNN1LblYA=
-github.com/getlantern/radiance v0.0.0-20260429171416-08e8d202d60d/go.mod h1:2JN8j2ba8a9Y6ZEk31NCPmWvWbFOWZqTBc4WIy+LiuE=
+github.com/getlantern/radiance v0.0.0-20260429214604-2eb58db5ed82 h1:zy+KqpK3dN2oAtJsfCvX4+Ehe5hsQfEW+TS0jVLYUig=
+github.com/getlantern/radiance v0.0.0-20260429214604-2eb58db5ed82/go.mod h1:2JN8j2ba8a9Y6ZEk31NCPmWvWbFOWZqTBc4WIy+LiuE=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/lantern-core/ffi/ffi.go
+++ b/lantern-core/ffi/ffi.go
@@ -461,6 +461,10 @@ func startStatusListener(c lanterncore.Core) {
 					statusListenerLastMu.Unlock()
 
 					if changed {
+						// [vpn-state-trace] hop=ffi_to_port — moment lantern-core forwards
+						// the parsed status to the Dart ReceivePort. The gap to dart_applied
+						// measures Dart isolate scheduling + Riverpod notify on Windows.
+						slog.Info("[vpn-state-trace]", "hop", "ffi_to_port", "status", ui, "ts_ms", time.Now().UnixMilli())
 						sendStatusToPort(VPNStatus(ui), errMsg)
 					}
 				})

--- a/lib/features/vpn/provider/vpn_notifier.dart
+++ b/lib/features/vpn/provider/vpn_notifier.dart
@@ -29,8 +29,11 @@ class VpnNotifier extends _$VpnNotifier {
       // after the FFI ReceivePort delivers a status. Pairs with ffi_to_port
       // (lantern-core) and ssehandler_flushed / sse_parsed / daemon_setstatus
       // (radiance) to localize the Windows lag in Freshdesk #174072.
+      // Use nextStatus.name (e.g. "disconnecting") rather than the default
+      // toString() ("VPNStatus.disconnecting") so the value matches the wire
+      // format emitted by radiance — makes cross-hop grep/correlation work.
       appLogger.info(
-        '[vpn-state-trace] hop=dart_applied status=$nextStatus '
+        '[vpn-state-trace] hop=dart_applied status=${nextStatus.name} '
         'ts_ms=${DateTime.now().millisecondsSinceEpoch}',
       );
       final suppressConnectionNotifications =

--- a/lib/features/vpn/provider/vpn_notifier.dart
+++ b/lib/features/vpn/provider/vpn_notifier.dart
@@ -25,6 +25,14 @@ class VpnNotifier extends _$VpnNotifier {
       final previousStatus = previous?.value?.status;
       final nextStatus = next.value!.status;
       final nextOrigin = next.value!.origin;
+      // [vpn-state-trace] hop=dart_applied — moment Riverpod fires the listener
+      // after the FFI ReceivePort delivers a status. Pairs with ffi_to_port
+      // (lantern-core) and ssehandler_flushed / sse_parsed / daemon_setstatus
+      // (radiance) to localize the Windows lag in Freshdesk #174072.
+      appLogger.info(
+        '[vpn-state-trace] hop=dart_applied status=$nextStatus '
+        'ts_ms=${DateTime.now().millisecondsSinceEpoch}',
+      );
       final suppressConnectionNotifications =
           nextOrigin == VPNStatusOrigin.settingsMutation &&
           (nextStatus == VPNStatus.connected ||


### PR DESCRIPTION
## Summary

Two diagnostic log lines on the lantern side of the VPN status delivery path:

| Hop | File | Where |
|---|---|---|
| \`ffi_to_port\` | \`lantern-core/ffi/ffi.go\` | After \`startStatusListener\` dedup, before \`sendStatusToPort\` |
| \`dart_applied\` | \`lib/features/vpn/provider/vpn_notifier.dart\` | Top of the \`ref.listen(vPNStatusProvider)\` callback |

Pairs with three hops added in [radiance#451](https://github.com/getlantern/radiance/pull/451) so a single \`vpn-state-trace\` grep gives a five-row timeline per status change:

\`\`\`
[vpn-state-trace] hop=daemon_setstatus    status=disconnecting ts_ms=...
[vpn-state-trace] hop=ssehandler_flushed  data=...             ts_ms=...
[vpn-state-trace] hop=sse_parsed          data=...             ts_ms=...
[vpn-state-trace] hop=ffi_to_port         status=Disconnecting ts_ms=...
[vpn-state-trace] hop=dart_applied        status=Disconnecting ts_ms=...
\`\`\`

## Why

Freshdesk #174072 — Windows users see the VPN toggle skip \`Connecting\` / \`Disconnecting\` states. PR getlantern/radiance#447 fixed the first-attach race; the residual lag is somewhere between \`setStatus\` and the Dart UI. Without timestamps from a real Windows run I can't pin which hop, so a single timeline tells us exactly where the delay sits.

## Cleanup

Remove both \`appLogger.info\` / \`slog.Info\` lines once the buggy hop is identified and fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)