### PR TITLE
Bump radiance to pick up unbounded dial watchdog

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260504173044-ca14a8ca3299
+	github.com/getlantern/radiance v0.0.0-20260504203153-371d9879d4cd
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0
@@ -172,7 +172,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 // indirect
 	github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40 // indirect
-	github.com/getlantern/lantern-box v0.0.76 // indirect
+	github.com/getlantern/lantern-box v0.0.77 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,8 +247,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/4
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40 h1:P5pkaBGxWOGBn7bKzjzdln/ro+ShG1RUbOuy+7pSzXE=
 github.com/getlantern/kindling v0.0.0-20260428171407-6143132aaf40/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
-github.com/getlantern/lantern-box v0.0.76 h1:SkSfkoYfZIXIyzte1+PXGX9PzdlNBKKwFt+fnCGkNAw=
-github.com/getlantern/lantern-box v0.0.76/go.mod h1:YV6+5bOdvw9rmc0cJoOTP7UaFt/6XWVOierv7KcfAkY=
+github.com/getlantern/lantern-box v0.0.77 h1:2b2TyrPXYHzIx1aPUvpE//AxoW0TMl/EF/bQHaZyfqw=
+github.com/getlantern/lantern-box v0.0.77/go.mod h1:YV6+5bOdvw9rmc0cJoOTP7UaFt/6XWVOierv7KcfAkY=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 h1:P9JX1yAu2uq3b5YiT0sLtHkTrkZuttV8gPZh81nUuag=
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260504173044-ca14a8ca3299 h1:LNfQHFdj2hyJpG8ULAQXC2c9U3Htf33YLn5gU1/NmsM=
-github.com/getlantern/radiance v0.0.0-20260504173044-ca14a8ca3299/go.mod h1:7n9EA++kf14Qon02cjpkxM96H497HUfzm7KQQN5H8gA=
+github.com/getlantern/radiance v0.0.0-20260504203153-371d9879d4cd h1:ieFZtg4GshMqgiTyI6lAjpcE8O3PTaUwTuw97RKfo1c=
+github.com/getlantern/radiance v0.0.0-20260504203153-371d9879d4cd/go.mod h1:CLnFP2zb1rx4xpgkxhdR3UERm4ypRWaYeNrBQPrpdns=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Bumps `github.com/getlantern/radiance` to the post-#457 commit so this build picks up [getlantern/lantern-box#252](https://github.com/getlantern/lantern-box/pull/252) — a passive `dialWatchdog` inside the unbounded outbound.

`go mod tidy` also moved the indirect `github.com/getlantern/lantern-box` from `v0.0.76` to `v0.0.77` automatically.

## What this gets us in the next client build

When the unbounded outbound's per-pairing dial latency degrades (rolling 10-dial window has zero dials under 1s **and** the most recent 5 are each over 5s), `lantern.log` starts showing:

```
level=WARN  pkg=lantern-box  msg="unbounded peer flagged unhealthy"
            reason="no fast dial in window and >=5 consecutive slow"
            median_slow=12.3s  trips_total=1  window_size=10
```

…and an info-level line when the pairing recovers (`unbounded peer recovered (fast dial seen)`). Purely observational in this version — no auto-reset action — so the worst case is structured-log noise we can grep, not a behavior change.

## Test plan

- [x] `go mod tidy` clean
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [ ] Once a build with this lands on a Lantern client, look for `unbounded peer flagged unhealthy` in `lantern.log` to confirm the symptom is being captured. A reasonable rate is the green light to start phase 2 (the broflake re-pairing API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)