### PR TITLE
Prevent multiple Lantern instances on Windows

### DIFF
--- a/windows/runner/CMakeLists.txt
+++ b/windows/runner/CMakeLists.txt
@@ -9,6 +9,7 @@ project(runner LANGUAGES CXX)
 add_executable(${BINARY_NAME} WIN32
   "flutter_window.cpp"
   "main.cpp"
+  "single_instance.cpp"
   "utils.cpp"
   "win32_window.cpp"
   "${FLUTTER_MANAGED_DIR}/generated_plugin_registrant.cc"

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -3,7 +3,15 @@
 #include <windows.h>
 
 #include "flutter_window.h"
+#include "single_instance.h"
 #include "utils.h"
+
+namespace {
+
+constexpr const wchar_t kSingleInstanceMutexName[] =
+    L"Local\\org.getlantern.lantern.single-instance";
+
+}  // namespace
 
 int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                       _In_ wchar_t *command_line, _In_ int show_command) {
@@ -11,6 +19,15 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // new console when running with a debugger.
   if (!::AttachConsole(ATTACH_PARENT_PROCESS) && ::IsDebuggerPresent()) {
     CreateAndAttachConsole();
+  }
+
+  SingleInstanceLock single_instance(kSingleInstanceMutexName);
+  if (!single_instance.IsPrimaryInstance()) {
+    ActivateExistingLanternWindow();
+    return EXIT_SUCCESS;
+  }
+  if (ActivateExistingLanternWindow()) {
+    return EXIT_SUCCESS;
   }
 
   // Initialize COM, so that it is available for use in the library and/or

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -10,6 +10,11 @@ namespace {
 
 constexpr const wchar_t kSingleInstanceMutexName[] =
     L"Local\\org.getlantern.lantern.single-instance";
+constexpr const wchar_t kSingleInstanceReadyEventName[] =
+    L"Local\\org.getlantern.lantern.window-ready";
+constexpr DWORD kWindowReadyTimeoutMs = 5000;
+constexpr DWORD kActivationRetryTimeoutMs = 1000;
+constexpr DWORD kActivationRetryIntervalMs = 100;
 
 }  // namespace
 
@@ -21,10 +26,14 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
     CreateAndAttachConsole();
   }
 
+  SingleInstanceReadyEvent window_ready(kSingleInstanceReadyEventName);
   SingleInstanceLock single_instance(kSingleInstanceMutexName);
   if (!single_instance.IsPrimaryInstance()) {
-    ActivateExistingLanternWindow();
-    return EXIT_SUCCESS;
+    window_ready.Wait(kWindowReadyTimeoutMs);
+    return ActivateExistingLanternWindowWithRetry(kActivationRetryTimeoutMs,
+                                                  kActivationRetryIntervalMs)
+               ? EXIT_SUCCESS
+               : EXIT_FAILURE;
   }
   if (ActivateExistingLanternWindow()) {
     return EXIT_SUCCESS;
@@ -48,6 +57,7 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
     return EXIT_FAILURE;
   }
   window.SetQuitOnClose(true);
+  window_ready.Signal();
 
   ::MSG msg;
   while (::GetMessage(&msg, nullptr, 0, 0)) {

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -35,9 +35,9 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
                ? EXIT_SUCCESS
                : EXIT_FAILURE;
   }
-  if (ActivateExistingLanternWindow()) {
-    return EXIT_SUCCESS;
-  }
+  // If we acquire the mutex, start this build. Normal installer upgrades close
+  // running Lantern instances before launch; handing off here could silently
+  // keep a pre-single-instance build alive.
 
   // Initialize COM, so that it is available for use in the library and/or
   // plugins.

