### PR TITLE
ci: stop bumping patch for nightly builds (fixes macOS sysext downgrade trap)

### DIFF
--- a/scripts/ci/version.sh
+++ b/scripts/ci/version.sh
@@ -13,7 +13,8 @@ set -euo pipefail
 # Examples:
 #   version.sh validate v1.2.3          → 1.2.3
 #   version.sh validate v1.2.3-beta     → 1.2.3-beta
-#   version.sh generate nightly         → 1.2.4-abc123-20260206T120000Z
+#   version.sh generate nightly         → 1.2.3-abc123-20260206T120000Z
+#   version.sh generate beta            → 1.2.4-beta
 #   version.sh extract 1.2.3-beta       → 1.2.3
 
 COMMAND="${1:?Command required: validate, generate, or extract}"
@@ -126,12 +127,23 @@ generate)
       exit 1
     fi
 
+    # Nightlies reuse the latest tagged base version — they do NOT bump the
+    # patch. Uniqueness comes from the SHA+timestamp suffix in the tag, and
+    # from CFBundleVersion (github.run_number) at pubspec-write time.
+    #
+    # Why: macOS pins system-extension upgrade/downgrade decisions on
+    # CFBundleShortVersionString. If a nightly advertises a higher base
+    # than the latest beta (e.g. beta 9.1.9 → nightly 9.1.10), a user who
+    # tests the nightly and then reverts to the beta hits the OS downgrade
+    # path, which returns OSSystemExtensionErrorDomain code 4 and bricks
+    # the network extension. Keeping the base equal makes the transition
+    # a same-version content change, which the reconciler handles via
+    # .deactivateThenActivate. See engineering#3474 bug #5.
     BASELINE=$(max_semver "${PROD:-0.0.0}" "${BETA:-0.0.0}")
-    NEXT=$(increment_patch "$BASELINE")
     SHA=$(git rev-parse --short=7 HEAD)
     TIMESTAMP=$(date -u +%Y%m%dT%H%M%SZ)
 
-    echo "${NEXT}-${SHA}-${TIMESTAMP}"
+    echo "${BASELINE}-${SHA}-${TIMESTAMP}"
     ;;
 
   beta)


### PR DESCRIPTION
## Summary

- `scripts/ci/version.sh generate nightly` no longer increments the patch. Nightlies now reuse the most recent tagged base version (`9.1.9-<sha>-<timestamp>` instead of `9.1.10-<sha>-<timestamp>`).
- Beta version generation is unchanged — it still bumps patch.
- Uniqueness for nightlies continues to come from the SHA + timestamp in the tag suffix and from `CFBundleVersion` (`github.run_number`), which is monotonic across all workflow runs.

## Why

macOS pins system-extension upgrade/downgrade decisions on `CFBundleShortVersionString`. With the old behavior, a nightly built ~7 hours after `v9.1.9-beta` advertised `CFBundleShortVersionString = 9.1.10`. Users who installed that nightly and then reverted to the `v9.1.9-beta` DMG triggered the OS downgrade path, which returned `OSSystemExtensionErrorDomain` code 4 (`extensionNotFound`) on activation and bricked the network extension — reproduced as bug #5 in [getlantern/engineering#3474](https://github.com/getlantern/engineering/issues/3474) (Ryan).

Keeping the nightly base equal to the latest beta makes the beta ↔ nightly transition a same-version content change. The reconciler updates in #8745 and #8751 already handle that path correctly via `.deactivateThenActivate`.

```mermaid
sequenceDiagram
    autonumber
    participant CI as Nightly CI<br/>scripts/ci/version.sh
    participant Pubspec as pubspec.yaml<br/>release.yml:226
    participant macOS as macOS SystemExtensions<br/>(activation registry)
    participant User as Ryan's Mac

    Note over CI,Pubspec: BEFORE this PR
    rect rgba(255, 200, 200, 0.3)
        CI->>Pubspec: generate nightly → 9.1.10-sha-ts ⚠️<br/>(patch bumped past v9.1.9-beta)
        Pubspec->>User: 9.1.10 DMG installed
        User->>macOS: activate org.getlantern.lantern.PacketTunnel<br/>CFBundleShortVersionString=9.1.10
        Note over macOS: extension registered ✅
        User->>User: revert to v9.1.9-beta DMG
        User->>macOS: activate (CFBundleShortVersionString=9.1.9)
        Note over macOS: downgrade detected →<br/>OSSystemExtensionErrorDomain code 4 🐛
    end

    Note over CI,Pubspec: AFTER this PR
    CI->>Pubspec: generate nightly → 9.1.9-sha-ts<br/>(same base as latest tag)
    Pubspec->>User: nightly DMG (CFBundleShortVersionString=9.1.9)
    User->>macOS: activate (same base)
    Note over macOS: classifyChange → .contentChange<br/>→ deactivateThenActivate ✅
```

## Test plan

- [x] `scripts/ci/version.sh generate nightly` returns `9.1.9-<sha>-<timestamp>` against current tags (verified locally — `9.1.9-41ae88c-20260514T170704Z`)
- [x] `scripts/ci/version.sh generate beta` still returns `9.1.10-beta` (unchanged)
- [x] `scripts/ci/version.sh extract 9.1.9-<sha>-<timestamp>` returns `9.1.9`
- [x] `scripts/ci/version.sh validate 9.1.9-<sha>-<timestamp>` passes (the base 9.1.9 is not less than the highest existing version 9.1.9)
- [ ] Next scheduled nightly tags as `v9.1.9-<sha>-<timestamp>` and the resulting pubspec is `9.1.9+<run_number>`
- [ ] Manual repro of the downgrade: install nightly, then install v9.1.9-beta, confirm system extension activates without error 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)