### PR TITLE
Check in-flight in app purchase

### DIFF
--- a/lib/features/auth/confirm_email.dart
+++ b/lib/features/auth/confirm_email.dart
@@ -112,6 +112,19 @@ class ConfirmEmail extends HookConsumerWidget {
       appRouter.pop();
       return;
     }
+
+    /// Defensive: never delete a Pro account on back-press, even if every other
+    /// guard somehow missed this case. A successful Apple/Google IAP promotes
+    /// the legacy user to `pro` inline server-side, so a paid user that
+    /// reaches this screen is already Pro and must be preserved.
+    if (ref.read(isUserProProvider)) {
+      appLogger.info(
+        'Back press in ConfirmEmail with pro user; preserving account',
+      );
+      appRouter.pop();
+      return;
+    }
+
     if (authFlow != AuthFlow.signUp) {
       appRouter.pop();
       return;

--- a/lib/features/auth/create_password.dart
+++ b/lib/features/auth/create_password.dart
@@ -8,6 +8,7 @@ import 'package:lantern/core/widgets/password_criteria.dart';
 import 'package:lantern/core/keys/app_keys.dart';
 import 'package:lantern/features/auth/provider/auth_notifier.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/features/plans/provider/payment_notifier.dart';
 
 
 @RoutePage(name: 'CreatePassword')
@@ -112,6 +113,10 @@ class CreatePassword extends HookConsumerWidget {
         context.hideLoadingDialog();
         appLogger.info('Password created successfully');
         ref.read(appSettingProvider.notifier).setUserLoggedIn(true);
+        // Signup completed: release any payment-in-flight flag set by an IAP
+        // (or other payment) flow that routed the user here, so future
+        // unrelated signup back-presses are not misprotected.
+        ref.read(paymentSessionProvider.notifier).clearRedirect();
         resolveRoutes(context, ref);
       },
     );

--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -3,6 +3,7 @@ import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/extensions/user_data.dart';
 import 'package:lantern/core/models/user.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/features/plans/provider/payment_notifier.dart';
 import 'package:lantern/features/plans/provider/referral_notifier.dart';
 import 'package:lantern/features/vpn/provider/server_location_notifier.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
@@ -153,5 +154,8 @@ class HomeNotifier extends _$HomeNotifier {
   void clearLogoutData() {
     ref.read(referralProvider.notifier).resetReferral();
     ref.read(appSettingProvider.notifier).setUserLoggedIn(false);
+    // Defensive: a stale payment-in-flight flag would protect future
+    // unrelated signup back-presses from deleting orphaned anonymous accounts.
+    ref.read(paymentSessionProvider.notifier).clearRedirect();
   }
 }

--- a/lib/features/plans/plans.dart
+++ b/lib/features/plans/plans.dart
@@ -408,8 +408,9 @@ class _PlansState extends ConsumerState<Plans> {
 
     final appSetting = ref.read(appSettingProvider);
     if (appSetting.userLoggedIn) {
-      /// If user logged in and purchase is successful then check user account status
-      /// to reflect new purchase and send user to pro flow
+      /// Renewal: user is already logged in, so the back-press protection
+      /// the redirect flag was guarding is no longer relevant.
+      ref.read(paymentSessionProvider.notifier).clearRedirect();
       userRenewalFlow();
       return;
     }

--- a/lib/features/plans/plans.dart
+++ b/lib/features/plans/plans.dart
@@ -370,11 +370,17 @@ class _PlansState extends ConsumerState<Plans> {
 
   Future<void> startInAppPurchaseFlow(Plan plan) async {
     context.showLoadingDialog();
+    // Mark a payment as in flight so that ConfirmEmail's back-press guard
+    // (confirm_email.dart) preserves the anonymous account if the user
+    // backs out before signup completes — same protection Stripe and the
+    // external paymentRedirect flow already get.
+    ref.read(paymentSessionProvider.notifier).markRedirectInitiated();
     final payments = ref.read(paymentProvider.notifier);
     final result = await payments.startInAppPurchaseFlow(
       planId: plan.id,
       onSuccess: (purchase) => processPurchase(purchase, plan),
       onError: (error) {
+        ref.read(paymentSessionProvider.notifier).clearRedirect();
         if (!mounted) return;
         context.showSnackBar(error);
         appLogger.error('Error subscribing to plan: $error');
@@ -383,6 +389,7 @@ class _PlansState extends ConsumerState<Plans> {
     );
     if (!mounted) return;
     result.fold((error) {
+      ref.read(paymentSessionProvider.notifier).clearRedirect();
       context.hideLoadingDialog();
       context.showSnackBar(error.localizedErrorMessage);
       appLogger.error('Error subscribing to plan: $error');


### PR DESCRIPTION
This pull request adds additional state management to the in-app purchase flow to better handle payment sessions and anonymous account preservation. The main changes ensure that the app correctly tracks when a payment is in progress and clears this state on error, improving user experience and consistency with other payment flows.

**Payment session state management:**

* Marked the payment session as "redirect initiated" at the start of the in-app purchase flow to preserve the anonymous account if the user backs out before signup completes. This mirrors protections already in place for Stripe and external payment flows.
* Ensured the payment session redirect state is cleared both on error callbacks and when the purchase result contains an error, preventing stale state and potential user confusion. [[1]](diffhunk://#diff-1727c8d1d523ab2bce743d249079ab4d7bffe41b056451897c6928d3b96f0c56R373-R383) [[2]](diffhunk://#diff-1727c8d1d523ab2bce743d249079ab4d7bffe41b056451897c6928d3b96f0c56R392)