### PR TITLE
AppPurchase: capture underlying error when status is canceled

### DIFF
--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -323,7 +323,21 @@ class AppPurchase {
         return;
       }
       if (status == PurchaseStatus.canceled) {
-        /// User has cancelled the purchase
+        // `canceled` is not necessarily a real user cancel — the
+        // in_app_purchase plugin also maps several silent Google Play
+        // rejections (offer ineligibility, missing payment method, region
+        // mismatch, billing-service hiccups) to the same status. Without
+        // capturing the underlying error we can't distinguish those from a
+        // user who actually X'd the dialog, which is the difference between
+        // "expected" and "a bug to fix." For Android, `error.details`
+        // typically contains a Map with the raw BillingClient
+        // `response_code` and `debug_message`.
+        appLogger.info(
+          '[AppPurchase] Purchase canceled: productID=${purchaseDetails.productID}'
+          ' errorCode=${purchaseDetails.error?.code}'
+          ' message=${purchaseDetails.error?.message}'
+          ' details=${purchaseDetails.error?.details}',
+        );
         _onError?.call("Purchase canceled");
         return;
       }


### PR DESCRIPTION
## Summary

- Add structured logging of `productID`, `error.code`, `error.message`, and `error.details` in the `PurchaseStatus.canceled` branch of `_handlePurchase`.
- No behavior change. Same user-visible "Purchase canceled" snackbar. Single `info`-level log line per cancel.

## Why

The `in_app_purchase` plugin maps several silent Google Play rejections to `PurchaseStatus.canceled` — not just real user cancellations. Among them:

- Offer ineligibility (e.g. user already used an introductory offer)
- Missing payment method on the Play account
- Region mismatch between the Lantern offer and the Play account
- Billing-service transient errors

Without the underlying error fields we can't tell those apart from a user who actually X'd the dialog. That's the difference between "expected behavior, no action" and "a bug we need to fix in the offer / region / fallback path."

This has been blocking root-cause on a cluster of v9.1.x Android tickets in China where users report "I bought Pro but it didn't activate" — investigated for FD [#174173](https://support.lantern.io/a/tickets/174173) (active Pro user attempting renewal, 7+ consecutive `canceled` responses over 30 min, every attempt landing the same way before Play eventually loses sight of the products altogether with `notFoundIDs=[1m_sub, 1y_sub]`). With the current code, that whole sequence is logged as `PurchaseStatus.canceled` with no further breadcrumb.

For Android, `purchaseDetails.error?.details` typically contains a Map with the raw BillingClient `response_code` and `debug_message`, which is exactly the signal we need.

## Test plan

- [x] `flutter analyze lib/core/services/app_purchase.dart` passes
- [ ] Next time a "purchase canceled" cluster appears, the logs include enough context to attribute it to a specific Google Play response code
- [ ] Manual repro: trigger a real user cancel (X the dialog) — confirm the new log line fires with the platform's USER_CANCELED code

## Out of scope (follow-ups)

This is the smallest possible visibility improvement. Larger fixes that depend on what we *see* once this lands:
- Choose a non-introductory offer for users who already used the introductory one (if Play has multiple `subscriptionOfferDetails`)
- Add a retry guardrail in `_handlePurchase` so repeated canceled responses surface alternative payment methods
- Route Pro renewals through `_pushRenewalPaymentScreen` (Stripe / Alipay / WeChat) when Play won't complete after N attempts

🤖 Generated with [Claude Code](https://claude.com/claude-code)