### PR TITLE
Fix Android Alipay handoff from payment webview

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -164,6 +164,15 @@
             <action android:name="android.intent.action.PROCESS_TEXT" />
             <data android:mimeType="text/plain" />
         </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="alipays" />
+        </intent>
+        <intent>
+            <action android:name="android.intent.action.VIEW" />
+            <data android:scheme="alipay" />
+        </intent>
+        <package android:name="com.eg.android.AlipayGphone" />
     </queries>
 
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -1,5 +1,6 @@
 package org.getlantern.lantern.handler
 
+import android.content.ActivityNotFoundException
 import android.content.Context
 import android.content.Intent
 import android.content.pm.ApplicationInfo
@@ -9,6 +10,7 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.net.ConnectivityManager
 import android.net.NetworkCapabilities
+import android.net.Uri
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -47,6 +49,7 @@ enum class Methods(val method: String) {
     AcknowledgeInAppPurchase("acknowledgeInAppPurchase"),
     RestoreInAppPurchase("restoreInAppPurchase"),
     PaymentRedirect("paymentRedirect"),
+    LaunchExternalUrl("launchExternalUrl"),
     ReportIssue("reportIssue"),
 
     //Oauth
@@ -509,6 +512,18 @@ class MethodHandler : FlutterPlugin,
                             e.localizedMessage ?: "Please try again",
                             e
                         )
+                    }
+                }
+            }
+
+            Methods.LaunchExternalUrl.method -> {
+                scope.handleValue(result, "launch_external_url") {
+                    val url = call.arguments<String>()
+                    if (url.isNullOrBlank()) {
+                        throw IllegalArgumentException("External URL is required")
+                    }
+                    withContext(Dispatchers.Main) {
+                        launchExternalUrl(url)
                     }
                 }
             }
@@ -1255,6 +1270,46 @@ class MethodHandler : FlutterPlugin,
             }
         }
 
