### PR TITLE
Bump radiance to fix Pro lost on upgrade (radiance #463)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260506142456-182a5c14342a
+	github.com/getlantern/radiance v0.0.0-20260506155156-d97729d3d176
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260504203153-371d9879d4cd
+	github.com/getlantern/radiance v0.0.0-20260506142456-182a5c14342a
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260506155156-d97729d3d176
+	github.com/getlantern/radiance v0.0.0-20260506160830-90ba96297da9
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260504203153-371d9879d4cd h1:ieFZtg4GshMqgiTyI6lAjpcE8O3PTaUwTuw97RKfo1c=
-github.com/getlantern/radiance v0.0.0-20260504203153-371d9879d4cd/go.mod h1:CLnFP2zb1rx4xpgkxhdR3UERm4ypRWaYeNrBQPrpdns=
+github.com/getlantern/radiance v0.0.0-20260506142456-182a5c14342a h1:oPzn8CmhoDNs+8MgBpWAQTzmZ8SK25uAjQhwy86R3Xs=
+github.com/getlantern/radiance v0.0.0-20260506142456-182a5c14342a/go.mod h1:CLnFP2zb1rx4xpgkxhdR3UERm4ypRWaYeNrBQPrpdns=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260506155156-d97729d3d176 h1:lPerrXCucyywPQZ2QV5fpUmREdMETK448mPOi2D+0C4=
-github.com/getlantern/radiance v0.0.0-20260506155156-d97729d3d176/go.mod h1:CLnFP2zb1rx4xpgkxhdR3UERm4ypRWaYeNrBQPrpdns=
+github.com/getlantern/radiance v0.0.0-20260506160830-90ba96297da9 h1:hzTz8kZnpLMo2NouNupcBcF5l2RVo4uKHsxg4QweUaY=
+github.com/getlantern/radiance v0.0.0-20260506160830-90ba96297da9/go.mod h1:CLnFP2zb1rx4xpgkxhdR3UERm4ypRWaYeNrBQPrpdns=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260506142456-182a5c14342a h1:oPzn8CmhoDNs+8MgBpWAQTzmZ8SK25uAjQhwy86R3Xs=
-github.com/getlantern/radiance v0.0.0-20260506142456-182a5c14342a/go.mod h1:CLnFP2zb1rx4xpgkxhdR3UERm4ypRWaYeNrBQPrpdns=
+github.com/getlantern/radiance v0.0.0-20260506155156-d97729d3d176 h1:lPerrXCucyywPQZ2QV5fpUmREdMETK448mPOi2D+0C4=
+github.com/getlantern/radiance v0.0.0-20260506155156-d97729d3d176/go.mod h1:CLnFP2zb1rx4xpgkxhdR3UERm4ypRWaYeNrBQPrpdns=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Picks up [`radiance#463`](https://github.com/getlantern/radiance/pull/463) at commit `182a5c1` to fix the v9.1.x **"Pro shown as expired after the update"** regression reported on Freshdesk #174455 / #174496 / #174515.

The radiance refactor in #370 (`restructure codebase around LocalBackend`) silently moved Android's settings.json from `<app.dataDir>/.lantern/settings.json` (v9.0.x) to `<app.dataDir>/.lantern/data/settings.json` (v9.1.x). Every existing install lost its persisted `user_id`, `device_id`, `jwt_token`, and `user_level` on first launch of v9.1.x — surfacing as "Pro expired" because the fresh client called `UserRecoverByDevice` against a brand-new device id and got back a fresh user.

## radiance #463 fix in two parts

1. `setupDirectories` honors the caller's path as-is again (drops the unconditional `maybeAddSuffix` calls #370 added).
2. One-shot migration in `InitSettings`: reads both `<dataDir>/settings.json` and `<dataDir>/data/settings.json` on first launch of the fixed client, prefers whichever actually has `user_level="pro"`, falls back to canonical otherwise. So any user already on v9.1.x gets their Pro state restored on the next upgrade regardless of which file holds the good state. 6 unit tests cover the migration paths.

## What this PR does

Single bump of `getlantern/radiance` in `go.mod` (and the corresponding `go.sum`) to commit `182a5c1` from the `fix/preserve-data-dir-path` branch. No other code changes.

## Test plan
- [ ] Build a nightly off this branch
- [ ] Manual Android upgrade test: install latest 9.1.5-beta on a real device with Pro, upgrade to a build off this branch, verify Pro is preserved
- [ ] Manual fresh-install test: install a build off this branch on a clean device, verify normal Pro purchase flow still works (migration is a no-op)
- [ ] Confirm no `/data` / `/logs` subdirectories are created under the app's data dir after upgrade

## Cut a nightly

Once approved, tag and cut a nightly so the fix lands for users currently affected on 9.1.5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)