--- a/windows/runner/single_instance.cpp
+++ b/windows/runner/single_instance.cpp
@@ -1,0 +1,107 @@
+#include "single_instance.h"
+
+#include "app_links/app_links_plugin_c_api.h"
+#include "win32_window.h"
+
+namespace {
+
+HWND FindExistingLanternWindow() {
+  if (HWND window = FindWindowW(Win32Window::GetWindowClassName(), nullptr)) {
+    return window;
+  }
+
+  // Older builds used Flutter's default class name before the single-instance
+  // guard existed. Keep these fallbacks so upgrading while Lantern is already
+  // running still activates that window instead of opening a duplicate.
+  if (HWND window = FindWindowW(L"FLUTTER_RUNNER_WIN32_WINDOW", L"Lantern")) {
+    return window;
+  }
+  return FindWindowW(L"FLUTTER_RUNNER_WIN32_WINDOW", L"lantern");
+}
+
+void FlashTaskbar(HWND window) {
+  FLASHWINFO flash_info = {};
+  flash_info.cbSize = sizeof(flash_info);
+  flash_info.hwnd = window;
+  flash_info.dwFlags = FLASHW_TRAY | FLASHW_TIMERNOFG;
+  flash_info.uCount = 3;
+  FlashWindowEx(&flash_info);
+}
+
+void AttachThreadInputIfNeeded(DWORD current_thread, DWORD target_thread,
+                               BOOL attach) {
+  if (target_thread != 0 && target_thread != current_thread) {
+    AttachThreadInput(current_thread, target_thread, attach);
+  }
+}
+
+}  // namespace
+
+SingleInstanceLock::SingleInstanceLock(const wchar_t* mutex_name) {
+  mutex_ = CreateMutexW(nullptr, TRUE, mutex_name);
+  const DWORD last_error = GetLastError();
+
+  if (mutex_ == nullptr) {
+    is_primary_instance_ = last_error != ERROR_ACCESS_DENIED;
+    return;
+  }
+
+  is_primary_instance_ = last_error != ERROR_ALREADY_EXISTS;
+}
+
+SingleInstanceLock::~SingleInstanceLock() {
+  if (mutex_ == nullptr) {
+    return;
+  }
+
+  if (is_primary_instance_) {
+    ReleaseMutex(mutex_);
+  }
+  CloseHandle(mutex_);
+}
+
+bool SingleInstanceLock::IsPrimaryInstance() const {
+  return is_primary_instance_;
+}
+
+bool ActivateExistingLanternWindow() {
+  HWND existing_window = FindExistingLanternWindow();
+  if (existing_window == nullptr) {
+    return false;
+  }
+
+  SendAppLink(existing_window);
+
+  if (IsIconic(existing_window)) {
+    ShowWindow(existing_window, SW_RESTORE);
+  } else {
+    ShowWindow(existing_window, SW_SHOW);
+  }
+
+  const DWORD current_thread = GetCurrentThreadId();
+  const HWND foreground_window = GetForegroundWindow();
+  const DWORD foreground_thread =
+      foreground_window == nullptr
+          ? 0
+          : GetWindowThreadProcessId(foreground_window, nullptr);
+  const DWORD target_thread = GetWindowThreadProcessId(existing_window, nullptr);
+
+  AttachThreadInputIfNeeded(current_thread, foreground_thread, TRUE);
+  if (target_thread != foreground_thread) {
+    AttachThreadInputIfNeeded(current_thread, target_thread, TRUE);
+  }
+
+  BringWindowToTop(existing_window);
+  const bool activated = SetForegroundWindow(existing_window) != 0;
+  SetFocus(existing_window);
+
+  if (target_thread != foreground_thread) {
+    AttachThreadInputIfNeeded(current_thread, target_thread, FALSE);
+  }
+  AttachThreadInputIfNeeded(current_thread, foreground_thread, FALSE);
+
+  if (!activated) {
+    FlashTaskbar(existing_window);
+  }
+  return true;
+}

--- a/windows/runner/single_instance.cpp
+++ b/windows/runner/single_instance.cpp
@@ -3,20 +3,49 @@
 #include "app_links/app_links_plugin_c_api.h"
 #include "win32_window.h"
 
