### PR TITLE
Bump radiance to main (legacy YAML migration)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260506165909-b8f04e3a710e
+	github.com/getlantern/radiance v0.0.0-20260506180721-4445a2040ede
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260506165909-b8f04e3a710e h1:uFk5VhV43p2l6hyx9I43wl5vxsxQRj/gHBk9553TfmY=
-github.com/getlantern/radiance v0.0.0-20260506165909-b8f04e3a710e/go.mod h1:RG9PNWlBmS4HPFf6JTQ9CnsCD98zy75vvm7PnBIsdQI=
+github.com/getlantern/radiance v0.0.0-20260506180721-4445a2040ede h1:RCf7U3JiNDMuhbS/lPp4qP6CbA2xmXBXEVk4gvRMysM=
+github.com/getlantern/radiance v0.0.0-20260506180721-4445a2040ede/go.mod h1:RG9PNWlBmS4HPFf6JTQ9CnsCD98zy75vvm7PnBIsdQI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary
Bumps \`github.com/getlantern/radiance\` to \`4445a20\` — the latest \`origin/main\`. Single new PR since the previous bump (#8734):

- **#464** settings: also migrate from pre-9.x flashlight/lantern-client YAML

## What this unlocks
Fresh v9.x installs that previously upgraded from a pre-9.x flashlight/lantern-client now recover user_id / device_id / token / pro state from the old per-platform YAML:
- macOS: \`~/Library/Application Support/Lantern/settings.yaml\`
- Windows: \`%APPDATA%\\Lantern\\settings.yaml\`
- Linux: \`~/.config/lantern/settings.yaml\`
- iOS: \`<sandbox>/userconfig.yaml\`

(Android stored its state in an encrypted SQLite that can't be read from Go — that case still needs a Kotlin-side migration outside this package.)

## Diff
- \`radiance\` \`v0.0.0-20260506165909-b8f04e3a710e\` → \`v0.0.0-20260506180721-4445a2040ede\`
- No transitive bumps this round.

## Test plan
- [x] \`go build ./lantern-core/...\` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)