### PR TITLE
bump radiance to fdf5b21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260512203645-9de94642f8d6
+	github.com/getlantern/radiance v0.0.0-20260512232534-fdf5b21caa02
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260512203645-9de94642f8d6 h1:W7unKzr8ZEnKXsu5PPrB3V/n/lNpx2gVvzbrotYIiZk=
-github.com/getlantern/radiance v0.0.0-20260512203645-9de94642f8d6/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
+github.com/getlantern/radiance v0.0.0-20260512232534-fdf5b21caa02 h1:9DfkAkip/ZrwKacgNsXjmqCeK8b+llUHbT+Bb87UzRA=
+github.com/getlantern/radiance v0.0.0-20260512232534-fdf5b21caa02/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary
- Bumps `github.com/getlantern/radiance` from `9de9464` to `fdf5b21`

Includes radiance commits:
- `fdf5b21` backend: clear selected server when it's removed (#479)

## Test plan
- [ ] CI green