+#include <shellapi.h>
+
 namespace {
 
 HWND FindExistingLanternWindow() {
-  if (HWND window = FindWindowW(Win32Window::GetWindowClassName(), nullptr)) {
-    return window;
+  return FindWindowW(Win32Window::GetWindowClassName(), nullptr);
+}
+
+bool IsSchemeFirstChar(wchar_t value) {
+  return (value >= L'A' && value <= L'Z') || (value >= L'a' && value <= L'z');
+}
+
+bool IsSchemeChar(wchar_t value) {
+  return IsSchemeFirstChar(value) || (value >= L'0' && value <= L'9') ||
+         value == L'+' || value == L'.' || value == L'-';
+}
+
+bool HasUriScheme(const wchar_t* value) {
+  if (value == nullptr || !IsSchemeFirstChar(value[0])) {
+    return false;
   }
 
-  // Older builds used Flutter's default class name before the single-instance
-  // guard existed. Keep these fallbacks so upgrading while Lantern is already
-  // running still activates that window instead of opening a duplicate.
-  if (HWND window = FindWindowW(L"FLUTTER_RUNNER_WIN32_WINDOW", L"Lantern")) {
-    return window;
+  for (int i = 1; value[i] != L'\0'; ++i) {
+    if (value[i] == L':') {
+      return true;
+    }
+    if (!IsSchemeChar(value[i])) {
+      return false;
+    }
   }
-  return FindWindowW(L"FLUTTER_RUNNER_WIN32_WINDOW", L"lantern");
+  return false;
+}
+
+bool HasLaunchAppLink() {
+  int argc = 0;
+  wchar_t** argv = CommandLineToArgvW(GetCommandLineW(), &argc);
+  if (argv == nullptr) {
+    return false;
+  }
+
+  const bool has_launch_app_link = argc == 2 && HasUriScheme(argv[1]);
+  LocalFree(argv);
+  return has_launch_app_link;
 }
 
 void FlashTaskbar(HWND window) {
@@ -93,7 +122,11 @@ bool ActivateExistingLanternWindow() {
     return false;
   }
 
-  SendAppLink(existing_window);
+  // SendAppLink reads this process's command line. Guard it so plain launches
+  // only focus the existing window and never emit an empty app-link event.
+  if (HasLaunchAppLink()) {
+    SendAppLink(existing_window);
+  }
 
   if (IsIconic(existing_window)) {
     ShowWindow(existing_window, SW_RESTORE);

--- a/windows/runner/single_instance.cpp
+++ b/windows/runner/single_instance.cpp
@@ -64,6 +64,29 @@ bool SingleInstanceLock::IsPrimaryInstance() const {
   return is_primary_instance_;
 }
 
+SingleInstanceReadyEvent::SingleInstanceReadyEvent(const wchar_t* event_name) {
+  event_ = CreateEventW(nullptr, TRUE, FALSE, event_name);
+}
+
+SingleInstanceReadyEvent::~SingleInstanceReadyEvent() {
+  if (event_ != nullptr) {
+    CloseHandle(event_);
+  }
+}
+
+void SingleInstanceReadyEvent::Signal() {
+  if (event_ != nullptr) {
+    SetEvent(event_);
+  }
+}
+
+bool SingleInstanceReadyEvent::Wait(DWORD timeout_ms) const {
+  if (event_ == nullptr) {
+    return false;
+  }
+  return WaitForSingleObject(event_, timeout_ms) == WAIT_OBJECT_0;
+}
+
 bool ActivateExistingLanternWindow() {
   HWND existing_window = FindExistingLanternWindow();
   if (existing_window == nullptr) {
@@ -104,4 +127,28 @@ bool ActivateExistingLanternWindow() {
     FlashTaskbar(existing_window);
   }
   return true;
+}
+
+bool ActivateExistingLanternWindowWithRetry(DWORD timeout_ms,
+                                            DWORD retry_interval_ms) {
+  const ULONGLONG deadline = GetTickCount64() + timeout_ms;
+
+  do {
+    if (ActivateExistingLanternWindow()) {
+      return true;
+    }
+
+    const ULONGLONG now = GetTickCount64();
+    if (now >= deadline) {
+      break;
+    }
+
+    DWORD sleep_ms = static_cast<DWORD>(deadline - now);
+    if (sleep_ms > retry_interval_ms) {
+      sleep_ms = retry_interval_ms;
+    }
+    Sleep(sleep_ms);
+  } while (true);
+
+  return false;
 }

--- a/windows/runner/single_instance.h
+++ b/windows/runner/single_instance.h
@@ -18,6 +18,23 @@ class SingleInstanceLock {
   bool is_primary_instance_ = true;
 };
 
+class SingleInstanceReadyEvent {
+ public:
+  explicit SingleInstanceReadyEvent(const wchar_t* event_name);
+  ~SingleInstanceReadyEvent();
+
+  SingleInstanceReadyEvent(const SingleInstanceReadyEvent&) = delete;
+  SingleInstanceReadyEvent& operator=(const SingleInstanceReadyEvent&) = delete;
+
+  void Signal();
+  bool Wait(DWORD timeout_ms) const;
+
+ private:
+  HANDLE event_ = nullptr;
+};
+
 bool ActivateExistingLanternWindow();
+bool ActivateExistingLanternWindowWithRetry(DWORD timeout_ms,
+                                            DWORD retry_interval_ms);
 
 #endif  // RUNNER_SINGLE_INSTANCE_H_

--- a/windows/runner/single_instance.h
+++ b/windows/runner/single_instance.h
@@ -1,0 +1,23 @@
+#ifndef RUNNER_SINGLE_INSTANCE_H_
+#define RUNNER_SINGLE_INSTANCE_H_
+
+#include <windows.h>
+
+class SingleInstanceLock {
+ public:
+  explicit SingleInstanceLock(const wchar_t* mutex_name);
+  ~SingleInstanceLock();
+
+  SingleInstanceLock(const SingleInstanceLock&) = delete;
+  SingleInstanceLock& operator=(const SingleInstanceLock&) = delete;
+
+  bool IsPrimaryInstance() const;
+
+ private:
+  HANDLE mutex_ = nullptr;
+  bool is_primary_instance_ = true;
+};
+
+bool ActivateExistingLanternWindow();
+
+#endif  // RUNNER_SINGLE_INSTANCE_H_

--- a/windows/runner/win32_window.cpp
+++ b/windows/runner/win32_window.cpp
@@ -16,7 +16,7 @@ namespace {
 #define DWMWA_USE_IMMERSIVE_DARK_MODE 20
 #endif
 
-constexpr const wchar_t kWindowClassName[] = L"FLUTTER_RUNNER_WIN32_WINDOW";
+constexpr const wchar_t kWindowClassName[] = L"ORG_GETLANTERN_LANTERN_WINDOW";
 
 /// Registry key for app theme preference.
 ///
@@ -85,6 +85,10 @@ class WindowClassRegistrar {
 };
 
 WindowClassRegistrar* WindowClassRegistrar::instance_ = nullptr;
+
+const wchar_t* Win32Window::GetWindowClassName() {
+  return kWindowClassName;
+}
 
 const wchar_t* WindowClassRegistrar::GetWindowClass() {
   if (!class_registered_) {

--- a/windows/runner/win32_window.h
+++ b/windows/runner/win32_window.h
@@ -49,6 +49,8 @@ class Win32Window {
   // window properties. Returns nullptr if the window has been destroyed.
   HWND GetHandle();
 
+  static const wchar_t* GetWindowClassName();
+
   // If true, closing this window will quit the application.
   void SetQuitOnClose(bool quit_on_close);
 


### PR DESCRIPTION
Adds a native Windows single-instance guard so launching Lantern again restores/focuses the existing window instead of starting another Flutter instance

It also forwards Windows app-link activations to the running instance so deep links continue to work