### PR TITLE
fix: surface Connecting/Disconnecting in Windows UI (Freshdesk #174072)

### DIFF
--- a/lantern-core/ffi/ffi.go
+++ b/lantern-core/ffi/ffi.go
@@ -41,16 +41,8 @@ func runOnGoStack(fn func() *C.char) *C.char {
 	return result
 }
 
-type VPNStatus string
-
 const (
 	enableLogging = false
-
-	Connecting    VPNStatus = "Connecting"
-	Connected     VPNStatus = "Connected"
-	Disconnecting VPNStatus = "Disconnecting"
-	Disconnected  VPNStatus = "Disconnected"
-	Error         VPNStatus = "Error"
 )
 
 var (
@@ -416,7 +408,7 @@ func getAvailableServers() *C.char {
 	})
 }
 
-func sendStatusToPort(status VPNStatus, errMsg string) {
+func sendStatusToPort(status vpn.VPNStatus, errMsg string) {
 	slog.Debug("sendStatusToPort called", "status", status)
 	port := statusPort.Load()
 	if port == 0 {
@@ -451,12 +443,12 @@ func startStatusListener(c lanterncore.Core) {
 					continue
 				}
 				c.VPNStatusEvents(context.Background(), func(evt vpn.StatusUpdateEvent) {
-					ui, errMsg := mapStatusEvent(evt)
+					status, errMsg := mapStatusEvent(evt)
 
 					statusListenerLastMu.Lock()
-					changed := ui != statusListenerLast
+					changed := string(status) != statusListenerLast
 					if changed {
-						statusListenerLast = ui
+						statusListenerLast = string(status)
 					}
 					statusListenerLastMu.Unlock()
 
@@ -464,8 +456,8 @@ func startStatusListener(c lanterncore.Core) {
 						// [vpn-state-trace] hop=ffi_to_port — moment lantern-core forwards
 						// the parsed status to the Dart ReceivePort. The gap to dart_applied
 						// measures Dart isolate scheduling + Riverpod notify on Windows.
-						slog.Info("[vpn-state-trace]", "hop", "ffi_to_port", "status", ui, "ts_ms", time.Now().UnixMilli())
-						sendStatusToPort(VPNStatus(ui), errMsg)
+						slog.Info("[vpn-state-trace]", "hop", "ffi_to_port", "status", status, "ts_ms", time.Now().UnixMilli())
+						sendStatusToPort(status, errMsg)
 					}
 				})
 				// SSE stream disconnected — retry after a short delay.
@@ -500,23 +492,27 @@ func startLogsListener(c lanterncore.Core) {
 	})
 }
 
-func mapStatusEvent(evt vpn.StatusUpdateEvent) (string, string) {
+// mapStatusEvent normalizes a radiance VPN status event for forwarding to
+// Dart. Most values pass through unchanged; the exceptions are:
+//   - vpn.Restarting collapses into vpn.Connecting so the UI shows a
+//     transitional state during a tunnel restart rather than an unknown
+//     "restarting" string the Dart parser falls back to disconnected on.
+//   - A non-empty evt.Error always maps to vpn.ErrorStatus (radiance also
+//     emits ErrorStatus in this case, but be explicit so the contract
+//     doesn't depend on radiance always agreeing).
+//   - An unrecognized status falls back to Disconnected so the UI never
+//     gets stuck on a stale connected indicator.
+func mapStatusEvent(evt vpn.StatusUpdateEvent) (vpn.VPNStatus, string) {
 	if evt.Error != "" {
-		return string(Error), evt.Error
+		return vpn.ErrorStatus, evt.Error
 	}
 	switch evt.Status {
-	case vpn.Connected:
-		return string(Connected), ""
-	case vpn.Connecting, vpn.Restarting:
-		return string(Connecting), ""
-	case vpn.Disconnecting:
-		return string(Disconnecting), ""
-	case vpn.Disconnected:
-		return string(Disconnected), ""
-	case vpn.ErrorStatus:
-		return string(Error), ""
+	case vpn.Connected, vpn.Connecting, vpn.Disconnecting, vpn.Disconnected, vpn.ErrorStatus:
+		return evt.Status, ""
+	case vpn.Restarting:
+		return vpn.Connecting, ""
 	default:
-		return string(Disconnected), ""
+		return vpn.Disconnected, ""
 	}
 }
 

--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -573,10 +573,16 @@ class LanternFFIService implements LanternCoreService {
   Future<Either<Failure, String>> startVPN() async {
     try {
       appLogger.debug('Starting VPN');
-      final result = _ffiService
-          .startVPN()
-          .cast<Utf8>()
-          .toDartString();
+      // Run on a background isolate. The FFI call performs ~1s of connect
+      // work and emits intermediate status updates ("connecting", then
+      // "connected") to the Dart status SendPort during that window. If we
+      // run it on the main isolate the event loop is blocked, so the port
+      // messages can't be delivered to listeners until the call returns —
+      // at which point both events fire back-to-back, leaving no frame for
+      // the UI to render the "Connecting" state. See Freshdesk #174072.
+      final result = await runInBackground<String>(() async {
+        return _ffiService.startVPN().cast<Utf8>().toDartString();
+      });
       if (result.isNotEmpty && !_ffiOkResults.contains(result)) {
         return left(Failure(error: result, localizedErrorMessage: result));
       }
@@ -647,8 +653,12 @@ class LanternFFIService implements LanternCoreService {
   Future<Either<Failure, String>> stopVPN() async {
     try {
       appLogger.debug('Stopping VPN');
-
-      final result = _ffiService.stopVPN().cast<Utf8>().toDartString();
+      // Run on a background isolate so the main isolate's event loop stays
+      // free to drain the status SendPort while the FFI call is running.
+      // See the comment in startVPN for the full reasoning.
+      final result = await runInBackground<String>(() async {
+        return _ffiService.stopVPN().cast<Utf8>().toDartString();
+      });
       if (result.isNotEmpty && !_ffiOkResults.contains(result)) {
         return left(Failure(error: result, localizedErrorMessage: result));
       }

--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -581,7 +581,12 @@ class LanternFFIService implements LanternCoreService {
       // at which point both events fire back-to-back, leaving no frame for
       // the UI to render the "Connecting" state. See Freshdesk #174072.
       final result = await runInBackground<String>(() async {
-        return _ffiService.startVPN().cast<Utf8>().toDartString();
+        final resultPtr = _ffiService.startVPN();
+        try {
+          return resultPtr.cast<Utf8>().toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
       if (result.isNotEmpty && !_ffiOkResults.contains(result)) {
         return left(Failure(error: result, localizedErrorMessage: result));
@@ -657,7 +662,12 @@ class LanternFFIService implements LanternCoreService {
       // free to drain the status SendPort while the FFI call is running.
       // See the comment in startVPN for the full reasoning.
       final result = await runInBackground<String>(() async {
-        return _ffiService.stopVPN().cast<Utf8>().toDartString();
+        final resultPtr = _ffiService.stopVPN();
+        try {
+          return resultPtr.cast<Utf8>().toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
       if (result.isNotEmpty && !_ffiOkResults.contains(result)) {
         return left(Failure(error: result, localizedErrorMessage: result));


### PR DESCRIPTION
## Summary

Fixes the user-reported symptom that on Windows v9.1.1 the VPN toggle skips the **Connecting** and **Disconnecting** UI states — the toggle appears to jump straight between Disconnected and Connected with nothing in between, even though the actual tunnel work takes ~1.4s.

Companion to the trace instrumentation added in radiance #451 + this repo's #8716; those PRs added the diagnostic hops that pinpointed the root cause. This PR is the actual fix.

## Root cause from the five-hop trace

For one of the user's connect cycles (Freshdesk #174072 attached logs):

| Hop | Time | Δ |
|---|---|---|
| `daemon_setstatus(connecting)` | 15:34:23.536 | — |
| `ssehandler_flushed(connecting)` | 15:34:23.537 | +1ms |
| `sse_parsed(connecting)` | 15:34:23.537 | +0ms |
| `ffi_to_port(connecting)` | 15:34:23.537 | +0ms ← written to Dart SendPort |
| `daemon_setstatus(connected)` | 15:34:24.933 | +1396ms ← actual connect work |
| `ssehandler_flushed(connected)` | 15:34:24.934 | +1ms |
| `sse_parsed(connected)` | 15:34:24.935 | +1ms |
| `ffi_to_port(connected)` | 15:34:24.936 | +1ms |
| **`dart_applied(connecting)`** | **15:34:24.939** | **+1402ms** ← Dart finally fires |
| `dart_applied(connected)` | 15:34:24.941 | +2ms ← back-to-back, no frame to paint |

Go-side end-to-end delivery is 1ms. The 1.4s gap is **between `ffi_to_port` (the SendPort write) and `dart_applied` (the Dart listener firing)**. Disconnect cycle has the same shape (449ms gap).

`startVPN` and `stopVPN` were calling the FFI synchronously on the main Dart isolate — blocking the event loop for the duration of the connect/disconnect work. Status messages emitted to the SendPort during that window queued. As soon as the FFI returned, Dart drained the queue, firing both the transitional and terminal listeners back-to-back. UI never had a frame to paint the transitional state.

## Fix

Wrap `_ffiService.startVPN()` and `_ffiService.stopVPN()` in `runInBackground`, matching the pattern already used by `isTagAvailable`, `connectToServer`, and ~10 other FFI methods in the same file. Once the FFI runs on a background isolate, the main isolate stays free to drain SendPort messages as they arrive.

Expected behavior post-fix: `dart_applied(connecting)` fires within ~1ms of `ffi_to_port(connecting)`, giving the UI ~1.4s of "Connecting..." before "Connected" arrives.

## Cleanup bundled

In `lantern-core/ffi/ffi.go`:

- Drop the local capitalized `VPNStatus` type and `Connecting`/`Connected`/`Disconnecting`/`Disconnected`/`Error` constants. Use `vpn.VPNStatus` from radiance directly throughout.
- `mapStatusEvent` returns `vpn.VPNStatus` instead of `string`.
- `sendStatusToPort` takes `vpn.VPNStatus`.
- The wire format switches from `"Connecting"` to `"connecting"` (radiance's actual enum value). Dart's `LanternStatus.fromJson` already calls `.toLowerCase()` before parsing, so this change is invisible to consumers — but it removes the case-translation tax and means every `[vpn-state-trace]` hop now carries the same lowercase string.

## Test plan

- [x] `go build ./lantern-core/ffi/...` clean
- [x] `go vet ./lantern-core/ffi/...` clean
- [x] `go test ./lantern-core/ffi/...` passes
- [x] `flutter analyze lib/lantern/lantern_ffi_service.dart` no issues
- [ ] Build a Windows binary, hand to the affected user (Freshdesk #174072 / #174124), confirm the Connecting/Disconnecting states are visible in the UI for the duration of the actual tunnel work
- [ ] Check the `[vpn-state-trace]` timeline shows `ffi_to_port → dart_applied` gap drops from ~1.4s to single-digit ms

## Follow-up (not in this PR)

Once the fix is verified live, remove the `[vpn-state-trace]` instrumentation in:
- `radiance/vpn/vpn.go` (daemon_setstatus)
- `radiance/ipc/server.go` (ssehandler_flushed)
- `radiance/ipc/client_nonmobile.go` (sse_parsed)
- `lantern-core/ffi/ffi.go` (ffi_to_port)
- `lib/features/vpn/provider/vpn_notifier.dart` (dart_applied)

The commit messages on those instrumentation PRs already say "remove all three lines once the buggy hop is identified and fixed."