### PR TITLE
macos: recover from stale-registry extensionNotFound on sysext activation

### DIFF
--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -3,6 +3,26 @@ import CryptoKit
 import Foundation
 import SystemExtensions
 
+/// Decides whether a failed system extension request should trigger a
+/// stale-registry recovery attempt. macOS occasionally surfaces
+/// `extensionNotFound` on an activation request when its registry holds a
+/// reference to a previously-installed extension that no longer matches the
+/// app on disk — e.g. after the .app bundle was replaced under an existing
+/// install. Submitting a deactivation request first clears that state and
+/// gives the subsequent activation a clean slot. The decision is gated to a
+/// single attempt per session so a persistent failure doesn't loop.
+internal enum StaleRegistryRecovery {
+  static func shouldRecover(
+    from error: NSError,
+    activationFailed: Bool,
+    alreadyAttempted: Bool
+  ) -> Bool {
+    guard !alreadyAttempted, activationFailed else { return false }
+    return error.domain == OSSystemExtensionErrorDomain
+      && error.code == OSSystemExtensionError.extensionNotFound.rawValue
+  }
+}
+
 class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
 
   static let shared = SystemExtensionManager()
@@ -24,6 +44,12 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
   @Published private(set) var initialized = false
 
   @Published private(set) var status: ExtensionStatus = .notInstalled
+
+  /// Set when we've issued a stale-registry recovery (deactivate-then-activate
+  /// in response to `extensionNotFound`). Reset on the next successful
+  /// completion. Single-shot per session to prevent an infinite retry loop if
+  /// the same error reproduces after the recovery deactivation.
+  private var didAttemptStaleRegistryRecovery = false
 
   override init() {
     super.init()
@@ -84,12 +110,21 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
       switch context {
       case .deactivateThenActivate(_, let activateAfter):
         if activateAfter {
+          // Mid-flow: the recovery's deactivation just finished, the
+          // activation it queued hasn't run yet. Do NOT clear the recovery
+          // latch here — if the upcoming activation also fails with
+          // extensionNotFound, we must surface that as a real error
+          // instead of re-entering the recovery loop.
           submitActivationRequest(
             reason: "activating bundled extension after removing mismatched version")
         } else {
+          didAttemptStaleRegistryRecovery = false
           submitPropertiesRequest(context: .inspectStatus)
         }
-      case .inspectStatus, .reconcile, .activate:
+      case .activate:
+        didAttemptStaleRegistryRecovery = false
+        submitPropertiesRequest(context: .inspectStatus)
+      case .inspectStatus, .reconcile:
         submitPropertiesRequest(context: .inspectStatus)
       }
     case .willCompleteAfterReboot:
@@ -127,6 +162,21 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
         "System extension request ended without applying changes: context=\(context?.logDescription ?? "unknown") error=\(nsError.localizedDescription)"
       )
       submitPropertiesRequest(context: .inspectStatus)
+      return
+    }
+
+    if StaleRegistryRecovery.shouldRecover(
+      from: nsError,
+      activationFailed: context?.isActivation ?? false,
+      alreadyAttempted: didAttemptStaleRegistryRecovery)
+    {
+      didAttemptStaleRegistryRecovery = true
+      appLogger.info(
+        "Activation failed with extensionNotFound — attempting stale-registry recovery via deactivate-then-activate (context=\(context?.logDescription ?? "unknown"))"
+      )
+      submitDeactivationRequest(
+        reason: "stale-registry recovery after extensionNotFound",
+        activateAfter: true)
       return
     }
 
