### PR TITLE
deps: bump radiance to main (2026-05-13)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260513120333-8fd1b0335917
+	github.com/getlantern/radiance v0.0.0-20260513193454-271d3857b2a1
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260513120333-8fd1b0335917 h1:7rJL4TXNfaIqxBigae5T4hHiVLCz4EEP2PkyDrLCtmw=
-github.com/getlantern/radiance v0.0.0-20260513120333-8fd1b0335917/go.mod h1:oBXKRBE6qxdBmxnjV9NI3CSOSy4zDlm1f7haUVWpwBQ=
+github.com/getlantern/radiance v0.0.0-20260513193454-271d3857b2a1 h1:DydQGwsX0lkmfkKjGivJyVEMBqkpHrwDz8A1nFo1Fz8=
+github.com/getlantern/radiance v0.0.0-20260513193454-271d3857b2a1/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Bumps `github.com/getlantern/radiance` from `8fd1b0335917` to `271d3857b2a1` (main @ 2026-05-13).

Includes 6 radiance commits since the previous pin:

- getlantern/radiance#475 set max compressed size for issue report to 19.5
- getlantern/radiance#476 bump lantern-box to v0.0.82
- getlantern/radiance#477 settings: migrate v9.0.x Windows Pro state across cross-dir move
- getlantern/radiance#479 backend: clear selected server when it's removed
- getlantern/radiance#480 vpn: preserve manually-selected outbound across config refreshes
- getlantern/radiance#474 add support for restore purchase

`go.mod` + `go.sum` updated together (per our `go mod tidy`-before-commit rule).

## Test plan

- [ ] CI green
- [ ] Smoke test: connect on macOS, switch a manually-selected server, force a config refresh, confirm the selection survives (covers #480)
- [ ] Smoke test: report issue flow accepts a typical attachment under the new size cap (covers #475)
- [ ] Smoke test: restore purchase action works on iOS (covers #474)

🤖 Generated with [Claude Code](https://claude.com/claude-code)