### PR TITLE
Bump radiance — fix x-lantern-client-country header leak (bandit.asn=0 in prod)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260501225237-861cb6dc5656
+	github.com/getlantern/radiance v0.0.0-20260504173044-ca14a8ca3299
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260501225237-861cb6dc5656 h1:vMfyNBYGnpi+3nFDVtzmsCQ7YTqzkzYw8Sk7cQgVxY0=
-github.com/getlantern/radiance v0.0.0-20260501225237-861cb6dc5656/go.mod h1:7n9EA++kf14Qon02cjpkxM96H497HUfzm7KQQN5H8gA=
+github.com/getlantern/radiance v0.0.0-20260504173044-ca14a8ca3299 h1:LNfQHFdj2hyJpG8ULAQXC2c9U3Htf33YLn5gU1/NmsM=
+github.com/getlantern/radiance v0.0.0-20260504173044-ca14a8ca3299/go.mod h1:7n9EA++kf14Qon02cjpkxM96H497HUfzm7KQQN5H8gA=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Picks up [radiance#456](https://github.com/getlantern/radiance/pull/456): the `x-lantern-client-country` header was being read from `settings.CountryCodeKey` (auto-populated from server config response, intended for issue reports) instead of `env.Country` (`RADIANCE_COUNTRY` env var). Every production client started sending the header on every `/config-new` request after the first response.

Server-side, this short-circuits `maxmind.LookupCountryASNState` and returns `bandit.asn=0` — silently breaking per-ASN EXP3.S learning.

## Server impact (from SigNoz, last 24h before the radiance fix)

- **~21.6%** of `/config-new` responses landed with `bandit.asn=0`
- **~82%** of those caused by this header (36k of 44k warns)
- **CN: ~100%** impact — every Chinese client broken at per-ASN bandit level
- **Rising 6× week-over-week** as the original radiance refactor (#370) rolled out

Refs [engineering#3398](https://github.com/getlantern/engineering/issues/3398).

## Test plan

- [x] `go mod tidy` clean; only `go.mod` + `go.sum` changed
- [x] `go build ./...` clean
- [ ] CI green
- [ ] After ship: SigNoz `"ASN resolved to 0"` warn rate should crater within hours of clients picking up this build, most dramatically in CN

🤖 Generated with [Claude Code](https://claude.com/claude-code)