+    }
+
+    private fun launchExternalUrl(url: String): Boolean {
+        val rawUrl = url.trim()
+        if (rawUrl.isEmpty()) return false
+
+        return try {
+            if (rawUrl.startsWith("intent:", ignoreCase = true)) {
+                val intent = Intent.parseUri(rawUrl, Intent.URI_INTENT_SCHEME)
+                if (startExternalIntent(intent)) {
+                    true
+                } else {
+                    val fallbackUrl = intent.getStringExtra("browser_fallback_url")
+                    !fallbackUrl.isNullOrBlank() && launchExternalUrl(fallbackUrl)
+                }
+            } else {
+                startExternalIntent(Intent(Intent.ACTION_VIEW, Uri.parse(rawUrl)))
+            }
+        } catch (e: Exception) {
+            AppLogger.e(TAG, "Unable to launch external URL: ${e.message}")
+            false
+        }
+    }
+
+    private fun startExternalIntent(intent: Intent): Boolean {
+        intent.addCategory(Intent.CATEGORY_BROWSABLE)
+        intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        intent.component = null
+        intent.selector = null
+
+        return try {
+            appContext.startActivity(intent)
+            true
+        } catch (e: ActivityNotFoundException) {
+            AppLogger.d(TAG, "No activity found for external URL")
+            false
+        } catch (e: SecurityException) {
+            AppLogger.e(TAG, "Unable to launch external URL: ${e.message}")
+            false
+        }
     }
 
     private fun isAnotherVpnActive(context: Context): Boolean {

--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -155,6 +155,7 @@ class MethodHandler : FlutterPlugin,
     companion object {
         const val TAG = "A/MethodHandler"
         const val channelName = "org.getlantern.lantern/method"
+        private const val MAX_EXTERNAL_URL_FALLBACK_DEPTH = 3
     }
 
     private val scope = CoroutineScope(Dispatchers.IO + SupervisorJob())
@@ -1273,25 +1274,47 @@ class MethodHandler : FlutterPlugin,
     }
 
     private fun launchExternalUrl(url: String): Boolean {
-        val rawUrl = url.trim()
-        if (rawUrl.isEmpty()) return false
+        var currentUrl = url.trim()
+        if (currentUrl.isEmpty()) return false
 
-        return try {
-            if (rawUrl.startsWith("intent:", ignoreCase = true)) {
-                val intent = Intent.parseUri(rawUrl, Intent.URI_INTENT_SCHEME)
-                if (startExternalIntent(intent)) {
-                    true
-                } else {
-                    val fallbackUrl = intent.getStringExtra("browser_fallback_url")
-                    !fallbackUrl.isNullOrBlank() && launchExternalUrl(fallbackUrl)
-                }
-            } else {
-                startExternalIntent(Intent(Intent.ACTION_VIEW, Uri.parse(rawUrl)))
+        val visitedUrls = mutableSetOf<String>()
+        var fallbackDepth = 0
+
+        while (currentUrl.isNotEmpty()) {
+            if (!visitedUrls.add(currentUrl)) {
+                AppLogger.w(TAG, "Detected cycle in external URL fallback chain")
+                return false
             }
-        } catch (e: Exception) {
-            AppLogger.e(TAG, "Unable to launch external URL: ${e.message}")
-            false
+
+            try {
+                if (!currentUrl.startsWith("intent:", ignoreCase = true)) {
+                    return startExternalIntent(Intent(Intent.ACTION_VIEW, Uri.parse(currentUrl)))
+                }
+
+                val intent = Intent.parseUri(currentUrl, Intent.URI_INTENT_SCHEME)
+                if (startExternalIntent(intent)) {
+                    return true
+                }
+
+                val fallbackUrl = intent.getStringExtra("browser_fallback_url")?.trim()
+                if (fallbackUrl.isNullOrEmpty()) {
+                    return false
+                }
+
+                fallbackDepth += 1
+                if (fallbackDepth > MAX_EXTERNAL_URL_FALLBACK_DEPTH) {
+                    AppLogger.w(TAG, "External URL fallback chain exceeded max depth")
+                    return false
+                }
+
+                currentUrl = fallbackUrl
+            } catch (e: Exception) {
+                AppLogger.e(TAG, "Unable to launch external URL: ${e.message}")
+                return false
+            }
         }
+
+        return false
     }
 
     private fun startExternalIntent(intent: Intent): Boolean {

--- a/lib/core/utils/url_utils.dart
+++ b/lib/core/utils/url_utils.dart
@@ -21,6 +21,13 @@ class UrlUtils {
     'https',
     'javascript',
   };
+  // Keep this list intentionally narrow. These are the schemes we currently
+  // need for payment app handoff from the in-app webview.
+  static const Set<String> _externalAppSchemes = {
+    'alipays',
+    'intent',
+    'market',
+  };
 
   static String normalizeWebviewUrl(String url) => url.trim();
 
@@ -41,7 +48,10 @@ class UrlUtils {
 
   static bool shouldOpenExternallyFromWebView(Uri uri) {
     final scheme = uri.scheme.toLowerCase();
-    return scheme.isNotEmpty && !_webviewHandledSchemes.contains(scheme);
+    if (scheme.isEmpty || _webviewHandledSchemes.contains(scheme)) {
+      return false;
+    }
+    return _externalAppSchemes.contains(scheme);
   }
 
   static Future<bool> launchExternalAppUrl(Uri uri) async {

--- a/lib/core/utils/url_utils.dart
+++ b/lib/core/utils/url_utils.dart
@@ -2,11 +2,26 @@ import 'dart:io';
 
 import 'package:desktop_webview_window/desktop_webview_window.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:lantern/core/common/common.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UrlUtils {
+  static const MethodChannel _methodChannel = MethodChannel(
+    'org.getlantern.lantern/method',
+  );
+  static const Set<String> _webviewHandledSchemes = {
+    'about',
+    'blob',
+    'chrome',
+    'data',
+    'file',
+    'http',
+    'https',
+    'javascript',
+  };
+
   static String normalizeWebviewUrl(String url) => url.trim();
 
   static bool _isSupportedWebviewUri(Uri uri) {
@@ -22,6 +37,39 @@ class UrlUtils {
       return false;
     }
     return _isSupportedWebviewUri(uri);
+  }
+
+  static bool shouldOpenExternallyFromWebView(Uri uri) {
+    final scheme = uri.scheme.toLowerCase();
+    return scheme.isNotEmpty && !_webviewHandledSchemes.contains(scheme);
+  }
+
+  static Future<bool> launchExternalAppUrl(Uri uri) async {
+    if (PlatformUtils.isAndroid) {
+      final launched = await _methodChannel.invokeMethod<bool>(
+        'launchExternalUrl',
+        uri.toString(),
+      );
+      return launched ?? false;
+    }
+    return launchUrl(uri, mode: LaunchMode.externalApplication);
+  }
+
+  static Future<bool> tryLaunchExternalAppUrl(
+    BuildContext context,
+    Uri uri,
+  ) async {
+    try {
+      final ok = await launchExternalAppUrl(uri);
+      if (!ok) throw 'Failed to open ${uri.toString()}';
+      return true;
+    } catch (e, st) {
+      appLogger.error('Unable to launch external app URL', e, st);
+      if (context.mounted) {
+        context.showSnackBar('could_not_open_url'.i18n);
+      }
+      return false;
+    }
   }
 
   static Future<void> openUrl(String url) async {

--- a/lib/core/widgets/app_webview.dart
+++ b/lib/core/widgets/app_webview.dart
@@ -80,7 +80,9 @@ class _InnerWebViewState extends ConsumerState<_InnerWebView> {
     hardwareAcceleration: true,
     // userAgent: _getUserAgent(),
     supportZoom: true,
-    preferredContentMode: UserPreferredContentMode.DESKTOP,
+    preferredContentMode: PlatformUtils.isMobile
+        ? UserPreferredContentMode.MOBILE
+        : UserPreferredContentMode.DESKTOP,
   );
   late final URLRequest _initialRequest;
 
@@ -108,6 +110,10 @@ class _InnerWebViewState extends ConsumerState<_InnerWebView> {
           return false;
         }
         if (req.url != null) {
+          final uri = Uri.tryParse(req.url.toString());
+          if (uri != null && await _consumeExternalAppUrlIfNeeded(uri)) {
+            return true;
+          }
           await controller.loadUrl(urlRequest: req);
           return true;
         }
@@ -240,6 +246,10 @@ class _InnerWebViewState extends ConsumerState<_InnerWebView> {
       return NavigationActionPolicy.CANCEL;
     }
 
+    if (await _consumeExternalAppUrlIfNeeded(u)) {
+      return NavigationActionPolicy.CANCEL;
+    }
+
     if (isLanternHost(u.host) && (u.path == '/' || u.path.isEmpty)) {
       return NavigationActionPolicy.ALLOW;
     }
@@ -247,5 +257,25 @@ class _InnerWebViewState extends ConsumerState<_InnerWebView> {
     appLogger.debug("shouldOverrideUrlLoading: $uri");
 
     return NavigationActionPolicy.ALLOW;
+  }
+
+  Future<bool> _consumeExternalAppUrlIfNeeded(Uri uri) async {
+    if (!UrlUtils.shouldOpenExternallyFromWebView(uri)) {
+      return false;
+    }
+
+    ref.read(webViewLoadingProvider.notifier).stop();
+    final launched = await UrlUtils.tryLaunchExternalAppUrl(context, uri);
+    final host = uri.host.isEmpty ? '<none>' : uri.host;
+    if (launched) {
+      appLogger.info(
+        'Webview opened external app URL: scheme=${uri.scheme}, host=$host',
+      );
+    } else {
+      appLogger.warning(
+        'Webview could not open external app URL: scheme=${uri.scheme}, host=$host',
+      );
+    }
+    return true;
   }
 }

--- a/test/core/utils/url_utils_test.dart
+++ b/test/core/utils/url_utils_test.dart
@@ -44,5 +44,20 @@ void main() {
         isTrue,
       );
     });
+
+    test('keeps unrelated custom schemes out of external dispatch', () {
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(
+          Uri.parse('mailto:support@lantern.io'),
+        ),
+        isFalse,
+      );
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(
+          Uri.parse('whatsapp://send?text=hi'),
+        ),
+        isFalse,
+      );
+    });
   });
 }

