### PR TITLE
fix macos test

### DIFF
--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -704,6 +704,11 @@ internal enum SystemExtensionReconciler {
     }
 
     if current.matchesVersion(desired) {
+      if current.isUninstalling {
+        // Same-version copy is draining; the nil-hash fallback below would
+        // otherwise mis-classify it as .matched and leave it in place.
+        return .contentChange
+      }
       guard let currentHash = current.contentHash, let desiredHash = desired.contentHash else {
         return .matched
       }

--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -706,7 +706,7 @@ internal enum SystemExtensionReconciler {
     if current.matchesVersion(desired) {
       if current.isUninstalling {
         // Same-version copy is draining; the nil-hash fallback below would
-        // otherwise mis-classify it as .matched and leave it in place.
+        // otherwise misclassify it as .matched and leave it in place.
         return .contentChange
       }
       guard let currentHash = current.contentHash, let desiredHash = desired.contentHash else {

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -385,6 +385,10 @@ final class RunnerTests: XCTestCase {
       installed: [enabledUninstalling]
     )
 
+    XCTAssertEqual(
+      reconciliation.change, .contentChange,
+      "classifyChange must return .contentChange for an uninstalling same-version copy with a nil contentHash — otherwise the nil-hash fallback would mark it .matched and leave the draining extension in place"
+    )
     XCTAssertNotEqual(
       reconciliation.status, .activated,
       "An enabled+uninstalling extension with skipped hash must not be treated as activated"


### PR DESCRIPTION
This pull request makes a targeted improvement to the system extension reconciliation logic in `SystemExtensionManager.swift`. The main change ensures that when the currently installed system extension is in the process of uninstalling, it is properly detected as a content change rather than being incorrectly classified as matched.

**System extension reconciliation logic:**

* Updated the `.matchesVersion` check in the `SystemExtensionReconciler` to return `.contentChange` if the current extension is uninstalling, preventing misclassification as `.matched` and ensuring correct handling during the uninstall process.