### PR TITLE
[stealth 04/11] Add stealth artifact leakage checks

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -12,6 +12,11 @@ on:
       installer_base_name:
         required: true
         type: string
+      stealth_leakage_mode:
+        description: "Optional stealth leakage scan mode, for example stealth or stealth-novpn"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build-android:
@@ -155,6 +160,15 @@ jobs:
           VERSION: ${{ inputs.version }}
           INSTALLER_NAME: ${{ inputs.installer_base_name }}
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
+
+      - name: Stealth leakage check
+        if: ${{ inputs.stealth_leakage_mode != '' }}
+        run: make stealth-leakage-check
+        env:
+          STEALTH_LEAKAGE_MODE: ${{ inputs.stealth_leakage_mode }}
+          STEALTH_LEAKAGE_PATHS: >-
+            ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.apk
+            ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.aab
 
       - name: Upload Android APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -162,6 +162,7 @@ jobs:
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
 
       - name: Stealth leakage check
+        id: stealth_leakage_check
         if: ${{ inputs.stealth_leakage_mode != '' }}
         shell: bash
         run: |
@@ -176,7 +177,7 @@ jobs:
             ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.aab
 
       - name: Upload stealth leakage report
-        if: ${{ always() && inputs.stealth_leakage_mode != '' }}
+        if: ${{ always() && inputs.stealth_leakage_mode != '' && steps.stealth_leakage_check.outcome != 'skipped' }}
         uses: actions/upload-artifact@v4
         with:
           name: stealth-leakage-report

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -166,6 +166,7 @@ jobs:
         run: make stealth-leakage-check
         env:
           STEALTH_LEAKAGE_MODE: ${{ inputs.stealth_leakage_mode }}
+          STEALTH_LEAKAGE_MISSING_OK: "0"
           STEALTH_LEAKAGE_PATHS: >-
             ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.apk
             ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.aab

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -163,13 +163,26 @@ jobs:
 
       - name: Stealth leakage check
         if: ${{ inputs.stealth_leakage_mode != '' }}
-        run: make stealth-leakage-check
+        shell: bash
+        run: |
+          set -o pipefail
+          : > stealth-leakage-report.txt
+          make stealth-leakage-check 2>&1 | tee stealth-leakage-report.txt
         env:
           STEALTH_LEAKAGE_MODE: ${{ inputs.stealth_leakage_mode }}
           STEALTH_LEAKAGE_MISSING_OK: "0"
           STEALTH_LEAKAGE_PATHS: >-
             ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.apk
             ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.aab
