### PR TITLE
android: fix abiFilters mismatch causing libflutter.so crash on x86_64

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -60,8 +60,12 @@ android {
         versionName = flutter.versionName
 
         ndk {
-            // Specifies the ABI configurations of native libraries Gradle should build and package with the app.
-            abiFilters = ["x86_64", "arm64-v8a"]
+            // Must match the ABIs Flutter actually builds (ANDROID_TARGET_PLATFORMS
+            // in the top-level Makefile: android-arm + android-arm64). Listing an
+            // ABI here that Flutter didn't build for produces an empty per-ABI
+            // split on Play and crashes installs on that architecture with
+            // "Could not find 'libflutter.so'".
+            abiFilters = ["arm64-v8a", "armeabi-v7a"]
             debugSymbolLevel 'FULL'
         }
 


### PR DESCRIPTION
## Summary

The Gradle `abiFilters` list in `android/app/build.gradle` did not match the ABIs Flutter actually builds (`ANDROID_TARGET_PLATFORMS` in the top-level Makefile). Google Play caught this in production for 9.1.2-beta:

```
MissingLibraryException: Could not find 'libflutter.so'.
Looked for: [x86_64], but only found: [].
```

## Root cause

```mermaid
sequenceDiagram
    autonumber
    participant Make as Makefile<br/>line 110, 513
    participant Flutter as Flutter SDK
    participant Gradle as android/app/build.gradle<br/>line 64
    participant Play as Google Play<br/>(AAB splitter)
    participant Dev as x86_64 device

    Make->>Flutter: flutter build appbundle --target-platform android-arm,android-arm64
    Flutter-->>Gradle: produces libflutter.so for armeabi-v7a + arm64-v8a only
    Note over Gradle: abiFilters = ["x86_64", "arm64-v8a"] ⚠️
    Gradle->>Play: AAB declares support for [x86_64, arm64-v8a]<br/>but x86_64 has zero native libs
    rect rgba(255, 200, 200, 0.3)
        Play->>Dev: Serve x86_64 split (empty) 🐛
        Dev->>Dev: FlutterLoader looks for libflutter.so<br/>finds [] → crash
    end
```

Two layered bugs:

1. **`x86_64` listed but never built.** The split Play served to x86_64 devices (Chromebooks running Android apps, BlueStacks, x86_64 emulators) was empty, crashing every install with `Could not find 'libflutter.so'. Looked for: [x86_64], but only found: []`.
2. **`armeabi-v7a` built but excluded.** Flutter produced 32-bit ARM libs (because the Makefile passes `android-arm`), but the `abiFilters` list dropped them — silently losing 32-bit ARM users.

## Fix

Align `abiFilters` with what Flutter actually builds:

```diff
- abiFilters = ["x86_64", "arm64-v8a"]
+ abiFilters = ["arm64-v8a", "armeabi-v7a"]
```

Drops the empty `x86_64` split (the actual crash) and re-includes the `armeabi-v7a` libs Flutter is already building. Also adds a comment pointing at the Makefile so the next person editing either list knows they need to keep them in sync.

## Alternative considered

Adding `android-x64` to `ANDROID_TARGET_PLATFORMS` would make Flutter actually build x86_64 libs, restoring Chromebook / emulator support. Rejected for now: real Lantern users are overwhelmingly arm64 phones, and shipping the extra x86_64 libs increases AAB size for negligible audience gain. Easy to revisit later if we get evidence of meaningful x86_64 demand.

## Test plan

- [ ] Build a release AAB locally and inspect the per-ABI split contents — confirm `arm64-v8a` and `armeabi-v7a` splits both contain `libflutter.so` (and the gomobile-produced libs), and that no `x86_64` split is produced.
- [ ] Push to internal Play track, confirm no install crashes from x86_64 devices in the new build (the previous crash should disappear from Play vitals).
- [ ] Confirm 32-bit ARM devices in QA install and run successfully (this changes their availability — they previously couldn't install because the AAB declared no `armeabi-v7a` support).

🤖 Generated with [Claude Code](https://claude.com/claude-code)