--- a/test/core/utils/url_utils_test.dart
+++ b/test/core/utils/url_utils_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/utils/url_utils.dart';
+
+void main() {
+  group('UrlUtils.shouldOpenExternallyFromWebView', () {
+    test('keeps normal webview schemes inside the webview', () {
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(
+          Uri.parse('https://lantern.io/checkout'),
+        ),
+        isFalse,
+      );
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(Uri.parse('about:blank')),
+        isFalse,
+      );
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(
+          Uri.parse('data:text/plain,payment'),
+        ),
+        isFalse,
+      );
+    });
+
+    test('opens payment app schemes outside the webview', () {
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(
+          Uri.parse('alipays://platformapi/startapp'),
+        ),
+        isTrue,
+      );
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(
+          Uri.parse(
+            'intent://platformapi/startapp#Intent;scheme=alipays;package=com.eg.android.AlipayGphone;end',
+          ),
+        ),
+        isTrue,
+      );
+      expect(
+        UrlUtils.shouldOpenExternallyFromWebView(
+          Uri.parse('market://details?id=com.eg.android.AlipayGphone'),
+        ),
+        isTrue,
+      );
+    });
+  });
+}


### PR DESCRIPTION
Updates the payment webview to use mobile content mode on Android and launch external app schemes/intents like Alipay, so Shepherd checkout can open the Alipay app instead of getting stuck in the desktop QR flow.