+
+      - name: Upload stealth leakage report
+        if: ${{ always() && inputs.stealth_leakage_mode != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: stealth-leakage-report
+          path: stealth-leakage-report.txt
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload Android APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,15 @@ on:
         required: false
         type: boolean
         default: false
+      stealth_leakage_mode:
+        description: "Run Android stealth leakage scanner for manual Android builds"
+        required: false
+        type: choice
+        options:
+          - none
+          - stealth
+          - stealth-novpn
+        default: none
 
 permissions:
   contents: write
@@ -69,6 +78,7 @@ jobs:
       linux_arch: ${{ steps.meta.outputs.linux_arch }}
       is_test_run: ${{ steps.meta.outputs.is_test_run }}
       smoke_enable_ip_check: ${{ steps.meta.outputs.smoke_enable_ip_check }}
+      stealth_leakage_mode: ${{ steps.meta.outputs.stealth_leakage_mode }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -202,6 +212,13 @@ jobs:
           fi
 
           SMOKE_ENABLE_IP_CHECK="false"
+          STEALTH_LEAKAGE_MODE=""
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            requested_stealth_leakage_mode="${{ github.event.inputs.stealth_leakage_mode }}"
+            if [[ "$requested_stealth_leakage_mode" != "none" ]]; then
+              STEALTH_LEAKAGE_MODE="$requested_stealth_leakage_mode"
+            fi
+          fi
 
           echo "build_type=$BUILD_TYPE" >> $GITHUB_OUTPUT
           echo "release_tag=$RELEASE_TAG" >> $GITHUB_OUTPUT
@@ -211,6 +228,7 @@ jobs:
           echo "installer_base_name=$INSTALLER_BASE_NAME" >> $GITHUB_OUTPUT
           echo "is_test_run=$IS_TEST_RUN" >> $GITHUB_OUTPUT
           echo "smoke_enable_ip_check=$SMOKE_ENABLE_IP_CHECK" >> $GITHUB_OUTPUT
+          echo "stealth_leakage_mode=$STEALTH_LEAKAGE_MODE" >> $GITHUB_OUTPUT
 
       - name: Update pubspec.yaml version
         shell: bash
@@ -355,6 +373,7 @@ jobs:
       version: ${{ needs.set-metadata.outputs.version }}
       build_type: ${{ needs.set-metadata.outputs.build_type }}
       installer_base_name: ${{ needs.set-metadata.outputs.installer_base_name }}
+      stealth_leakage_mode: ${{ needs.set-metadata.outputs.stealth_leakage_mode }}
 
   release-create:
     needs: set-metadata

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ PYTHON ?= python3
 STEALTH_LEAKAGE_MODE ?= stealth
 STEALTH_LEAKAGE_CONFIG ?= scripts/stealth/forbidden_tokens.json
 STEALTH_LEAKAGE_PATHS ?= $(ANDROID_RELEASE_APK) $(ANDROID_RELEASE_AAB) $(ANDROID_APK_RELEASE_BUILD) $(ANDROID_AAB_RELEASE_BUILD)
+STEALTH_LEAKAGE_MISSING_OK ?= 1
 ANDROID_NDK_VERSION          ?= 28.2.13676358
 ANDROID_CMAKE_VERSION        ?= 3.22.1
 ANDROID_BUILD_TOOLS_VERSION  ?= 35.0.0
@@ -559,7 +560,7 @@ stealth-leakage-check:
 	$(PYTHON) scripts/stealth/check_leakage.py \
 		--config "$(STEALTH_LEAKAGE_CONFIG)" \
 		--mode "$(STEALTH_LEAKAGE_MODE)" \
-		--missing-ok \
+		$(if $(filter 1 true yes,$(STEALTH_LEAKAGE_MISSING_OK)),--missing-ok,) \
 		$(STEALTH_LEAKAGE_PATHS)
 
 stealth-novpn-leakage-check:

--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ ANDROID_RELEASE_APK := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYP
 ANDROID_RELEASE_AAB := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE)).aab
 ANDROID_MAPPING_SRC := build/app/outputs/mapping/release/mapping.txt
 ANDROID_SYMBOLS_SRC := build/app/outputs/native-debug-symbols/release/native-debug-symbols.zip
+PYTHON ?= python3
+STEALTH_LEAKAGE_MODE ?= stealth
+STEALTH_LEAKAGE_CONFIG ?= scripts/stealth/forbidden_tokens.json
+STEALTH_LEAKAGE_PATHS ?= $(ANDROID_RELEASE_APK) $(ANDROID_RELEASE_AAB) $(ANDROID_APK_RELEASE_BUILD) $(ANDROID_AAB_RELEASE_BUILD)
 ANDROID_NDK_VERSION          ?= 28.2.13676358
 ANDROID_CMAKE_VERSION        ?= 3.22.1
 ANDROID_BUILD_TOOLS_VERSION  ?= 35.0.0
@@ -549,6 +553,17 @@ android-release: clean android pubget gen android-apk-release
 
 .PHONY: android-release-ci
 android-release-ci: android pubget gen android-apk-release android-aab-release
+
+.PHONY: stealth-leakage-check stealth-novpn-leakage-check
+stealth-leakage-check:
+	$(PYTHON) scripts/stealth/check_leakage.py \
+		--config "$(STEALTH_LEAKAGE_CONFIG)" \
+		--mode "$(STEALTH_LEAKAGE_MODE)" \
+		--missing-ok \
+		$(STEALTH_LEAKAGE_PATHS)
+
+stealth-novpn-leakage-check:
+	$(MAKE) stealth-leakage-check STEALTH_LEAKAGE_MODE=stealth-novpn
 
 # iOS Build
 .PHONY: install-ios-deps

--- a/docs/stealth-leakage-checks.md
+++ b/docs/stealth-leakage-checks.md
@@ -1,0 +1,58 @@
+# Stealth Leakage Checks
+
+`scripts/stealth/check_leakage.py` scans built stealth artifacts for normal
+Lantern identifiers. It accepts APK, AAB, ZIP-like archives, and unpacked build
+directories. Archive entries are scanned recursively, and string matching checks
+UTF-8, UTF-16LE, and UTF-16BE encodings.
+
+Run the default stealth check:
+
+```sh
+make stealth-leakage-check \
+  STEALTH_LEAKAGE_PATHS="path/to/app.apk path/to/app.aab"
+```
+
+Run the stricter no-VPN variant:
+
+```sh
+make stealth-novpn-leakage-check \
+  STEALTH_LEAKAGE_PATHS="path/to/app.apk"
+```
+
+If the configured targets are absent, the Make targets skip successfully. This
+keeps normal builds and ordinary CI runs from failing on stealth-only checks.
+
+## Modes
+
+The forbidden-token config lives at
+`scripts/stealth/forbidden_tokens.json`.
+
+`stealth` checks for:
+
+- normal Lantern package, brand, library, service, and organization identifiers
+- user-facing VPN strings
+- OAuth provider strings and method-channel entry points
+- billing and subscription entry points
+- app-link hosts, custom schemes, and deep-link paths
+- Lantern social/support URLs
+- update feed and release URLs
+
+`stealth-novpn` extends `stealth` and also checks Android VPN/TUN surfaces such
+as `android.net.VpnService`, `BIND_VPN_SERVICE`, `TunOptions`, and VPN quick
+tile/service actions.
+
+## Allowlists
+
+Each mode supports an `allowlist` in the JSON config. Allowlist entries can
+match by `token`, `category`, `location` glob, and `encoding`. Example:
+
+```json
+{
+  "token": "Lantern",
+  "location": "*.SF",
+  "reason": "example only"
+}
+```
+
+Keep allowlist entries narrow and mode-specific so real leaks still fail the
+scan.

--- a/scripts/stealth/check_leakage.py
+++ b/scripts/stealth/check_leakage.py
@@ -305,7 +305,7 @@ class Scanner:
         if target.is_dir():
             self.scan_directory(target)
             return
-        self.scan_file(target, str(target))
+        self.scan_file(target, str(target), scan_path=False)
 
     def scan_directory(self, root: Path) -> None:
         for dirpath, _, filenames in os.walk(root):
@@ -317,8 +317,9 @@ class Scanner:
                     logical = str(path)
                 self.scan_file(path, logical)
 
-    def scan_file(self, path: Path, logical: str) -> None:
-        self.scan_bytes(f"{logical}[path]", logical.encode("utf-8", "surrogateescape"))
+    def scan_file(self, path: Path, logical: str, scan_path: bool = True) -> None:
+        if scan_path:
+            self.scan_bytes(f"{logical}[path]", logical.encode("utf-8", "surrogateescape"))
         try:
             if is_archive_name(path.name) and zipfile.is_zipfile(path):
                 self.scan_archive_bytes(path.read_bytes(), logical, depth=0)
@@ -485,7 +486,7 @@ def print_text_result(mode: str, result: ScanResult, max_findings: int) -> None:
         for error in result.errors:
             print(f"  - {error}", file=sys.stderr)
 
-    if not result.findings:
+    if not result.findings and not result.errors:
         if result.targets:
             joined = ", ".join(result.targets)
             print(

--- a/scripts/stealth/check_leakage.py
+++ b/scripts/stealth/check_leakage.py
@@ -336,6 +336,7 @@ class Scanner:
             return
         try:
             with zipfile.ZipFile(path) as archive:
+                self.scan_archive_metadata(archive, logical)
                 self.scan_archive_members(archive, logical, depth)
         except (OSError, zipfile.BadZipFile, NotImplementedError) as exc:
             self.errors.append(f"{logical}: unable to read archive: {exc}")
@@ -344,14 +345,18 @@ class Scanner:
         if depth > self.max_depth:
             self.errors.append(f"{logical}: exceeded nested archive depth {self.max_depth}")
             return
-        self.scan_bytes(f"{logical}[archive]", data)
         try:
             with zipfile.ZipFile(io.BytesIO(data)) as archive:
+                self.scan_archive_metadata(archive, logical)
                 self.scan_archive_members(archive, logical, depth)
         except zipfile.BadZipFile:
             return
         except NotImplementedError as exc:
             self.errors.append(f"{logical}: unsupported nested archive compression: {exc}")
+
+    def scan_archive_metadata(self, archive: zipfile.ZipFile, logical: str) -> None:
+        if archive.comment:
+            self.scan_bytes(f"{logical}[archive-comment]", archive.comment)
 
     def scan_archive_members(self, archive: zipfile.ZipFile, logical: str, depth: int) -> None:
         for info in archive.infolist():
@@ -493,6 +498,10 @@ def print_text_result(mode: str, result: ScanResult, max_findings: int) -> None:
                 f"Stealth leakage check passed for mode '{mode}' "
                 f"({result.scanned_blobs} scanned blobs from {joined})."
             )
+        return
+
+    if not result.findings:
+        print(f"Stealth leakage check failed for mode '{mode}' due to scanner errors.")
         return
 
     print(f"Forbidden identifiers found for mode '{mode}':")

--- a/scripts/stealth/check_leakage.py
+++ b/scripts/stealth/check_leakage.py
@@ -1,0 +1,565 @@
+#!/usr/bin/env python3
+"""Scan built stealth artifacts for forbidden Lantern identifiers.
+
+The scanner works on APK/AAB/ZIP-like archives and unpacked build output
+directories. It only uses the Python standard library so it can run in CI before
+tool-specific Android inspection utilities are installed.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import fnmatch
+import glob
+import io
+import json
+import os
+from pathlib import Path
+import shlex
+import sys
+from typing import Any
+import zipfile
+
+
+ARCHIVE_SUFFIXES = {".apk", ".aab", ".zip", ".jar", ".aar", ".ap_"}
+DEFAULT_CONFIG = Path(__file__).with_name("forbidden_tokens.json")
+TEXT_ENCODINGS = ("utf-8", "utf-16le", "utf-16be")
+
+
+class ConfigError(Exception):
+    pass
+
+
+@dataclasses.dataclass(frozen=True)
+class Needle:
+    encoding: str
+    value: bytes
+
+
+@dataclasses.dataclass(frozen=True)
+class Rule:
+    category: str
+    token: str
+    description: str
+    case_sensitive: bool
+    needles: tuple[Needle, ...]
+
+
+@dataclasses.dataclass(frozen=True)
+class Finding:
+    location: str
+    category: str
+    token: str
+    description: str
+    encoding: str
+    count: int
+    first_offset: int
+    excerpt: str
+
+
+@dataclasses.dataclass
+class ScanResult:
+    targets: list[str]
+    missing: list[str]
+    scanned_blobs: int
+    findings: list[Finding]
+    errors: list[str]
+
+
+def load_config(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as infile:
+            config = json.load(infile)
+    except json.JSONDecodeError as exc:
+        raise ConfigError(f"{path}: invalid JSON: {exc}") from exc
+    except OSError as exc:
+        raise ConfigError(f"{path}: unable to read config: {exc}") from exc
+
+    if not isinstance(config, dict):
+        raise ConfigError(f"{path}: config must be a JSON object")
+    if not isinstance(config.get("categories"), dict):
+        raise ConfigError(f"{path}: missing object field 'categories'")
+    if not isinstance(config.get("modes"), dict):
+        raise ConfigError(f"{path}: missing object field 'modes'")
+    return config
+
+
+def resolve_mode(config: dict[str, Any], mode: str) -> tuple[list[str], list[dict[str, Any]]]:
+    modes = config["modes"]
+    if mode not in modes:
+        valid = ", ".join(sorted(modes))
+        raise ConfigError(f"unknown mode '{mode}'. Valid modes: {valid}")
+
+    categories: list[str] = []
+    allowlist: list[dict[str, Any]] = []
+    visiting: set[str] = set()
+    visited: set[str] = set()
+
+    def visit(name: str) -> None:
+        if name in visited:
+            return
+        if name in visiting:
+            raise ConfigError(f"mode inheritance cycle involving '{name}'")
+        spec = modes.get(name)
+        if not isinstance(spec, dict):
+            raise ConfigError(f"mode '{name}' must be an object")
+
+        visiting.add(name)
+        parents = spec.get("extends", [])
+        if isinstance(parents, str):
+            parents = [parents]
+        if not isinstance(parents, list):
+            raise ConfigError(f"mode '{name}' field 'extends' must be a string or array")
+        for parent in parents:
+            if not isinstance(parent, str):
+                raise ConfigError(f"mode '{name}' has non-string parent")
+            if parent not in modes:
+                raise ConfigError(f"mode '{name}' extends unknown mode '{parent}'")
+            visit(parent)
+
+        mode_categories = spec.get("categories", [])
+        if not isinstance(mode_categories, list):
+            raise ConfigError(f"mode '{name}' field 'categories' must be an array")
+        for category in mode_categories:
+            if not isinstance(category, str):
+                raise ConfigError(f"mode '{name}' has non-string category")
+            if category not in config["categories"]:
+                raise ConfigError(f"mode '{name}' references unknown category '{category}'")
+            if category not in categories:
+                categories.append(category)
+
+        mode_allowlist = spec.get("allowlist", [])
+        if not isinstance(mode_allowlist, list):
+            raise ConfigError(f"mode '{name}' field 'allowlist' must be an array")
+        for item in mode_allowlist:
+            if not isinstance(item, dict):
+                raise ConfigError(f"mode '{name}' allowlist entries must be objects")
+            allowlist.append(item)
+
+        visiting.remove(name)
+        visited.add(name)
+
+    global_allowlist = config.get("allowlist", [])
+    if not isinstance(global_allowlist, list):
+        raise ConfigError("top-level 'allowlist' must be an array when present")
+    for item in global_allowlist:
+        if not isinstance(item, dict):
+            raise ConfigError("top-level allowlist entries must be objects")
+        allowlist.append(item)
+
+    visit(mode)
+    return categories, allowlist
+
+
+def compile_rules(config: dict[str, Any], categories: list[str]) -> list[Rule]:
+    rules: list[Rule] = []
+    for category in categories:
+        category_spec = config["categories"][category]
+        if not isinstance(category_spec, dict):
+            raise ConfigError(f"category '{category}' must be an object")
+        tokens = category_spec.get("tokens", [])
+        if not isinstance(tokens, list):
+            raise ConfigError(f"category '{category}' field 'tokens' must be an array")
+        default_case = bool(category_spec.get("case_sensitive", False))
+        category_description = str(category_spec.get("description", ""))
+
+        for token_spec in tokens:
+            if isinstance(token_spec, str):
+                token = token_spec
+                description = category_description
+                case_sensitive = default_case
+            elif isinstance(token_spec, dict):
+                token = token_spec.get("token")
+                description = str(token_spec.get("description", category_description))
+                case_sensitive = bool(token_spec.get("case_sensitive", default_case))
+            else:
+                raise ConfigError(f"category '{category}' contains a non-string token")
+
+            if not isinstance(token, str) or token == "":
+                raise ConfigError(f"category '{category}' contains an empty token")
+            rules.append(
+                Rule(
+                    category=category,
+                    token=token,
+                    description=description,
+                    case_sensitive=case_sensitive,
+                    needles=build_needles(token, case_sensitive),
+                )
+            )
+    return rules
+
+
+def build_needles(token: str, case_sensitive: bool) -> tuple[Needle, ...]:
+    needles: list[Needle] = []
+    for encoding in TEXT_ENCODINGS:
+        value = token.encode(encoding)
+        if not case_sensitive:
+            value = value.lower()
+        needles.append(Needle(encoding=encoding, value=value))
+    return tuple(needles)
+
+
+def pattern_matches(value: str, patterns: Any) -> bool:
+    if patterns is None:
+        return True
+    if isinstance(patterns, str):
+        patterns = [patterns]
+    if not isinstance(patterns, list):
+        return False
+    return any(isinstance(pattern, str) and fnmatch.fnmatchcase(value, pattern) for pattern in patterns)
+
+
+def finding_is_allowed(finding: Finding, allowlist: list[dict[str, Any]]) -> bool:
+    for item in allowlist:
+        token = item.get("token")
+        if token is not None:
+            if isinstance(token, str):
+                tokens = [token]
+            elif isinstance(token, list):
+                tokens = token
+            else:
+                continue
+            lowered = {str(candidate).lower() for candidate in tokens}
+            if finding.token.lower() not in lowered:
+                continue
+
+        category = item.get("category")
+        if category is not None:
+            if isinstance(category, str):
+                categories = [category]
+            elif isinstance(category, list):
+                categories = category
+            else:
+                continue
+            if finding.category not in {str(candidate) for candidate in categories}:
+                continue
+
+        location = item.get("location", item.get("path"))
+        if not pattern_matches(finding.location, location):
+            continue
+
+        encoding = item.get("encoding")
+        if encoding is not None:
+            if isinstance(encoding, str):
+                encodings = [encoding]
+            elif isinstance(encoding, list):
+                encodings = encoding
+            else:
+                continue
+            if finding.encoding not in {str(candidate) for candidate in encodings}:
+                continue
+
+        return True
+    return False
+
+
+def printable_excerpt(data: bytes, offset: int, width: int = 96) -> str:
+    start = max(0, offset - width // 2)
+    end = min(len(data), offset + width // 2)
+    excerpt = data[start:end]
+    rendered = "".join(chr(byte) if 32 <= byte < 127 else "." for byte in excerpt)
+    if start > 0:
+        rendered = "..." + rendered
+    if end < len(data):
+        rendered = rendered + "..."
+    return rendered
+
+
+def count_matches(haystack: bytes, needle: bytes) -> tuple[int, int]:
+    count = 0
+    first = -1
+    start = 0
+    while True:
+        index = haystack.find(needle, start)
+        if index < 0:
+            return count, first
+        if first < 0:
+            first = index
+        count += 1
+        start = index + max(1, len(needle))
+
+
+class Scanner:
+    def __init__(self, rules: list[Rule], allowlist: list[dict[str, Any]], max_depth: int) -> None:
+        self.rules = rules
+        self.allowlist = allowlist
+        self.max_depth = max_depth
+        self.scanned_blobs = 0
+        self.findings: list[Finding] = []
+        self.errors: list[str] = []
+        self.needs_lowercase = any(not rule.case_sensitive for rule in self.rules)
+
+    def scan_target(self, target: Path) -> None:
+        if target.is_dir():
+            self.scan_directory(target)
+            return
+        self.scan_file(target, str(target))
+
+    def scan_directory(self, root: Path) -> None:
+        for dirpath, _, filenames in os.walk(root):
+            for filename in filenames:
+                path = Path(dirpath) / filename
+                try:
+                    logical = str(path.relative_to(root.parent))
+                except ValueError:
+                    logical = str(path)
+                self.scan_file(path, logical)
+
+    def scan_file(self, path: Path, logical: str) -> None:
+        self.scan_bytes(f"{logical}[path]", logical.encode("utf-8", "surrogateescape"))
+        try:
+            if is_archive_name(path.name) and zipfile.is_zipfile(path):
+                self.scan_archive_file(path, logical, depth=0)
+            else:
+                self.scan_bytes(logical, path.read_bytes())
+        except OSError as exc:
+            self.errors.append(f"{path}: unable to read file: {exc}")
+        except zipfile.BadZipFile as exc:
+            self.errors.append(f"{path}: invalid zip archive: {exc}")
+
+    def scan_archive_file(self, path: Path, logical: str, depth: int) -> None:
+        if depth > self.max_depth:
+            self.errors.append(f"{logical}: exceeded nested archive depth {self.max_depth}")
+            return
+        try:
+            with zipfile.ZipFile(path) as archive:
+                self.scan_archive_members(archive, logical, depth)
+        except (OSError, zipfile.BadZipFile, NotImplementedError) as exc:
+            self.errors.append(f"{logical}: unable to read archive: {exc}")
+
+    def scan_archive_bytes(self, data: bytes, logical: str, depth: int) -> None:
+        if depth > self.max_depth:
+            self.errors.append(f"{logical}: exceeded nested archive depth {self.max_depth}")
+            return
+        try:
+            with zipfile.ZipFile(io.BytesIO(data)) as archive:
+                self.scan_archive_members(archive, logical, depth)
+        except zipfile.BadZipFile:
+            self.scan_bytes(logical, data)
+        except NotImplementedError as exc:
+            self.errors.append(f"{logical}: unsupported nested archive compression: {exc}")
+
+    def scan_archive_members(self, archive: zipfile.ZipFile, logical: str, depth: int) -> None:
+        for info in archive.infolist():
+            entry_location = f"{logical}!{info.filename}"
+            self.scan_bytes(
+                f"{entry_location}[entry-name]",
+                info.filename.encode("utf-8", "surrogateescape"),
+            )
+            if info.is_dir():
+                continue
+            try:
+                data = archive.read(info)
+            except (RuntimeError, OSError, zipfile.BadZipFile, NotImplementedError) as exc:
+                self.errors.append(f"{entry_location}: unable to read archive entry: {exc}")
+                continue
+            if is_archive_name(info.filename) and zipfile.is_zipfile(io.BytesIO(data)):
+                self.scan_archive_bytes(data, entry_location, depth + 1)
+            else:
+                self.scan_bytes(entry_location, data)
+
+    def scan_bytes(self, location: str, data: bytes) -> None:
+        self.scanned_blobs += 1
+        lowered = data.lower() if self.needs_lowercase else data
+        for rule in self.rules:
+            haystack = data if rule.case_sensitive else lowered
+            for needle in rule.needles:
+                count, first = count_matches(haystack, needle.value)
+                if count == 0:
+                    continue
+                finding = Finding(
+                    location=location,
+                    category=rule.category,
+                    token=rule.token,
+                    description=rule.description,
+                    encoding=needle.encoding,
+                    count=count,
+                    first_offset=first,
+                    excerpt=printable_excerpt(data, first),
+                )
+                if not finding_is_allowed(finding, self.allowlist):
+                    self.findings.append(finding)
+
+
+def is_archive_name(name: str) -> bool:
+    return Path(name.lower()).suffix in ARCHIVE_SUFFIXES
+
+
+def expand_targets(raw_paths: list[str], missing_ok: bool) -> tuple[list[Path], list[str]]:
+    targets: list[Path] = []
+    missing: list[str] = []
+    for raw_path in raw_paths:
+        matches: list[str]
+        if glob.has_magic(raw_path):
+            matches = glob.glob(raw_path, recursive=True)
+        else:
+            matches = [raw_path]
+        existing = [Path(match) for match in matches if Path(match).exists()]
+        if existing:
+            targets.extend(existing)
+        elif not missing_ok:
+            missing.append(raw_path)
+        else:
+            missing.append(raw_path)
+
+    deduped: list[Path] = []
+    seen: set[str] = set()
+    for target in targets:
+        key = str(target.resolve())
+        if key not in seen:
+            seen.add(key)
+            deduped.append(target)
+    return deduped, missing
+
+
+def build_parser(config: dict[str, Any] | None = None) -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Scan APK/AAB archives or unpacked build output for forbidden stealth identifiers."
+    )
+    parser.add_argument("paths", nargs="*", help="Artifact files, directories, or glob patterns to scan.")
+    parser.add_argument(
+        "--mode",
+        default=os.environ.get("STEALTH_LEAKAGE_MODE", "stealth"),
+        help="Scanner mode from the config. Defaults to STEALTH_LEAKAGE_MODE or 'stealth'.",
+    )
+    parser.add_argument(
+        "--config",
+        default=os.environ.get("STEALTH_LEAKAGE_CONFIG", str(DEFAULT_CONFIG)),
+        help="Forbidden-token config JSON path.",
+    )
+    parser.add_argument(
+        "--missing-ok",
+        action="store_true",
+        help="Exit successfully when requested targets are absent.",
+    )
+    parser.add_argument(
+        "--max-depth",
+        type=int,
+        default=3,
+        help="Maximum nested archive depth to inspect.",
+    )
+    parser.add_argument(
+        "--max-findings",
+        type=int,
+        default=200,
+        help="Maximum findings to print in text output.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format.",
+    )
+    parser.add_argument(
+        "--list-modes",
+        action="store_true",
+        help="List configured modes and exit.",
+    )
+    return parser
+
+
+def print_text_result(mode: str, result: ScanResult, max_findings: int) -> None:
+    if result.missing:
+        if result.targets:
+            print("Missing scan targets skipped:")
+            for missing in result.missing:
+                print(f"  - {missing}")
+        else:
+            print("No existing leakage scan targets found; skipped.")
+
+    if result.errors:
+        print("Scanner errors:", file=sys.stderr)
+        for error in result.errors:
+            print(f"  - {error}", file=sys.stderr)
+
+    if not result.findings:
+        if result.targets:
+            joined = ", ".join(result.targets)
+            print(
+                f"Stealth leakage check passed for mode '{mode}' "
+                f"({result.scanned_blobs} scanned blobs from {joined})."
+            )
+        return
+
+    print(f"Forbidden identifiers found for mode '{mode}':")
+    for finding in result.findings[:max_findings]:
+        print(
+            f"- {finding.category}: token {finding.token!r} "
+            f"in {finding.location} ({finding.encoding}, {finding.count} match"
+            f"{'' if finding.count == 1 else 'es'}, first offset {finding.first_offset})"
+        )
+        if finding.description:
+            print(f"  reason: {finding.description}")
+        print(f"  excerpt: {finding.excerpt}")
+
+    if len(result.findings) > max_findings:
+        remaining = len(result.findings) - max_findings
+        print(f"... {remaining} additional finding(s) omitted. Re-run with --max-findings to show more.")
+
+
+def result_as_json(mode: str, result: ScanResult) -> dict[str, Any]:
+    return {
+        "mode": mode,
+        "targets": result.targets,
+        "missing": result.missing,
+        "scanned_blobs": result.scanned_blobs,
+        "errors": result.errors,
+        "findings": [dataclasses.asdict(finding) for finding in result.findings],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    try:
+        config = load_config(Path(args.config))
+        if args.list_modes:
+            for mode in sorted(config["modes"]):
+                print(mode)
+            return 0
+        categories, allowlist = resolve_mode(config, args.mode)
+        rules = compile_rules(config, categories)
+    except ConfigError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    env_paths = shlex.split(os.environ.get("STEALTH_LEAKAGE_PATHS", ""))
+    raw_paths = args.paths or env_paths
+    if not raw_paths:
+        parser.error("provide at least one path or set STEALTH_LEAKAGE_PATHS")
+
+    targets, missing = expand_targets(raw_paths, args.missing_ok)
+    if missing and not args.missing_ok:
+        print("error: missing scan target(s):", file=sys.stderr)
+        for path in missing:
+            print(f"  - {path}", file=sys.stderr)
+        return 2
+
+    scanner = Scanner(rules, allowlist, max_depth=args.max_depth)
+    for target in targets:
+        scanner.scan_target(target)
+
+    result = ScanResult(
+        targets=[str(target) for target in targets],
+        missing=missing,
+        scanned_blobs=scanner.scanned_blobs,
+        findings=scanner.findings,
+        errors=scanner.errors,
+    )
+
+    if args.format == "json":
+        print(json.dumps(result_as_json(args.mode, result), indent=2, sort_keys=True))
+    else:
+        print_text_result(args.mode, result, args.max_findings)
+
+    if result.errors:
+        return 2
+    if result.findings:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/stealth/check_leakage.py
+++ b/scripts/stealth/check_leakage.py
@@ -60,6 +60,15 @@ class Finding:
     excerpt: str
 
 
+@dataclasses.dataclass(frozen=True)
+class LocalEntryLayout:
+    start: int
+    data_start: int
+    data_end: int
+    filename: bytes
+    extra: bytes
+
+
 @dataclasses.dataclass
 class ScanResult:
     targets: list[str]
@@ -368,9 +377,10 @@ class Scanner:
     ) -> None:
         covered: list[tuple[int, int]] = []
         for info in archive.infolist():
-            entry_range = self.local_entry_range(data, info)
-            if entry_range is not None:
-                covered.append(entry_range)
+            layout = self.local_entry_layout(data, info)
+            if layout is not None:
+                self.scan_local_entry_metadata(logical, info, layout)
+                covered.append((layout.start, layout.data_end))
 
         start_dir = getattr(archive, "start_dir", None)
         if isinstance(start_dir, int):
@@ -386,11 +396,24 @@ class Scanner:
         if cursor < len(data):
             self.scan_bytes(f"{logical}[non-entry]", data[cursor:])
 
-    def local_entry_range(
+    def scan_local_entry_metadata(
+        self,
+        logical: str,
+        info: zipfile.ZipInfo,
+        layout: LocalEntryLayout,
+    ) -> None:
+        entry_location = f"{logical}!{info.filename}"
+        central_filename = info.filename.encode("utf-8", "surrogateescape")
+        if layout.filename and layout.filename != central_filename:
+            self.scan_bytes(f"{entry_location}[local-entry-name]", layout.filename)
+        if layout.extra and layout.extra != info.extra:
+            self.scan_bytes(f"{entry_location}[local-entry-extra]", layout.extra)
+
+    def local_entry_layout(
         self,
         data: bytes,
         info: zipfile.ZipInfo,
-    ) -> tuple[int, int] | None:
+    ) -> LocalEntryLayout | None:
         start = info.header_offset
         if start < 0 or start + 30 > len(data):
             return None
@@ -412,8 +435,22 @@ class Scanner:
             return None
         if signature != 0x04034B50:
             return None
-        data_start = start + 30 + filename_len + extra_len
-        return start, data_start + compressed_size
+        filename_start = start + 30
+        extra_start = filename_start + filename_len
+        data_start = extra_start + extra_len
+        if data_start > len(data):
+            return None
+        compressed_size = info.compress_size if info.compress_size >= 0 else compressed_size
+        data_end = data_start + compressed_size
+        if data_end < data_start or data_end > len(data):
+            return None
+        return LocalEntryLayout(
+            start=start,
+            data_start=data_start,
+            data_end=data_end,
+            filename=data[filename_start:extra_start],
+            extra=data[extra_start:data_start],
+        )
 
     def scan_archive_members(self, archive: zipfile.ZipFile, logical: str, depth: int) -> None:
         for info in archive.infolist():

--- a/scripts/stealth/check_leakage.py
+++ b/scripts/stealth/check_leakage.py
@@ -17,6 +17,7 @@ import json
 import os
 from pathlib import Path
 import shlex
+import struct
 import sys
 from typing import Any
 import zipfile
@@ -347,6 +348,7 @@ class Scanner:
             return
         try:
             with zipfile.ZipFile(io.BytesIO(data)) as archive:
+                self.scan_archive_non_entry_bytes(data, archive, logical)
                 self.scan_archive_metadata(archive, logical)
                 self.scan_archive_members(archive, logical, depth)
         except zipfile.BadZipFile:
@@ -358,6 +360,61 @@ class Scanner:
         if archive.comment:
             self.scan_bytes(f"{logical}[archive-comment]", archive.comment)
 
+    def scan_archive_non_entry_bytes(
+        self,
+        data: bytes,
+        archive: zipfile.ZipFile,
+        logical: str,
+    ) -> None:
+        covered: list[tuple[int, int]] = []
+        for info in archive.infolist():
+            entry_range = self.local_entry_range(data, info)
+            if entry_range is not None:
+                covered.append(entry_range)
+
+        start_dir = getattr(archive, "start_dir", None)
+        if isinstance(start_dir, int):
+            covered.append((start_dir, len(data)))
+
+        cursor = 0
+        for start, end in sorted(covered):
+            start = max(0, min(start, len(data)))
+            end = max(start, min(end, len(data)))
+            if cursor < start:
+                self.scan_bytes(f"{logical}[non-entry]", data[cursor:start])
+            cursor = max(cursor, end)
+        if cursor < len(data):
+            self.scan_bytes(f"{logical}[non-entry]", data[cursor:])
+
+    def local_entry_range(
+        self,
+        data: bytes,
+        info: zipfile.ZipInfo,
+    ) -> tuple[int, int] | None:
+        start = info.header_offset
+        if start < 0 or start + 30 > len(data):
+            return None
+        try:
+            (
+                signature,
+                _version,
+                _flags,
+                _compression,
+                _mtime,
+                _mdate,
+                _crc,
+                compressed_size,
+                _file_size,
+                filename_len,
+                extra_len,
+            ) = struct.unpack_from("<IHHHHHIIIHH", data, start)
+        except struct.error:
+            return None
+        if signature != 0x04034B50:
+            return None
+        data_start = start + 30 + filename_len + extra_len
+        return start, data_start + compressed_size
+
     def scan_archive_members(self, archive: zipfile.ZipFile, logical: str, depth: int) -> None:
         for info in archive.infolist():
             entry_location = f"{logical}!{info.filename}"
@@ -365,6 +422,10 @@ class Scanner:
                 f"{entry_location}[entry-name]",
                 info.filename.encode("utf-8", "surrogateescape"),
             )
+            if info.extra:
+                self.scan_bytes(f"{entry_location}[entry-extra]", info.extra)
+            if info.comment:
+                self.scan_bytes(f"{entry_location}[entry-comment]", info.comment)
             if info.is_dir():
                 continue
             try:

--- a/scripts/stealth/check_leakage.py
+++ b/scripts/stealth/check_leakage.py
@@ -25,6 +25,7 @@ import zipfile
 ARCHIVE_SUFFIXES = {".apk", ".aab", ".zip", ".jar", ".aar", ".ap_"}
 DEFAULT_CONFIG = Path(__file__).with_name("forbidden_tokens.json")
 TEXT_ENCODINGS = ("utf-8", "utf-16le", "utf-16be")
+ALLOWLIST_MATCH_FIELDS = frozenset(("token", "category", "location", "path", "encoding"))
 
 
 class ConfigError(Exception):
@@ -135,6 +136,7 @@ def resolve_mode(config: dict[str, Any], mode: str) -> tuple[list[str], list[dic
         for item in mode_allowlist:
             if not isinstance(item, dict):
                 raise ConfigError(f"mode '{name}' allowlist entries must be objects")
+            validate_allowlist_entry(item, f"mode '{name}' allowlist")
             allowlist.append(item)
 
         visiting.remove(name)
@@ -146,10 +148,19 @@ def resolve_mode(config: dict[str, Any], mode: str) -> tuple[list[str], list[dic
     for item in global_allowlist:
         if not isinstance(item, dict):
             raise ConfigError("top-level allowlist entries must be objects")
+        validate_allowlist_entry(item, "top-level allowlist")
         allowlist.append(item)
 
     visit(mode)
     return categories, allowlist
+
+
+def validate_allowlist_entry(item: dict[str, Any], context: str) -> None:
+    if not any(item.get(field) is not None for field in ALLOWLIST_MATCH_FIELDS):
+        raise ConfigError(
+            f"{context} entries must include at least one matcher field: "
+            f"{', '.join(sorted(ALLOWLIST_MATCH_FIELDS))}"
+        )
 
 
 def compile_rules(config: dict[str, Any], categories: list[str]) -> list[Rule]:
@@ -310,7 +321,7 @@ class Scanner:
         self.scan_bytes(f"{logical}[path]", logical.encode("utf-8", "surrogateescape"))
         try:
             if is_archive_name(path.name) and zipfile.is_zipfile(path):
-                self.scan_archive_file(path, logical, depth=0)
+                self.scan_archive_bytes(path.read_bytes(), logical, depth=0)
             else:
                 self.scan_bytes(logical, path.read_bytes())
         except OSError as exc:
@@ -332,11 +343,12 @@ class Scanner:
         if depth > self.max_depth:
             self.errors.append(f"{logical}: exceeded nested archive depth {self.max_depth}")
             return
+        self.scan_bytes(f"{logical}[archive]", data)
         try:
             with zipfile.ZipFile(io.BytesIO(data)) as archive:
                 self.scan_archive_members(archive, logical, depth)
         except zipfile.BadZipFile:
-            self.scan_bytes(logical, data)
+            return
         except NotImplementedError as exc:
             self.errors.append(f"{logical}: unsupported nested archive compression: {exc}")
 

--- a/scripts/stealth/check_leakage.py
+++ b/scripts/stealth/check_leakage.py
@@ -360,8 +360,8 @@ class Scanner:
                 self.scan_archive_non_entry_bytes(data, archive, logical)
                 self.scan_archive_metadata(archive, logical)
                 self.scan_archive_members(archive, logical, depth)
-        except zipfile.BadZipFile:
-            return
+        except zipfile.BadZipFile as exc:
+            self.errors.append(f"{logical}: unable to read archive: {exc}")
         except NotImplementedError as exc:
             self.errors.append(f"{logical}: unsupported nested archive compression: {exc}")
 

--- a/scripts/stealth/check_leakage_test.py
+++ b/scripts/stealth/check_leakage_test.py
@@ -237,6 +237,20 @@ class LeakageScannerTest(unittest.TestCase):
             self.assertIn("failed", stdout.getvalue())
             self.assertIn("Scanner errors", stderr.getvalue())
 
+    def test_corrupt_nested_archive_reports_error(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            raw_config = check_leakage.load_config(config)
+            categories, allowlist = check_leakage.resolve_mode(raw_config, "stealth")
+            rules = check_leakage.compile_rules(raw_config, categories)
+            scanner = check_leakage.Scanner(rules, allowlist, max_depth=1)
+
+            scanner.scan_archive_bytes(self.corrupt_zip_with_signature(), "inner.apk", 0)
+
+            self.assertEqual(len(scanner.errors), 1)
+            self.assertIn("inner.apk: unable to read archive", scanner.errors[0])
+
     def insert_before_central_directory(self, data: bytes, payload: bytes) -> bytes:
         eocd_offset = data.rfind(b"PK\x05\x06")
         self.assertNotEqual(eocd_offset, -1)
@@ -272,6 +286,21 @@ class LeakageScannerTest(unittest.TestCase):
         struct.pack_into("<H", out, header_offset + 28, extra_len + len(payload))
         struct.pack_into("<I", out, eocd_offset + len(payload) + 16, central_dir_offset + len(payload))
         return bytes(out)
+
+    def corrupt_zip_with_signature(self) -> bytes:
+        bogus_central_directory = b"\x00" * 46
+        eocd = struct.pack(
+            "<4s4H2LH",
+            b"PK\x05\x06",
+            0,
+            0,
+            1,
+            1,
+            46,
+            0,
+            0,
+        )
+        return bogus_central_directory + eocd
 
 
 if __name__ == "__main__":

--- a/scripts/stealth/check_leakage_test.py
+++ b/scripts/stealth/check_leakage_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+import zipfile
+from contextlib import redirect_stderr, redirect_stdout
+import io
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import check_leakage
+
+
+class LeakageScannerTest(unittest.TestCase):
+    def write_config(self, root: Path) -> Path:
+        config = {
+            "categories": {
+                "brand": {
+                    "description": "brand leak",
+                    "tokens": ["Lantern"]
+                },
+                "novpn": {
+                    "description": "novpn leak",
+                    "tokens": ["android.net.VpnService"]
+                }
+            },
+            "modes": {
+                "stealth": {
+                    "categories": ["brand"],
+                    "allowlist": [
+                        {
+                            "token": "Lantern",
+                            "location": "*allowed.txt",
+                            "reason": "test allowlist"
+                        }
+                    ]
+                },
+                "stealth-novpn": {
+                    "extends": "stealth",
+                    "categories": ["novpn"]
+                }
+            }
+        }
+        path = root / "tokens.json"
+        path.write_text(json.dumps(config), encoding="utf-8")
+        return path
+
+    def scan(self, config_path: Path, mode: str, *paths: Path) -> int:
+        with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+            return check_leakage.main([
+                "--config",
+                str(config_path),
+                "--mode",
+                mode,
+                *[str(path) for path in paths],
+            ])
+
+    def test_detects_forbidden_token_in_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            target = root / "out"
+            target.mkdir()
+            (target / "classes.dex").write_bytes(b"prefix Lantern suffix")
+
+            self.assertEqual(self.scan(config, "stealth", target), 1)
+
+    def test_scans_zip_entry_content_and_name(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            archive = root / "app.apk"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("assets/Lantern.txt", b"no content leak here")
+
+            self.assertEqual(self.scan(config, "stealth", archive), 1)
+
+    def test_mode_specific_allowlist(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            target = root / "allowed.txt"
+            target.write_bytes(b"Lantern")
+
+            self.assertEqual(self.scan(config, "stealth", target), 0)
+
+    def test_stealth_novpn_extends_base_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            target = root / "manifest.bin"
+            target.write_text("android.net.VpnService", encoding="utf-8")
+
+            self.assertEqual(self.scan(config, "stealth", target), 0)
+            self.assertEqual(self.scan(config, "stealth-novpn", target), 1)
+
+    def test_missing_ok_skips_absent_targets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            missing = root / "missing.apk"
+
+            with redirect_stdout(io.StringIO()), redirect_stderr(io.StringIO()):
+                code = check_leakage.main([
+                    "--config",
+                    str(config),
+                    "--missing-ok",
+                    str(missing),
+                ])
+            self.assertEqual(code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/stealth/check_leakage_test.py
+++ b/scripts/stealth/check_leakage_test.py
@@ -132,6 +132,22 @@ class LeakageScannerTest(unittest.TestCase):
 
             self.assertEqual(self.scan(config, "stealth", archive), 1)
 
+    def test_scans_zip_local_header_extra_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            archive = root / "app.apk"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("assets/clean.txt", b"clean")
+
+            archive.write_bytes(self.insert_local_extra(
+                archive.read_bytes(),
+                "assets/clean.txt",
+                b"\x99\x99\x07\x00Lantern",
+            ))
+
+            self.assertEqual(self.scan(config, "stealth", archive), 1)
+
     def test_scans_non_entry_archive_bytes(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -229,6 +245,32 @@ class LeakageScannerTest(unittest.TestCase):
         new_eocd_offset = eocd_offset + len(payload)
         out = bytearray(out)
         struct.pack_into("<I", out, new_eocd_offset + 16, central_dir_offset + len(payload))
+        return bytes(out)
+
+    def insert_local_extra(self, data: bytes, entry_name: str, payload: bytes) -> bytes:
+        with zipfile.ZipFile(io.BytesIO(data)) as zf:
+            header_offset = zf.getinfo(entry_name).header_offset
+        (
+            signature,
+            _version,
+            _flags,
+            _compression,
+            _mtime,
+            _mdate,
+            _crc,
+            _compressed_size,
+            _file_size,
+            filename_len,
+            extra_len,
+        ) = struct.unpack_from("<IHHHHHIIIHH", data, header_offset)
+        self.assertEqual(signature, 0x04034B50)
+        insert_at = header_offset + 30 + filename_len + extra_len
+        eocd_offset = data.rfind(b"PK\x05\x06")
+        self.assertNotEqual(eocd_offset, -1)
+        central_dir_offset = struct.unpack_from("<I", data, eocd_offset + 16)[0]
+        out = bytearray(data[:insert_at] + payload + data[insert_at:])
+        struct.pack_into("<H", out, header_offset + 28, extra_len + len(payload))
+        struct.pack_into("<I", out, eocd_offset + len(payload) + 16, central_dir_offset + len(payload))
         return bytes(out)
 
 

--- a/scripts/stealth/check_leakage_test.py
+++ b/scripts/stealth/check_leakage_test.py
@@ -108,6 +108,16 @@ class LeakageScannerTest(unittest.TestCase):
 
             self.assertEqual(self.scan(config, "stealth", archive), 1)
 
+    def test_archive_entry_allowlist_is_not_shadowed_by_raw_archive_scan(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            archive = root / "app.apk"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("assets/allowed.txt", b"Lantern")
+
+            self.assertEqual(self.scan(config, "stealth", archive), 0)
+
     def test_mode_specific_allowlist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -178,6 +188,8 @@ class LeakageScannerTest(unittest.TestCase):
 
             self.assertEqual(code, 2)
             self.assertNotIn("Stealth leakage check passed", stdout.getvalue())
+            self.assertNotIn("Forbidden identifiers found", stdout.getvalue())
+            self.assertIn("failed", stdout.getvalue())
             self.assertIn("Scanner errors", stderr.getvalue())
 
 

--- a/scripts/stealth/check_leakage_test.py
+++ b/scripts/stealth/check_leakage_test.py
@@ -2,6 +2,7 @@
 import json
 from pathlib import Path
 import sys
+import struct
 import tempfile
 import unittest
 import zipfile
@@ -118,6 +119,34 @@ class LeakageScannerTest(unittest.TestCase):
 
             self.assertEqual(self.scan(config, "stealth", archive), 0)
 
+    def test_scans_zip_entry_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            archive = root / "app.apk"
+            info = zipfile.ZipInfo("assets/clean.txt")
+            info.extra = b"\x99\x99\x07\x00Lantern"
+            info.comment = b"Lantern comment metadata"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr(info, b"clean")
+
+            self.assertEqual(self.scan(config, "stealth", archive), 1)
+
+    def test_scans_non_entry_archive_bytes(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            archive = root / "app.apk"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("assets/clean.txt", b"clean")
+
+            archive.write_bytes(self.insert_before_central_directory(
+                archive.read_bytes(),
+                b"Lantern signing block",
+            ))
+
+            self.assertEqual(self.scan(config, "stealth", archive), 1)
+
     def test_mode_specific_allowlist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -191,6 +220,16 @@ class LeakageScannerTest(unittest.TestCase):
             self.assertNotIn("Forbidden identifiers found", stdout.getvalue())
             self.assertIn("failed", stdout.getvalue())
             self.assertIn("Scanner errors", stderr.getvalue())
+
+    def insert_before_central_directory(self, data: bytes, payload: bytes) -> bytes:
+        eocd_offset = data.rfind(b"PK\x05\x06")
+        self.assertNotEqual(eocd_offset, -1)
+        central_dir_offset = struct.unpack_from("<I", data, eocd_offset + 16)[0]
+        out = data[:central_dir_offset] + payload + data[central_dir_offset:]
+        new_eocd_offset = eocd_offset + len(payload)
+        out = bytearray(out)
+        struct.pack_into("<I", out, new_eocd_offset + 16, central_dir_offset + len(payload))
+        return bytes(out)
 
 
 if __name__ == "__main__":

--- a/scripts/stealth/check_leakage_test.py
+++ b/scripts/stealth/check_leakage_test.py
@@ -77,6 +77,26 @@ class LeakageScannerTest(unittest.TestCase):
 
             self.assertEqual(self.scan(config, "stealth", archive), 1)
 
+    def test_direct_target_filename_is_not_scanned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            archive = root / "Lantern.apk"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("assets/clean.txt", b"no content leak here")
+
+            self.assertEqual(self.scan(config, "stealth", archive), 0)
+
+    def test_directory_child_filename_is_scanned(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            target = root / "out"
+            target.mkdir()
+            (target / "Lantern.txt").write_bytes(b"no content leak here")
+
+            self.assertEqual(self.scan(config, "stealth", target), 1)
+
     def test_scans_zip_archive_comment(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -133,6 +153,32 @@ class LeakageScannerTest(unittest.TestCase):
                     str(missing),
                 ])
             self.assertEqual(code, 0)
+
+    def test_scanner_errors_do_not_print_success(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            nested = root / "inner.apk"
+            with zipfile.ZipFile(nested, "w") as zf:
+                zf.writestr("assets/clean.txt", b"clean")
+            archive = root / "outer.apk"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.write(nested, "inner.apk")
+
+            stdout = io.StringIO()
+            stderr = io.StringIO()
+            with redirect_stdout(stdout), redirect_stderr(stderr):
+                code = check_leakage.main([
+                    "--config",
+                    str(config),
+                    "--max-depth",
+                    "0",
+                    str(archive),
+                ])
+
+            self.assertEqual(code, 2)
+            self.assertNotIn("Stealth leakage check passed", stdout.getvalue())
+            self.assertIn("Scanner errors", stderr.getvalue())
 
 
 if __name__ == "__main__":

--- a/scripts/stealth/check_leakage_test.py
+++ b/scripts/stealth/check_leakage_test.py
@@ -77,6 +77,17 @@ class LeakageScannerTest(unittest.TestCase):
 
             self.assertEqual(self.scan(config, "stealth", archive), 1)
 
+    def test_scans_zip_archive_comment(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            archive = root / "app.apk"
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("assets/clean.txt", b"no content leak here")
+                zf.comment = b"archive comment mentions Lantern"
+
+            self.assertEqual(self.scan(config, "stealth", archive), 1)
+
     def test_mode_specific_allowlist(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             root = Path(tmp)
@@ -85,6 +96,18 @@ class LeakageScannerTest(unittest.TestCase):
             target.write_bytes(b"Lantern")
 
             self.assertEqual(self.scan(config, "stealth", target), 0)
+
+    def test_rejects_allowlist_entries_without_matchers(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            config = self.write_config(root)
+            data = json.loads(config.read_text(encoding="utf-8"))
+            data["modes"]["stealth"]["allowlist"] = [{"reason": "too broad"}]
+            config.write_text(json.dumps(data), encoding="utf-8")
+            target = root / "classes.dex"
+            target.write_bytes(b"Lantern")
+
+            self.assertEqual(self.scan(config, "stealth", target), 2)
 
     def test_stealth_novpn_extends_base_mode(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/stealth/forbidden_tokens.json
+++ b/scripts/stealth/forbidden_tokens.json
@@ -1,0 +1,182 @@
+{
+  "version": 1,
+  "categories": {
+    "lantern_identity": {
+      "description": "normal Lantern package, brand, library, service, or organization identifier",
+      "tokens": [
+        "Lantern",
+        "LanternApp",
+        "LanternVPN",
+        "LanternVpn",
+        "LanternVpnService",
+        "liblantern",
+        "lanternd",
+        "lantern-installer",
+        "org.getlantern",
+        "org.getlantern.lantern",
+        "org/getlantern",
+        "org/getlantern/lantern",
+        "group.getlantern.lantern",
+        "com.getlantern",
+        "getlantern"
+      ]
+    },
+    "vpn_user_strings": {
+      "description": "user-facing VPN labels, message identifiers, and visible VPN state strings",
+      "tokens": [
+        {
+          "token": "VPN",
+          "case_sensitive": true,
+          "description": "uppercase VPN user-facing acronym"
+        },
+        "LanternVPN",
+        "LanternVpn",
+        "vpn_may_be_needed",
+        "google_and_apple_sign_in_blocked",
+        "continue_without_vpn",
+        "turn_on_vpn",
+        "vpn_connected",
+        "vpn_connecting",
+        "vpn_disconnected",
+        "watchVPNStatus",
+        "start_vpn",
+        "stop_vpn",
+        "split_tunneling"
+      ]
+    },
+    "oauth_provider_strings": {
+      "description": "OAuth provider UI labels, routes, or method-channel entry points",
+      "tokens": [
+        "oauth",
+        "oauthLoginUrl",
+        "oauthLoginCallback",
+        "isOAuthLogin",
+        "getOAuthProvider",
+        "continue_with_google",
+        "continue_with_apple",
+        "Sign in with Google",
+        "Continue with Google",
+        "Continue with Apple",
+        "google_sign_in",
+        "GoogleSignIn",
+        "google_and_apple_sign_in_blocked",
+        "com.google.android.gms.auth",
+        "accounts.google.com",
+        "appleid.apple.com"
+      ]
+    },
+    "billing_entry_points": {
+      "description": "billing provider, subscription, purchase, or payment entry point",
+      "tokens": [
+        "billing",
+        "BillingClient",
+        "com.android.vending.BILLING",
+        "stripe",
+        "flutter_stripe",
+        "stripePayment",
+        "stripeSubscription",
+        "stripeBillingPortal",
+        "stripeBillingPortalUrl",
+        "in_app_purchase",
+        "play.google.com/store/account/subscriptions",
+        "apps.apple.com/account/subscriptions",
+        "add_billing_details",
+        "billing_account",
+        "next_billing_date"
+      ]
+    },
+    "app_links": {
+      "description": "normal Lantern app-link hosts, custom schemes, and deep-link paths",
+      "tokens": [
+        "lantern.io",
+        "www.lantern.io",
+        "support.lantern.io",
+        "unbounded.lantern.io",
+        "getlantern.org",
+        "admin@getlantern.org",
+        "lantern://",
+        "lantern:",
+        "/report-issue",
+        "/private-server",
+        "/auth",
+        "applinks:lantern.io",
+        "webcredentials:lantern.io"
+      ]
+    },
+    "social_urls": {
+      "description": "normal Lantern social/support profile URLs and handles",
+      "tokens": [
+        "twitter.com/getlantern",
+        "twitter.com/Lantern_Russia",
+        "twitter.com/getlantern_fa",
+        "twitter.com/getlantern_CN",
+        "instagram.com/getlantern",
+        "instagram.com/lantern.io_ru",
+        "instagram.com/getlantern_fa",
+        "t.me/lantern",
+        "t.me/LanternFarsi",
+        "t.me/lantern_china",
+        "lantern_official_bot",
+        "LanternFarsi",
+        "lantern_china"
+      ]
+    },
+    "update_urls": {
+      "description": "normal Lantern update feeds and release URLs",
+      "tokens": [
+        "s3.amazonaws.com/lantern.io/releases",
+        "lantern.io/releases",
+        "appcast.xml",
+        "latest/appcast",
+        "generate_appcast"
+      ]
+    },
+    "stealth_novpn_surfaces": {
+      "description": "Android VPN/TUN service permissions, classes, methods, and tunnel setup surfaces forbidden in stealth-novpn",
+      "tokens": [
+        "android.net.VpnService",
+        "android.permission.BIND_VPN_SERVICE",
+        "android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED",
+        "android.permission.FOREGROUND_SERVICE_SPECIAL_USE",
+        "VpnService",
+        "VpnService.Builder",
+        "LanternVpnService",
+        "TunOptions",
+        {
+          "token": "TUN",
+          "case_sensitive": true,
+          "description": "uppercase TUN tunnel acronym"
+        },
+        "tun2socks",
+        "addDisallowedApplication",
+        "setUnderlyingNetworks",
+        "ACTION_START_VPN",
+        "ACTION_STOP_VPN",
+        "ACTION_TILE_START",
+        "android.service.quicksettings.action.QS_TILE",
+        "android.permission.BIND_QUICK_SETTINGS_TILE"
+      ]
+    }
+  },
+  "modes": {
+    "stealth": {
+      "categories": [
+        "lantern_identity",
+        "vpn_user_strings",
+        "oauth_provider_strings",
+        "billing_entry_points",
+        "app_links",
+        "social_urls",
+        "update_urls"
+      ],
+      "allowlist": []
+    },
+    "stealth-novpn": {
+      "extends": "stealth",
+      "categories": [
+        "stealth_novpn_surfaces"
+      ],
+      "allowlist": []
+    }
+  }
+}

--- a/scripts/stealth/forbidden_tokens.json
+++ b/scripts/stealth/forbidden_tokens.json
@@ -137,7 +137,6 @@
         "android.net.VpnService",
         "android.permission.BIND_VPN_SERVICE",
         "android.permission.FOREGROUND_SERVICE_SYSTEM_EXEMPTED",
-        "android.permission.FOREGROUND_SERVICE_SPECIAL_USE",
         "VpnService",
         "VpnService.Builder",
         "LanternVpnService",


### PR DESCRIPTION
## Summary
- add a configurable stealth leakage scanner for archives and unpacked build output
- define forbidden-token modes for stealth and stealth-novpn artifacts
- add Makefile and Android workflow entry points plus scanner docs

## Validation
- python3 -m pytest scripts/stealth/check_leakage_test.py
- python3 scripts/stealth/check_leakage.py --help
- git diff --check HEAD~1..HEAD

Closes getlantern/engineering#3570