@@ -316,6 +366,11 @@ private enum RequestContext: Equatable {
   case reconcile
   case activate(reason: String)
   case deactivateThenActivate(reason: String, activateAfter: Bool)
+
+  var isActivation: Bool {
+    if case .activate = self { return true }
+    return false
+  }
 
   var logDescription: String {
     switch self {

--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -110,18 +110,20 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
       switch context {
       case .deactivateThenActivate(_, let activateAfter):
         if activateAfter {
-          // Mid-flow: the recovery's deactivation just finished, the
-          // activation it queued hasn't run yet. Do NOT clear the recovery
-          // latch here — if the upcoming activation also fails with
-          // extensionNotFound, we must surface that as a real error
-          // instead of re-entering the recovery loop.
           submitActivationRequest(
             reason: "activating bundled extension after removing mismatched version")
         } else {
-          didAttemptStaleRegistryRecovery = false
           submitPropertiesRequest(context: .inspectStatus)
         }
       case .activate:
+        // Activation succeeded — recovery is either complete or wasn't
+        // needed. Clear the latch so a future trap (after the user
+        // relaunches) can attempt recovery again. The latch is
+        // intentionally NOT cleared elsewhere: a successful manual
+        // deactivation doesn't re-arm recovery, and the recovery's own
+        // intermediate deactivation must leave it set so a failure of the
+        // post-recovery activation surfaces as a real error rather than
+        // re-entering the loop.
         didAttemptStaleRegistryRecovery = false
         submitPropertiesRequest(context: .inspectStatus)
       case .inspectStatus, .reconcile:

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -1,5 +1,6 @@
 @testable import Lantern
 import Foundation
+import SystemExtensions
 import XCTest
 
 final class RunnerTests: XCTestCase {
@@ -396,6 +397,101 @@ final class RunnerTests: XCTestCase {
     XCTAssertNotEqual(
       reconciliation.action, .none,
       "Reconciler must take action rather than leaving a draining extension in place"
+    )
+  }
+
+  // MARK: - StaleRegistryRecovery
+
+  // Activation failed with extensionNotFound (code 4) and recovery has not
+  // been attempted yet — should trigger a deactivate-then-activate recovery.
+  func testStaleRegistryRecoveryFiresOnExtensionNotFoundDuringActivation() {
+    let error = NSError(
+      domain: OSSystemExtensionErrorDomain,
+      code: OSSystemExtensionError.extensionNotFound.rawValue
+    )
+    XCTAssertTrue(
+      StaleRegistryRecovery.shouldRecover(
+        from: error,
+        activationFailed: true,
+        alreadyAttempted: false
+      )
+    )
+  }
+
+  // Single-shot: once recovery has been attempted in this session, a second
+  // extensionNotFound must not trigger another recovery — otherwise we'd
+  // loop indefinitely if the deactivation didn't actually clear the state.
+  func testStaleRegistryRecoverySkipsSecondAttempt() {
+    let error = NSError(
+      domain: OSSystemExtensionErrorDomain,
+      code: OSSystemExtensionError.extensionNotFound.rawValue
+    )
+    XCTAssertFalse(
+      StaleRegistryRecovery.shouldRecover(
+        from: error,
+        activationFailed: true,
+        alreadyAttempted: true
+      )
+    )
+  }
+
+  // Other OSSystemExtensionError codes (missingEntitlement, codeSignatureInvalid,
+  // etc.) are real, distinct failures that recovery can't paper over. Only
+  // extensionNotFound is the registry-state signal we want to retry through.
+  func testStaleRegistryRecoveryIgnoresOtherErrorCodes() {
+    let codes: [Int] = [
+      OSSystemExtensionError.missingEntitlement.rawValue,
+      OSSystemExtensionError.codeSignatureInvalid.rawValue,
+      OSSystemExtensionError.validationFailed.rawValue,
+      OSSystemExtensionError.unsupportedParentBundleLocation.rawValue,
+    ]
+    for code in codes {
+      let error = NSError(domain: OSSystemExtensionErrorDomain, code: code)
+      XCTAssertFalse(
+        StaleRegistryRecovery.shouldRecover(
+          from: error,
+          activationFailed: true,
+          alreadyAttempted: false
+        ),
+        "Should not recover from error code \(code) — that's a distinct failure mode"
+      )
+    }
+  }
+
+  // Recovery is scoped to activation requests. If a properties-query or
+  // deactivation fails with extensionNotFound, we should not attempt to
+  // recover via a second deactivation — those request types don't suffer
+  // from the same stale-activation-slot bug, and retrying would mask real
+  // errors.
+  func testStaleRegistryRecoveryDoesNotFireForNonActivationContexts() {
+    let error = NSError(
+      domain: OSSystemExtensionErrorDomain,
+      code: OSSystemExtensionError.extensionNotFound.rawValue
+    )
+    XCTAssertFalse(
+      StaleRegistryRecovery.shouldRecover(
+        from: error,
+        activationFailed: false,
+        alreadyAttempted: false
+      )
+    )
+  }
+
+  // Non-OSSystemExtensionError domain errors (e.g. networking, file IO)
+  // bubbling up here would be unexpected, but if they do we should not
+  // attempt recovery — the deactivate-then-activate path only makes sense
+  // for OS-registry inconsistencies.
+  func testStaleRegistryRecoveryRequiresOSSystemExtensionErrorDomain() {
+    let error = NSError(
+      domain: "SomeOtherDomain",
+      code: OSSystemExtensionError.extensionNotFound.rawValue
+    )
+    XCTAssertFalse(
+      StaleRegistryRecovery.shouldRecover(
+        from: error,
+        activationFailed: true,
+        alreadyAttempted: false
+      )
     )
   }
 


### PR DESCRIPTION
## Summary

- On the first activation request that fails with `OSSystemExtensionErrorDomain` code 4 (`extensionNotFound`), submit a deactivation first (clears the OS's zombie registry slot), then retry activation via the existing `.deactivateThenActivate(activateAfter: true)` flow.
- Single-shot per app session: if the recovery's deactivation-then-activation also fails with code 4, surface the error as usual instead of looping.
- Decision logic extracted to a pure helper (`StaleRegistryRecovery.shouldRecover`) so RunnerTests can exercise it directly without mocking the system-extension framework.

## Why

Reproduced as bug #5 in [getlantern/engineering#3474](https://github.com/getlantern/engineering/issues/3474). When the `.app` bundle is replaced under an active system extension (most commonly: user drags a different-version DMG over `/Applications/Lantern.app`), macOS drops its outer view of the previous extension while keeping internal state that blocks a fresh activation of the same bundle ID. On next launch the OS reports `notInstalled`, the reconciler submits an activation request, and macOS returns code 4 — leaving the user with no network extension and no recovery path inside the app.

Submitting a deactivation request first clears that residual state. Ryan's logs at 2026-05-14 13:40–13:47 show this exact sequence: `notInstalled` on launch, `activationRequest` → ~9 s wait → error 4, with retries getting the same result. This change inserts a recovery deactivation between the initial activation failure and the give-up path.

```mermaid
sequenceDiagram
    autonumber
    participant App as SystemExtensionManager<br/>SystemExtensionManager.swift
    participant OS as macOS<br/>OSSystemExtensionManager

    Note over App,OS: Before this PR (Ryan's logs)
    App->>OS: activationRequest<br/>SystemExtensionManager.swift:211
    Note over OS: registry holds stale<br/>reference from prior install 🐛
    OS-->>App: didFailWithError<br/>extensionNotFound (code 4)
    rect rgba(255, 200, 200, 0.3)
        Note over App: updateStatus(.error)<br/>SystemExtensionManager.swift:179 — user stuck
    end

    Note over App,OS: After this PR
    App->>OS: activationRequest
    OS-->>App: didFailWithError code 4
    Note over App: StaleRegistryRecovery.shouldRecover → true ⚠️<br/>didAttemptStaleRegistryRecovery = true
    App->>OS: deactivationRequest<br/>(activateAfter: true)
    OS-->>App: didFinishWithResult .completed
    Note over App: latch NOT reset — mid-flow
    App->>OS: activationRequest<br/>(retry)
    OS-->>App: didFinishWithResult .completed
    Note over App: latch reset ✅<br/>status → .activated
```

## Test plan

- [x] `RunnerTests.testStaleRegistryRecoveryFiresOnExtensionNotFoundDuringActivation` — activation + code 4 + no prior attempt → recover
- [x] `RunnerTests.testStaleRegistryRecoverySkipsSecondAttempt` — single-shot loop guard
- [x] `RunnerTests.testStaleRegistryRecoveryIgnoresOtherErrorCodes` — missingEntitlement, codeSignatureInvalid, validationFailed, unsupportedParentBundleLocation all skip recovery
- [x] `RunnerTests.testStaleRegistryRecoveryDoesNotFireForNonActivationContexts` — recovery is activation-scoped
- [x] `RunnerTests.testStaleRegistryRecoveryRequiresOSSystemExtensionErrorDomain` — other error domains pass through
- [ ] Manual repro of Ryan's scenario: install nightly with higher CFBundleShortVersionString, then install v9.1.9-beta DMG, confirm the recovery flow activates the extension without leaving the user stuck

## Notes

- The latch is reset only when an *activation* request completes — not when the recovery's intermediate deactivation completes — so the post-recovery activation, if it also fails, is treated as a real error rather than triggering a second recovery.
- The recovery only fires for activation contexts. A failed properties query or a failed user-triggered deactivation will not pre-emptively submit another deactivation — those request types don't suffer from the stale-activation-slot bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)