### PR TITLE
[stealth 01/11] Add stealth build profile plumbing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -174,6 +174,28 @@ APPDMG    := $(call get-command,appdmg)
 
 DART_DEFINES := --dart-define=BUILD_TYPE=$(BUILD_TYPE) $(if $(VERSION),--dart-define=VERSION=$(VERSION),)
 
+STEALTH_PROFILE_SCRIPT := scripts/stealth/generate_profile.py
+STEALTH_PROFILE_TOOL := python3 $(STEALTH_PROFILE_SCRIPT)
+STEALTH_PROFILE ?=
+STEALTH_MODE ?=
+STEALTH_PACKAGE_NAME ?=
+STEALTH_APP_NAME ?=
+STEALTH_SESSION_NAME ?=
+STEALTH_OBFUSCATION_SEED ?=
+STEALTH_GO_OBFUSCATION_SEED ?= $(STEALTH_OBFUSCATION_SEED)
+STEALTH_DENYLIST_VERSION ?=
+STEALTH_PROFILE_OUT ?= $(BUILD_DIR)/stealth/profile.json
+STEALTH_DART_DEFINES_FILE ?= $(BUILD_DIR)/stealth/dart-defines.json
+STEALTH_ARTIFACT_METADATA ?= $(BUILD_DIR)/stealth/artifact-metadata.json
+STEALTH_GO_TAGS_FILE ?= $(BUILD_DIR)/stealth/go-tags-suffix.txt
+STEALTH_PROFILE_STAMP ?= $(BUILD_DIR)/stealth/profile.stamp
+STEALTH_PROFILE_INPUTS_FILE ?= $(BUILD_DIR)/stealth/profile.inputs
+STEALTH_ENABLED := $(strip $(STEALTH_MODE)$(STEALTH_PROFILE))
+STEALTH_DART_DEFINES := $(if $(STEALTH_ENABLED),--dart-define-from-file=$(STEALTH_DART_DEFINES_FILE),)
+STEALTH_GO_TAGS = $(if $(STEALTH_ENABLED),$(if $(wildcard $(STEALTH_GO_TAGS_FILE)),$(shell cat "$(STEALTH_GO_TAGS_FILE)"),$(error missing $(STEALTH_GO_TAGS_FILE); run make stealth-profile before building)),)
+STEALTH_PROFILE_ENV := $(if $(STEALTH_ENABLED),ORG_GRADLE_PROJECT_stealthProfile="$(abspath $(STEALTH_PROFILE_OUT))",)
+MAYBE_STEALTH_PROFILE := $(if $(STEALTH_ENABLED),$(STEALTH_PROFILE_STAMP),)
+
 INSTALLER_RESOURCES := installer-resources
 
 # Missing and Guards
@@ -182,6 +204,69 @@ guard-%:
 
 check-gomobile:
 	@command -v gomobile >/dev/null || (echo "gomobile not found. Run 'make install-android-deps'" && exit 1)
+
+.PHONY: stealth-profile FORCE
+stealth-profile:
+	$(MAKE) -B "$(STEALTH_PROFILE_STAMP)"
+
+$(STEALTH_PROFILE_STAMP): FORCE $(STEALTH_PROFILE_SCRIPT)
+	$(call MKDIR_P,$(dir $(STEALTH_PROFILE_STAMP)))
+	@set -e; { \
+	  printf 'STEALTH_PROFILE_SCRIPT_SHA256='; \
+	  python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE_SCRIPT)"; \
+	  printf 'STEALTH_PROFILE=%s\n' "$(STEALTH_PROFILE)"; \
+	  printf 'STEALTH_PROFILE_SHA256='; \
+	  if [ -n "$(STEALTH_PROFILE)" ] && [ -f "$(STEALTH_PROFILE)" ]; then \
+	    python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE)"; \
+	  else \
+	    printf '\n'; \
+	  fi; \
+	  printf 'STEALTH_MODE=%s\n' "$(STEALTH_MODE)"; \
+	  printf 'STEALTH_PACKAGE_NAME=%s\n' "$(STEALTH_PACKAGE_NAME)"; \
+	  printf 'STEALTH_APP_NAME=%s\n' "$(STEALTH_APP_NAME)"; \
+	  printf 'STEALTH_SESSION_NAME=%s\n' "$(STEALTH_SESSION_NAME)"; \
+	  printf 'STEALTH_GO_OBFUSCATION_SEED_SHA256='; \
+	  if [ -n "$(STEALTH_GO_OBFUSCATION_SEED)" ]; then \
+	    python3 -c 'import hashlib, sys; print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())' "$(STEALTH_GO_OBFUSCATION_SEED)"; \
+	  else \
+	    printf '\n'; \
+	  fi; \
+	  printf 'STEALTH_DENYLIST_VERSION=%s\n' "$(STEALTH_DENYLIST_VERSION)"; \
+	} > "$(STEALTH_PROFILE_INPUTS_FILE).tmp"
+	@set -e; \
+	tmp_profile="$(STEALTH_PROFILE_OUT).tmp"; \
+	tmp_dart_defines="$(STEALTH_DART_DEFINES_FILE).tmp"; \
+	tmp_artifact_metadata="$(STEALTH_ARTIFACT_METADATA).tmp"; \
+	tmp_go_tags="$(STEALTH_GO_TAGS_FILE).tmp"; \
+	trap 'rm -f "$(STEALTH_PROFILE_INPUTS_FILE).tmp" "$$tmp_profile" "$$tmp_dart_defines" "$$tmp_artifact_metadata" "$$tmp_go_tags"' EXIT; \
+	if test -f "$(STEALTH_PROFILE_INPUTS_FILE)" && \
+		cmp -s "$(STEALTH_PROFILE_INPUTS_FILE).tmp" "$(STEALTH_PROFILE_INPUTS_FILE)" && \
+		test -s "$(STEALTH_PROFILE_OUT)" && \
+		test -s "$(STEALTH_DART_DEFINES_FILE)" && \
+		test -s "$(STEALTH_ARTIFACT_METADATA)" && \
+		test -s "$(STEALTH_GO_TAGS_FILE)"; then \
+	  touch "$@"; \
+	  rm -f "$(STEALTH_PROFILE_INPUTS_FILE).tmp"; \
+	else \
+	  $(STEALTH_PROFILE_TOOL) \
+		$(if $(STEALTH_PROFILE),--input "$(STEALTH_PROFILE)",) \
+		$(if $(STEALTH_MODE),--mode "$(STEALTH_MODE)",) \
+		$(if $(STEALTH_PACKAGE_NAME),--package-name "$(STEALTH_PACKAGE_NAME)",) \
+		$(if $(STEALTH_APP_NAME),--app-name "$(STEALTH_APP_NAME)",) \
+		$(if $(STEALTH_SESSION_NAME),--session-name "$(STEALTH_SESSION_NAME)",) \
+		$(if $(STEALTH_GO_OBFUSCATION_SEED),--go-obfuscation-seed "$(STEALTH_GO_OBFUSCATION_SEED)",) \
+		$(if $(STEALTH_DENYLIST_VERSION),--denylist-version "$(STEALTH_DENYLIST_VERSION)",) \
+		--output "$$tmp_profile" \
+		--dart-defines-output "$$tmp_dart_defines" \
+		--artifact-metadata-output "$$tmp_artifact_metadata"; \
+	  $(STEALTH_PROFILE_TOOL) --input "$$tmp_profile" --go-tags-suffix > "$$tmp_go_tags"; \
+	  mv "$(STEALTH_PROFILE_INPUTS_FILE).tmp" "$(STEALTH_PROFILE_INPUTS_FILE)"; \
+	  mv "$$tmp_profile" "$(STEALTH_PROFILE_OUT)"; \
+	  mv "$$tmp_dart_defines" "$(STEALTH_DART_DEFINES_FILE)"; \
+	  mv "$$tmp_artifact_metadata" "$(STEALTH_ARTIFACT_METADATA)"; \
+	  mv "$$tmp_go_tags" "$(STEALTH_GO_TAGS_FILE)"; \
+	  touch "$@"; \
+	fi
 
 
 .PHONY: require-appdmg
@@ -202,9 +287,9 @@ else
 endif
 
 .PHONY: desktop-lib
-desktop-lib:
+desktop-lib: $(MAYBE_STEALTH_PROFILE)
 	$(SETENV) go build -v -trimpath -buildmode=c-shared \
-		-tags="$(TAGS)" \
+		-tags="$(TAGS)$(STEALTH_GO_TAGS)" \
 		-ldflags="-w -s $(EXTRA_LDFLAGS)" \
 		-o $(LIB_NAME) ./$(FFI_DIR)
 	@echo "Built desktop library: $(LIB_NAME)"
@@ -222,11 +307,11 @@ install-macos-deps: install-gomobile
 .PHONY: macos
 macos: $(MACOS_FRAMEWORK_BUILD)
 
-$(MACOS_FRAMEWORK_BUILD): $(GO_SOURCES)
+$(MACOS_FRAMEWORK_BUILD): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	@echo "Building macOS Framework.."
 	rm -rf $(MACOS_FRAMEWORK_BUILD) && mkdir -p $(MACOS_FRAMEWORK_DIR)
 	GOTOOLCHAIN=$(GO_VERSION) GOOS=darwin gomobile bind -v \
-		-tags=$(TAGS),netgo  -trimpath \
+		-tags=$(TAGS),netgo$(STEALTH_GO_TAGS)  -trimpath \
 		-target=macos \
 		-o $(MACOS_FRAMEWORK_BUILD) \
 		-ldflags="-w -s -checklinkname=0 $(EXTRA_LDFLAGS)" \
@@ -242,14 +327,14 @@ macos-framework: $(MACOS_FRAMEWORK_BUILD)
 .PHONY: macos-debug
 macos-debug: $(DARWIN_DEBUG_BUILD)
 
-$(DARWIN_DEBUG_BUILD): $(DARWIN_LIB_BUILD)
+$(DARWIN_DEBUG_BUILD): $(DARWIN_LIB_BUILD) $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (debug) for macOS..."
-	flutter build macos --debug
+	flutter build macos --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: macos-unit-tests
-macos-unit-tests: $(MACOS_FRAMEWORK_BUILD)
+macos-unit-tests: $(MACOS_FRAMEWORK_BUILD) $(MAYBE_STEALTH_PROFILE)
 	@echo "Preparing macOS test project (building native assets)..."
-	flutter build macos --debug
+	flutter build macos --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 	@echo "Running macOS Runner unit tests..."
 	xcodebuild test \
 		-workspace macos/Runner.xcworkspace \
@@ -261,10 +346,10 @@ macos-unit-tests: $(MACOS_FRAMEWORK_BUILD)
 		CODE_SIGNING_REQUIRED=NO \
 		CODE_SIGN_IDENTITY=""
 
-$(DARWIN_RELEASE_BUILD):
+$(DARWIN_RELEASE_BUILD): $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for macOS..."
 	rm -vf $(MACOS_INSTALLER)
-	flutter build macos --release $(DART_DEFINES)
+	flutter build macos --release $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 build-macos-release: $(DARWIN_RELEASE_BUILD)
 
@@ -311,13 +396,13 @@ install-linux-deps:
 .PHONY: linux-arm64
 linux-arm64: $(LINUX_LIB_ARM64)
 
-$(LINUX_LIB_ARM64): $(GO_SOURCES)
+$(LINUX_LIB_ARM64): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	CC=$(LINUX_CC_ARM64) GOOS=linux GOARCH=arm64 LIB_NAME=$@ $(MAKE) desktop-lib
 
 .PHONY: linux-amd64
 linux-amd64: $(LINUX_LIB_AMD64)
 
-$(LINUX_LIB_AMD64): $(GO_SOURCES)
+$(LINUX_LIB_AMD64): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	CC=$(LINUX_CC_AMD64) GOOS=linux GOARCH=amd64 LIB_NAME=$@ $(MAKE) desktop-lib
 
 .PHONY: linux
@@ -327,33 +412,33 @@ linux: linux-$(LINUX_TARGET_ARCH)
 
 .PHONY: lanternd-linux-amd64 lanternd-linux-arm64
 
-lanternd-linux-amd64: $(GO_SOURCES)
+lanternd-linux-amd64: $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_LINUX_AMD64)))
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
 		-ldflags "-w -s $(EXTRA_LDFLAGS)" \
 		-o $(LANTERND_LINUX_AMD64) $(LANTERND_SRC)
 	@echo "Built lanternd (linux-amd64): $(LANTERND_LINUX_AMD64)"
 
-lanternd-linux-arm64: $(GO_SOURCES)
+lanternd-linux-arm64: $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_LINUX_ARM64)))
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
 		-ldflags "-w -s $(EXTRA_LDFLAGS)" \
 		-o $(LANTERND_LINUX_ARM64) $(LANTERND_SRC)
 	@echo "Built lanternd (linux-arm64): $(LANTERND_LINUX_ARM64)"
 
 .PHONY: linux-debug
-linux-debug:
+linux-debug: $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (debug) for Linux..."
-	flutter build linux --debug
+	flutter build linux --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: linux-release linux-release-ci
 linux-release: clean linux-release-ci
 
-linux-release-ci: linux pubget gen
+linux-release-ci: linux pubget gen $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for Linux..."
-	flutter build linux --release $(DART_DEFINES)
+	flutter build linux --release $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 	$(MAKE) lanternd-linux-$(LINUX_TARGET_ARCH)
 
 	@if [ "$(LINUX_TARGET_ARCH)" = "arm64" ]; then \
@@ -394,12 +479,12 @@ windows: windows-amd64
 
 windows-amd64: WINDOWS_GOOS := windows
 windows-amd64: WINDOWS_GOARCH := amd64
-windows-amd64:
+windows-amd64: $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(WINDOWS_LIB_AMD64)))
 	$(MAKE) desktop-lib GOOS=$(WINDOWS_GOOS) GOARCH=$(WINDOWS_GOARCH) LIB_NAME=$(WINDOWS_LIB_AMD64) CGO_LDFLAGS="$(WINDOWS_CGO_LDFLAGS)"
 windows-arm64: WINDOWS_GOOS := windows
 windows-arm64: WINDOWS_GOARCH := arm64
-windows-arm64:
+windows-arm64: $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(WINDOWS_LIB_ARM64)))
 	$(MAKE) desktop-lib GOOS=$(WINDOWS_GOOS) GOARCH=$(WINDOWS_GOARCH) LIB_NAME=$(WINDOWS_LIB_ARM64) CGO_LDFLAGS="$(WINDOWS_CGO_LDFLAGS)"
 
@@ -407,18 +492,18 @@ lanternd-windows-amd64: $(LANTERND_WINDOWS_AMD64)
 
 lanternd-windows-arm64: $(LANTERND_WINDOWS_ARM64)
 
-$(LANTERND_WINDOWS_AMD64):
+$(LANTERND_WINDOWS_AMD64): $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_WINDOWS_AMD64)))
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
 		-ldflags "$(EXTRA_LDFLAGS)" \
 		-o $(LANTERND_WINDOWS_AMD64) $(LANTERND_SRC)
 	@echo "Built lanternd (windows-amd64): $(LANTERND_WINDOWS_AMD64)"
 
-$(LANTERND_WINDOWS_ARM64):
+$(LANTERND_WINDOWS_ARM64): $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_WINDOWS_ARM64)))
 	GOOS=windows GOARCH=arm64 CGO_ENABLED=0 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
 		-ldflags "$(EXTRA_LDFLAGS)" \
 		-o $(LANTERND_WINDOWS_ARM64) $(LANTERND_SRC)
 	@echo "Built lanternd (windows-arm64): $(LANTERND_WINDOWS_ARM64)"
@@ -441,14 +526,14 @@ prepare-windows-release: lanternd-windows-amd64 lanternd-windows-arm64
 	$(MAKE) copy-lanternd-release-arm64
 
 .PHONY: windows-debug
-windows-debug: windows
+windows-debug: windows $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (debug) for Windows..."
-	flutter build windows --debug
+	flutter build windows --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: build-windows-release
-build-windows-release:
+build-windows-release: $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for Windows..."
-	flutter build windows --release --verbose
+	flutter build windows --release --verbose $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: windows-release
 windows-release: clean windows pubget gen build-windows-release prepare-windows-release
@@ -489,10 +574,10 @@ install-android-deps: install-gomobile
 .PHONY: android
 android: check-android-sdk check-gomobile $(ANDROID_LIB_BUILD)
 
-$(ANDROID_LIB_BUILD): $(GO_SOURCES)
+$(ANDROID_LIB_BUILD): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(MAKE) build-android
 
-build-android: check-android-sdk check-gomobile
+build-android: check-android-sdk check-gomobile $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Android libraries..."
 	rm -rf $(ANDROID_LIB_BUILD) $(ANDROID_LIBS_DIR)/$(ANDROID_LIB)
 	mkdir -p $(dir $(ANDROID_LIB_BUILD)) $(ANDROID_LIBS_DIR)
@@ -502,7 +587,7 @@ build-android: check-android-sdk check-gomobile
 		-androidapi=23 \
 		-target="$(GOMOBILE_ANDROID_TARGET)" \
 		-javapkg=lantern.io \
-		-tags=$(TAGS) -trimpath \
+		-tags=$(TAGS)$(STEALTH_GO_TAGS) -trimpath \
 		-o=$(ANDROID_LIB_BUILD) \
 		-ldflags="$(ANDROID_GOMOBILE_LDFLAGS) $(EXTRA_LDFLAGS)" \
 		$(GOMOBILE_REPOS)
@@ -513,24 +598,24 @@ build-android: check-android-sdk check-gomobile
 .PHONY: android-debug
 android-debug: $(ANDROID_DEBUG_BUILD)
 
-$(ANDROID_DEBUG_BUILD): $(ANDROID_LIB_BUILD)
-	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --debug -Plantern.sideloadUpdates=true
+$(ANDROID_DEBUG_BUILD): $(ANDROID_LIB_BUILD) $(MAYBE_STEALTH_PROFILE)
+	$(STEALTH_PROFILE_ENV) flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES) -Plantern.sideloadUpdates=true
 
 # --target-platform restricts Flutter's libapp.so / libflutter.so to arm64.
 # abiFilters is arm64-only for all artifacts now (no thinAbi flag needed).
 # -Plantern.sideloadUpdates=true adds REQUEST_INSTALL_PACKAGES only to the
 # direct-download APK artifact; Play AAB builds intentionally omit it.
 .PHONY: android-apk-release
-android-apk-release:
-	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES) -Plantern.sideloadUpdates=true
+android-apk-release: $(MAYBE_STEALTH_PROFILE)
+	$(STEALTH_PROFILE_ENV) flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES) $(STEALTH_DART_DEFINES) -Plantern.sideloadUpdates=true
 	cp $(ANDROID_APK_RELEASE_BUILD) $(ANDROID_RELEASE_APK)
 
 # AAB is arm64-only too (armeabi-v7a dropped — golang/go#70495 SIGSYS on
 # 32-bit). 32-bit-only devices no longer get Play updates; they were
 # crash-looping on Android 8-10 regardless.
 .PHONY: android-aab-release
-android-aab-release:
-	flutter build appbundle --target-platform $(ANDROID_AAB_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES)
+android-aab-release: $(MAYBE_STEALTH_PROFILE)
+	$(STEALTH_PROFILE_ENV) flutter build appbundle --target-platform $(ANDROID_AAB_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 	cp $(ANDROID_AAB_RELEASE_BUILD) $(ANDROID_RELEASE_AAB)
 	# Copy Play console artifacts
 	@if [ -f "$(ANDROID_MAPPING_SRC)" ]; then \
@@ -562,15 +647,15 @@ ios: $(IOS_FRAMEWORK_BUILD)
 .PHONY: ios
 ios: check-gomobile $(IOS_FRAMEWORK_BUILD)
 
-$(IOS_FRAMEWORK_BUILD): $(GO_SOURCES)
+$(IOS_FRAMEWORK_BUILD): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(MAKE) build-ios
 
-build-ios:
+build-ios: $(MAYBE_STEALTH_PROFILE)
 	@echo "Building iOS Framework.."
 	rm -rf $(IOS_FRAMEWORK_BUILD)
 	rm -rf $(IOS_FRAMEWORK_DIR) && mkdir -p $(IOS_FRAMEWORK_DIR)
 	GOOS=ios gomobile bind -v \
-		-tags=$(TAGS),with_low_memory, -trimpath \
+		-tags=$(TAGS),with_low_memory$(STEALTH_GO_TAGS) -trimpath \
 		-target=ios \
 		-o $(IOS_FRAMEWORK_BUILD) \
 		-ldflags="-w -s -checklinkname=0 $(EXTRA_LDFLAGS)" \
@@ -590,8 +675,8 @@ format:
 	@echo "Formatting Swift code..."
 	$(MAKE) swift-format
 
-ios-release: clean pubget ios
-	flutter build ipa --release --export-options-plist ./ExportOptions.plist $(DART_DEFINES)
+ios-release: clean pubget ios $(MAYBE_STEALTH_PROFILE)
+	flutter build ipa --release --export-options-plist ./ExportOptions.plist $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 	@set -e; \
 	  IPA_DIR="$(CURDIR)/build/ios/ipa"; \
 	  IPA_SRC=$$(ls -t "$$IPA_DIR"/*.ipa 2>/dev/null | head -n 1); \

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,6 +42,121 @@ def start = new Date(2015, 1, 1).getTime()
 def now = System.currentTimeMillis()
 def code = (int)((now - start) / 1000)
 
+def defaultStealthProfile = [
+        mode             : "normal",
+        packageName      : "org.getlantern.lantern",
+        appName          : "Lantern",
+        sessionName      : "LanternVpn",
+        denylistVersion  : 0,
+]
+
+def stealthModeAliases = [
+        vpn  : "stealth-vpn",
+        novpn: "stealth-novpn",
+]
+
+def normalizeStealthMode = { value ->
+    def mode = value.toString().trim()
+    return stealthModeAliases.get(mode, mode)
+}
+
+def buildConfigString = { value ->
+    def escaped = value.toString()
+            .replace("\\", "\\\\")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+            .replace("\b", "\\b")
+            .replace("\f", "\\f")
+            .replace("\"", "\\\"")
+    return "\"${escaped}\""
+}
+
+def manifestPlaceholderString = { fieldName, value ->
+    def text = value.toString()
+    if (!text.trim()) {
+        throw new GradleException("Stealth profile ${fieldName} must not be empty")
+    }
+    for (int i = 0; i < text.length(); i++) {
+        def ch = text.charAt(i)
+        if (Character.isISOControl(ch) || ['"', "'", '&', '<', '>'].contains(String.valueOf(ch))) {
+            throw new GradleException(
+                    "Stealth profile ${fieldName} contains XML-reserved or control characters"
+            )
+        }
+    }
+    return text
+}
+
+def nonNegativeInteger = { fieldName, value ->
+    try {
+        def parsed = Integer.parseInt(value.toString())
+        if (parsed < 0) {
+            throw new NumberFormatException("negative")
+        }
+        return parsed
+    } catch (NumberFormatException ignored) {
+        throw new GradleException("Stealth profile ${fieldName} must be a non-negative integer")
+    }
+}
+
+def androidApplicationId = { fieldName, value ->
+    if (!(value instanceof CharSequence)) {
+        throw new GradleException("Stealth profile ${fieldName} must be a string")
+    }
+    def text = value.toString().trim()
+    if (!(text ==~ /[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+/)) {
+        throw new GradleException(
+                "Stealth profile ${fieldName} must be a valid Android applicationId"
+        )
+    }
+    return text
+}
+
+def resolveRepoRelativeFile = { path ->
+    def candidate = new File(path.toString())
+    if (candidate.isAbsolute()) {
+        return candidate
+    }
+    def fromRepoRoot = new File(rootProject.projectDir.parentFile, path.toString())
+    if (fromRepoRoot.exists()) {
+        return fromRepoRoot
+    }
+    return file(path.toString())
+}
+
+def loadStealthProfile = {
+    def profilePath = (findProperty("stealthProfile") ?: System.getenv("STEALTH_PROFILE"))?.toString()?.trim()
+    if (!profilePath) {
+        return defaultStealthProfile
+    }
+
+    def profileFile = resolveRepoRelativeFile(profilePath)
+    if (!profileFile.exists()) {
+        throw new GradleException("Stealth profile not found: ${profilePath}")
+    }
+
+    def parsed = new groovy.json.JsonSlurper().parse(profileFile)
+    if (!(parsed instanceof Map)) {
+        throw new GradleException("Stealth profile must be a JSON object: ${profileFile}")
+    }
+
+    def profile = defaultStealthProfile + parsed.findAll { it.value != null }
+    profile.mode = normalizeStealthMode(profile.mode)
+    if (!["stealth-vpn", "stealth-novpn"].contains(profile.mode)) {
+        throw new GradleException(
+                "Unsupported Stealth mode '${profile.mode}' in ${profileFile}; expected stealth-vpn, stealth-novpn, vpn, or novpn"
+        )
+    }
+    profile.appName = manifestPlaceholderString("appName", profile.appName)
+    profile.sessionName = manifestPlaceholderString("sessionName", profile.sessionName)
+    profile.denylistVersion = nonNegativeInteger("denylistVersion", profile.denylistVersion)
+    profile.packageName = androidApplicationId("packageName", profile.packageName)
+    return profile
+}
+
+def stealthProfile = loadStealthProfile()
+
 android {
     namespace = "org.getlantern.lantern"
     compileSdk = 36
@@ -74,6 +189,10 @@ android {
 
     kotlinOptions {
         jvmTarget = "17"
+    }
+
+    buildFeatures {
+        buildConfig true
     }
 
     // arm64-only for every artifact (APK + AAB). armeabi-v7a (32-bit) was
@@ -109,11 +228,18 @@ android {
     }
 
     defaultConfig {
-        applicationId = "org.getlantern.lantern"
+        applicationId = stealthProfile.packageName.toString()
         minSdkVersion = 24
         targetSdk = 36
         versionCode = code
         versionName = flutter.versionName
+        manifestPlaceholders = [appName: stealthProfile.appName.toString()]
+        buildConfigField "boolean", "STEALTH_ENABLED", (stealthProfile.mode.toString() != "normal").toString()
+        buildConfigField "String", "STEALTH_MODE", buildConfigString(stealthProfile.mode)
+        buildConfigField "String", "STEALTH_PACKAGE_NAME", buildConfigString(stealthProfile.packageName)
+        buildConfigField "String", "STEALTH_APP_NAME", buildConfigString(stealthProfile.appName)
+        buildConfigField "String", "STEALTH_SESSION_NAME", buildConfigString(stealthProfile.sessionName)
+        buildConfigField "int", "STEALTH_DENYLIST_VERSION", stealthProfile.denylistVersion.toString()
         buildConfigField "String", "SIDELOAD_SIGNING_CERTIFICATE_SHA256", "\"${sideloadSigningCertificateSha256}\""
 
         ndk {
@@ -128,9 +254,6 @@ android {
                 cppFlags "-std=c++14 -fexceptions -frtti"
                 arguments "-DANDROID_ARM_NEON=TRUE", '-DANDROID_STL=c++_shared'
             }
-        }
-        buildFeatures {
-            buildConfig true
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -19,7 +19,7 @@
     <application
         android:name=".LanternApp"
         android:icon="@mipmap/ic_launcher"
-        android:label="Lantern"
+        android:label="${appName}"
         android:usesCleartextTraffic="true"
         android:roundIcon="@mipmap/ic_launcher_round">
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -46,7 +46,7 @@ class LanternVpnService :
     PlatformInterfaceWrapper {
     companion object {
         private const val TAG = "LanternVpnService"
-        private const val sessionName = "LanternVpn"
+        private val sessionName = BuildConfig.STEALTH_SESSION_NAME
         const val ACTION_START_RADIANCE = "com.getlantern.START_RADIANCE"
         const val ACTION_START_VPN = "org.getlantern.START_VPN"
         const val ACTION_CONNECT_TO_SERVER = "org.getlantern.CONNECT_TO_SERVER"
@@ -70,14 +70,6 @@ class LanternVpnService :
         private val connectInFlight = AtomicBoolean(false)
 
         lateinit var instance: LanternVpnService
-
-        // Process-lifetime scope for teardown that must run off the main thread
-        // but outlive the service instance. Mobile.stopVPN() is a blocking JNI
-        // call; running it on the main thread in onDestroy ANRs during service
-        // teardown (getlantern/engineering#3563). serviceScope is cancelled in
-        // onDestroy's finally, so teardown can't live there — this scope is
-        // never cancelled.
-        private val teardownScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     }
 
     private val notificationHelper = NotificationHelper()
@@ -170,43 +162,42 @@ class LanternVpnService :
     override fun onDestroy() {
         try {
             AppLogger.d(TAG, "destroying LanternVpnService")
-            // Only the TUN fd close stays synchronous on the main thread — it's
-            // cheap and the OS should release the interface promptly.
             closeTunInterface()
-
-            // Everything else runs OFF the main thread. Mobile.stopVPN() is a
-            // blocking JNI call (tunnel/connection close) — running it on the
-            // main thread here ANRs during service teardown and contends with any
-            // in-flight performStopVPN (getlantern/engineering#3563). teardownScope
-            // is process-lifetime, so this survives the serviceScope.cancel()
-            // below and still completes, keeping the next process launch clean.
-            // Mobile.stopVPN() is a no-op when c.tunnel is already nil, so a
-            // double-call from the stop path is harmless. Closed unconditionally
-            // when radiance is up: any non-Connected state (Restarting,
-            // Connecting, Disconnecting, Error) still has a non-nil c.tunnel.
-            // The notification/tile/receiver cleanup runs AFTER stopVPN so the UI
-            // reflects the stopped state and the status receiver stays registered
-            // through teardown. serviceCleanUp() unregisters via the application
-            // context (not the service), so running it after super.onDestroy() is safe.
-            teardownScope.launch {
-                runCatching {
-                    if (Mobile.isRadianceConnected()) {
-                        Mobile.stopVPN()
-                        AppLogger.d(TAG, "stopVPN completed during destroy")
-                    } else {
-                        AppLogger.d(TAG, "Skipping stopVPN — Radiance IPC not running")
+            // Clean up synchronously — cannot use serviceScope here because
+            // it is cancelled in the finally block below.
+            //
+            // Call Mobile.stopVPN() as long as radiance is up. The previous
+            // isVPNConnected() guard (status == Connected) was wrong — if the
+            // tunnel is in any non-Connected state (Restarting, Connecting,
+            // Disconnecting, Error), c.tunnel is still non-nil on the Go side
+            // and needs to be closed so the next process lifetime starts clean.
+            // Mobile.stopVPN() itself is a no-op when c.tunnel is nil.
+            val radianceConnected = Mobile.isRadianceConnected()
+            AppLogger.d(TAG, "onDestroy — radianceConnected=$radianceConnected")
+            if (!radianceConnected) {
+                AppLogger.d(TAG, "Skipping stopVPN — Radiance IPC not running")
+            } else {
+                runCatching { Mobile.stopVPN() }
+                    .onSuccess { AppLogger.d(TAG, "stopVPN completed during destroy") }
+                    .onFailure { e ->
+                        AppLogger.e(TAG, "Mobile.stopVPN() failed during destroy", e)
                     }
-                }.onFailure { e -> AppLogger.e(TAG, "Mobile.stopVPN() failed during destroy", e) }
-
-                runCatching { DefaultNetworkMonitor.stop() }
-                    .onFailure { e -> AppLogger.e(TAG, "DefaultNetworkMonitor.stop() failed during destroy", e) }
-
-                notificationHelper.stopVPNConnectedNotification(this@LanternVpnService)
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    QuickTileService.triggerUpdateTileState(this@LanternVpnService, false)
-                }
-                serviceCleanUp()
             }
+            runCatching {
+                runBlocking(Dispatchers.IO) { DefaultNetworkMonitor.stop() }
+            }.onFailure { e ->
+                AppLogger.e(
+                    TAG,
+                    "DefaultNetworkMonitor.stop() failed during destroy",
+                    e
+                )
+            }
+            notificationHelper.stopVPNConnectedNotification(this)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                QuickTileService.triggerUpdateTileState(this, false)
+            }
+            serviceCleanUp()
+
         } finally {
             serviceScope.cancel()
             super.onDestroy()

--- a/docs/stealth-build-profile.md
+++ b/docs/stealth-build-profile.md
@@ -1,0 +1,111 @@
+# Stealth Build Profile
+
+Stealth builds use the normal Lantern source tree. The build is switched by
+passing either a generated profile mode or a private profile JSON file into the
+existing Makefile targets.
+
+Normal builds are unchanged when neither `STEALTH_MODE` nor `STEALTH_PROFILE`
+is set.
+
+## Generate a Profile
+
+Generate a private profile under `build/stealth/`:
+
+```sh
+make stealth-profile STEALTH_MODE=stealth-vpn
+```
+
+Supported modes are:
+
+- `stealth-vpn`
+- `stealth-novpn`
+
+The generated profile includes:
+
+- `mode`
+- `packageName`
+- `appName`
+- `sessionName`
+- `goObfuscationSeed`
+- `denylistVersion`
+
+Override generated values with Make variables:
+
+```sh
+make stealth-profile \
+  STEALTH_MODE=stealth-vpn \
+  STEALTH_PACKAGE_NAME=org.example.client.s123 \
+  STEALTH_APP_NAME=Client \
+  STEALTH_SESSION_NAME=ClientVpn \
+  STEALTH_GO_OBFUSCATION_SEED=0123456789abcdef \
+  STEALTH_DENYLIST_VERSION=1
+```
+
+Use an existing private profile:
+
+```sh
+make stealth-profile STEALTH_PROFILE=/secure/profiles/client.json
+```
+
+## Build With a Profile
+
+Android build targets generate or normalize the profile before invoking Flutter:
+
+```sh
+make android-release STEALTH_MODE=stealth-vpn
+make android-release STEALTH_PROFILE=/secure/profiles/client.json
+```
+
+The Makefile writes:
+
+- `build/stealth/profile.json`: private normalized profile for support/debugging
+- `build/stealth/profile.inputs`: private Make cache key for profile inputs
+- `build/stealth/dart-defines.json`: Flutter `--dart-define-from-file` input
+- `build/stealth/artifact-metadata.json`: private CI artifact metadata
+- `build/stealth/go-tags-suffix.txt`: Go build tag suffix consumed by Make
+
+Treat the entire `build/stealth/` directory as private and do not publish these
+files in public release artifacts. They contain profile values that identify a
+build stream. Dart defines, metadata, and the Make cache key omit the raw Go
+obfuscation seed; metadata and the cache key include seed hashes for change
+detection and support correlation.
+
+## Android Plumbing
+
+`android/app/build.gradle` reads the normalized profile from a
+`-PstealthProfile=/path/to/profile` Gradle property, or from
+`ORG_GRADLE_PROJECT_stealthProfile` when invoked through Flutter/Make. The
+legacy `STEALTH_PROFILE` environment variable remains a fallback for manual
+non-daemon Gradle invocations.
+
+Gradle profile loading only affects Android manifest and `BuildConfig` values.
+It does not populate Dart constants by itself. Use the Make targets, or pass
+the generated `build/stealth/dart-defines.json` explicitly with
+`flutter build --dart-define-from-file=build/stealth/dart-defines.json`, so
+`AppBuildInfo` and `AppSecrets` see the same profile values as Gradle.
+
+The profile sets:
+
+- Android `applicationId`
+- Android manifest app label
+- `BuildConfig.STEALTH_*` constants
+
+The Android namespace and Kotlin package remain `org.getlantern.lantern`, so no
+separate source tree is needed.
+
+## Dart and Go Plumbing
+
+Flutter receives profile values through `--dart-define-from-file`, exposed in
+`AppBuildInfo.stealth*` constants. Go builds receive tags:
+
+- `stealth`
+- `stealth_vpn` or `stealth_novpn`
+
+## Package Name Migration Tradeoff
+
+Generated stealth profiles use a per-profile Android package name by default.
+Android treats each package name as a different app, so a build with a new
+`packageName` does not update an existing install and does not share that app's
+data directory. Release and support workflows need to keep the private profile
+for each distributed build so they can identify which package name, app label,
+session name, denylist version, and Go obfuscation seed were used.

--- a/lib/core/common/app_build_info.dart
+++ b/lib/core/common/app_build_info.dart
@@ -17,6 +17,38 @@ class AppBuildInfo {
     defaultValue: false,
   );
 
+  static const String stealthMode = String.fromEnvironment(
+    'STEALTH_MODE',
+    defaultValue: 'normal',
+  );
+
+  static const bool stealthNoVpn = bool.fromEnvironment(
+    'STEALTH_NO_VPN',
+    defaultValue: false,
+  );
+
+  static const String stealthPackageName = String.fromEnvironment(
+    'STEALTH_PACKAGE_NAME',
+    defaultValue: 'org.getlantern.lantern',
+  );
+
+  static const String stealthAppName = String.fromEnvironment(
+    'STEALTH_APP_NAME',
+    defaultValue: 'Lantern',
+  );
+
+  static const String stealthSessionName = String.fromEnvironment(
+    'STEALTH_SESSION_NAME',
+    defaultValue: 'LanternVpn',
+  );
+
+  static const int stealthDenylistVersion = int.fromEnvironment(
+    'STEALTH_DENYLIST_VERSION',
+    defaultValue: 0,
+  );
+
+  static bool get isStealthBuild => stealthMode.startsWith('stealth-');
+
   /// Developer mode is exposed in debug and nightly builds only.
   static bool get isDevModeEnabled => kDebugMode || buildType == 'nightly';
 }

--- a/lib/core/common/app_secrets.dart
+++ b/lib/core/common/app_secrets.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:lantern/core/common/app_build_info.dart';
 
 class AppSecrets {
   static String get macosAppGroupId => dotenv.env['MACOS_APP_GROUP'] ?? '';
@@ -15,5 +16,5 @@ class AppSecrets {
   static String get windowsGuid =>
       dotenv.env['WINDOWS_GUID'] ?? dotenv.env['WINDOWS_APP_GUID'] ?? '';
 
-  static String get lanternPackageName => "org.getlantern.lantern";
+  static String get lanternPackageName => AppBuildInfo.stealthPackageName;
 }

--- a/scripts/stealth/generate_profile.py
+++ b/scripts/stealth/generate_profile.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Generate and validate Stealth Lantern build profiles."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import secrets
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+MAX_ANDROID_INT = 2_147_483_647
+VALID_MODES = ("stealth-vpn", "stealth-novpn")
+MODE_ALIASES = {
+    "vpn": "stealth-vpn",
+    "novpn": "stealth-novpn",
+}
+DEFAULTS = {
+    "denylistVersion": 0,
+}
+DART_DEFINE_KEYS = {
+    "mode": "STEALTH_MODE",
+    "packageName": "STEALTH_PACKAGE_NAME",
+    "appName": "STEALTH_APP_NAME",
+    "sessionName": "STEALTH_SESSION_NAME",
+    "denylistVersion": "STEALTH_DENYLIST_VERSION",
+}
+ARTIFACT_METADATA_KEYS = (
+    "appName",
+    "denylistVersion",
+    "generatedAt",
+    "mode",
+    "packageName",
+    "profileId",
+    "schemaVersion",
+    "sessionName",
+)
+PACKAGE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$")
+XML_ATTRIBUTE_RESERVED = set("\"'&<>")
+
+
+class ProfileError(ValueError):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except OSError as exc:
+        raise ProfileError(f"failed to read profile input {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ProfileError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ProfileError(f"profile input {path} must be a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    except OSError as exc:
+        raise ProfileError(f"failed to write JSON output {path}: {exc}") from exc
+
+
+def new_profile_id() -> str:
+    return f"stl_{secrets.token_hex(6)}"
+
+
+def default_package_name(profile_id: str) -> str:
+    suffix = profile_id[4:] if profile_id.startswith("stl_") else profile_id
+    return f"com.s{suffix}.app"
+
+
+def coerce_denylist_version(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ProfileError("denylistVersion must be a non-negative integer")
+    if isinstance(value, int):
+        version = value
+    elif isinstance(value, str) and re.fullmatch(r"\d+", value.strip()):
+        version = int(value.strip())
+    else:
+        raise ProfileError("denylistVersion must be a non-negative integer")
+    if version < 0:
+        raise ProfileError("denylistVersion must be a non-negative integer")
+    if version > MAX_ANDROID_INT:
+        raise ProfileError("denylistVersion must fit in a 32-bit signed integer")
+    return version
+
+
+def coerce_schema_version(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ProfileError("schemaVersion must be an integer")
+    if isinstance(value, int):
+        version = value
+    elif isinstance(value, str) and re.fullmatch(r"\d+", value.strip()):
+        version = int(value.strip())
+    else:
+        raise ProfileError("schemaVersion must be an integer")
+    if version != SCHEMA_VERSION:
+        raise ProfileError(
+            f"unsupported schemaVersion {version}; expected {SCHEMA_VERSION}"
+        )
+    return version
+
+
+def validate_manifest_placeholder_text(field: str, value: str) -> str:
+    if not value:
+        raise ProfileError(f"{field} is required")
+    if any(
+        char in XML_ATTRIBUTE_RESERVED or ord(char) < 32 or 0x7F <= ord(char) <= 0x9F
+        for char in value
+    ):
+        raise ProfileError(
+            f"{field} must not contain XML-reserved or control characters"
+        )
+    return value
+
+
+def normalize_mode(value: Any) -> str:
+    mode = str(value or "").strip()
+    return MODE_ALIASES.get(mode, mode)
+
+
+def validate_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    schema_version = coerce_schema_version(profile.get("schemaVersion", SCHEMA_VERSION))
+
+    mode = normalize_mode(profile.get("mode", ""))
+    if mode not in VALID_MODES:
+        raise ProfileError(f"mode must be one of: {', '.join(VALID_MODES)}")
+
+    package_name = str(profile.get("packageName", "")).strip()
+    if not PACKAGE_RE.fullmatch(package_name):
+        raise ProfileError(
+            "packageName must be a valid Android application ID with at least two segments"
+        )
+
+    app_name = str(profile.get("appName", "")).strip()
+    validate_manifest_placeholder_text("appName", app_name)
+
+    session_name = str(profile.get("sessionName", "")).strip()
+    validate_manifest_placeholder_text("sessionName", session_name)
+
+    go_obfuscation_seed = str(
+        profile.get("goObfuscationSeed") or profile.get("obfuscationSeed", "")
+    ).strip()
+    if not go_obfuscation_seed:
+        raise ProfileError("goObfuscationSeed is required")
+
+    normalized = dict(profile)
+    normalized["mode"] = mode
+    normalized["packageName"] = package_name
+    normalized["appName"] = app_name
+    normalized["sessionName"] = session_name
+    normalized.pop("nativeLibraryName", None)
+    normalized.pop("obfuscationSeed", None)
+    normalized["goObfuscationSeed"] = go_obfuscation_seed
+    normalized["denylistVersion"] = coerce_denylist_version(
+        profile.get("denylistVersion", DEFAULTS["denylistVersion"])
+    )
+    normalized["schemaVersion"] = schema_version
+    return normalized
+
+
+def build_profile(args: argparse.Namespace) -> dict[str, Any]:
+    loaded = {}
+    if args.input:
+        loaded = load_json(args.input)
+    elif args.output and args.output.exists():
+        loaded = load_json(args.output)
+
+    profile_id = str(loaded.get("profileId") or new_profile_id())
+    generated_at = str(
+        loaded.get("generatedAt")
+        or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    )
+
+    mode = normalize_mode(args.mode or loaded.get("mode", ""))
+
+    app_name = args.app_name or loaded.get("appName") or ""
+    session_name = args.session_name or loaded.get("sessionName") or ""
+
+    if mode in VALID_MODES:
+        if not app_name:
+            raise ProfileError(
+                "--app-name is required for stealth builds and must not be a Lantern-branded value"
+            )
+        if not session_name:
+            raise ProfileError(
+                "--session-name is required for stealth builds and must not be a Lantern-branded value"
+            )
+
+    profile = {
+        "schemaVersion": loaded.get("schemaVersion", SCHEMA_VERSION),
+        "profileId": profile_id,
+        "generatedAt": generated_at,
+        "mode": mode or None,
+        "packageName": args.package_name
+        or loaded.get("packageName")
+        or default_package_name(profile_id),
+        "appName": app_name,
+        "sessionName": session_name,
+        "goObfuscationSeed": args.go_obfuscation_seed
+        or loaded.get("goObfuscationSeed")
+        or loaded.get("obfuscationSeed")
+        or secrets.token_hex(16),
+        "denylistVersion": (
+            args.denylist_version
+            if args.denylist_version is not None
+            else loaded.get("denylistVersion", DEFAULTS["denylistVersion"])
+        ),
+    }
+
+    for key, value in loaded.items():
+        profile.setdefault(key, value)
+
+    return validate_profile(profile)
+
+
+def dart_defines(profile: dict[str, Any]) -> dict[str, str]:
+    defines = {define: str(profile[key]) for key, define in DART_DEFINE_KEYS.items()}
+    defines["STEALTH_NO_VPN"] = (
+        "true" if profile["mode"] == "stealth-novpn" else "false"
+    )
+    return defines
+
+
+def artifact_metadata(profile: dict[str, Any]) -> dict[str, Any]:
+    metadata = {key: profile[key] for key in ARTIFACT_METADATA_KEYS if key in profile}
+    metadata["goObfuscationSeedSha256"] = hashlib.sha256(
+        str(profile["goObfuscationSeed"]).encode("utf-8")
+    ).hexdigest()
+    return metadata
+
+
+def go_tags_suffix(profile: dict[str, Any]) -> str:
+    mode_tag = str(profile["mode"]).replace("-", "_")
+    return f",stealth,{mode_tag}"
+
+
+def load_go_tags_profile(args: argparse.Namespace) -> dict[str, Any]:
+    if not args.input:
+        raise ProfileError("--input is required when using --go-tags-suffix")
+    return validate_profile(load_json(args.input))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, help="optional input profile JSON")
+    parser.add_argument("--output", type=Path, help="normalized profile output path")
+    parser.add_argument("--dart-defines-output", type=Path)
+    parser.add_argument("--artifact-metadata-output", type=Path)
+    parser.add_argument("--go-tags-suffix", action="store_true")
+    parser.add_argument("--mode", choices=VALID_MODES + tuple(MODE_ALIASES))
+    parser.add_argument("--package-name")
+    parser.add_argument("--app-name")
+    parser.add_argument("--session-name")
+    parser.add_argument("--go-obfuscation-seed")
+    parser.add_argument("--denylist-version", type=int)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        profile = load_go_tags_profile(args) if args.go_tags_suffix else build_profile(args)
+        if args.go_tags_suffix:
+            print(go_tags_suffix(profile), end="")
+            return 0
+        if not args.output:
+            raise ProfileError("--output is required when generating a profile")
+        write_json(args.output, profile)
+        if args.dart_defines_output:
+            write_json(args.dart_defines_output, dart_defines(profile))
+        if args.artifact_metadata_output:
+            write_json(args.artifact_metadata_output, artifact_metadata(profile))
+        print(f"Wrote stealth profile: {args.output}")
+        return 0
+    except ProfileError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/stealth/generate_profile_test.py
+++ b/scripts/stealth/generate_profile_test.py
@@ -1,0 +1,252 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import generate_profile
+
+
+class GenerateProfileTest(unittest.TestCase):
+    def test_generates_profile_outputs_and_redacts_seed_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_path = root / "profile.json"
+            defines_path = root / "dart-defines.json"
+            metadata_path = root / "metadata.json"
+
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--app-name",
+                    "Beacon",
+                    "--session-name",
+                    "BeaconLink",
+                    "--go-obfuscation-seed",
+                    "seed-for-test",
+                    "--denylist-version",
+                    "7",
+                    "--output",
+                    str(profile_path),
+                    "--dart-defines-output",
+                    str(defines_path),
+                    "--artifact-metadata-output",
+                    str(metadata_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+
+            profile = json.loads(profile_path.read_text())
+            self.assertEqual(profile["mode"], "stealth-vpn")
+            self.assertEqual(profile["packageName"], "org.example.safe.s123")
+            self.assertEqual(profile["appName"], "Beacon")
+            self.assertEqual(profile["sessionName"], "BeaconLink")
+            self.assertNotIn("nativeLibraryName", profile)
+            self.assertEqual(profile["goObfuscationSeed"], "seed-for-test")
+            self.assertEqual(profile["denylistVersion"], 7)
+
+            defines = json.loads(defines_path.read_text())
+            self.assertEqual(defines["STEALTH_MODE"], "stealth-vpn")
+            self.assertEqual(defines["STEALTH_NO_VPN"], "false")
+            self.assertEqual(
+                defines["STEALTH_PACKAGE_NAME"], "org.example.safe.s123"
+            )
+            self.assertNotIn("STEALTH_NATIVE_LIBRARY_NAME", defines)
+            self.assertNotIn("STEALTH_GO_OBFUSCATION_SEED", defines)
+
+            metadata = json.loads(metadata_path.read_text())
+            self.assertNotIn("goObfuscationSeed", metadata)
+            self.assertNotIn("unexpectedPrivateField", metadata)
+            self.assertIn("goObfuscationSeedSha256", metadata)
+
+    def test_go_tags_suffix_from_profile(self):
+        profile = {
+            "mode": "stealth-novpn",
+            "packageName": "org.example.safe.s456",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+            "unexpectedPrivateField": "do-not-export",
+        }
+
+        normalized = generate_profile.validate_profile(profile)
+
+        self.assertEqual(normalized["mode"], "stealth-novpn")
+        self.assertEqual(generate_profile.dart_defines(normalized)["STEALTH_NO_VPN"], "true")
+        self.assertEqual(
+            generate_profile.go_tags_suffix(normalized),
+            ",stealth,stealth_novpn",
+        )
+        self.assertNotIn(
+            "unexpectedPrivateField",
+            generate_profile.artifact_metadata(normalized),
+        )
+
+    def test_accepts_mode_aliases(self):
+        profile = {
+            "mode": "novpn",
+            "packageName": "org.example.safe.s456",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        normalized = generate_profile.validate_profile(profile)
+
+        self.assertEqual(normalized["mode"], "stealth-novpn")
+
+    def test_go_tags_suffix_requires_input(self):
+        exit_code = generate_profile.main(["--go-tags-suffix"])
+
+        self.assertEqual(exit_code, 2)
+
+    def test_rejects_invalid_package_name(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "bad package",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_unsupported_schema_version(self):
+        profile = {
+            "schemaVersion": generate_profile.SCHEMA_VERSION + 1,
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_boolean_denylist_version(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": True,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_float_denylist_version(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 1.9,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_denylist_version_outside_android_int_range(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": generate_profile.MAX_ANDROID_INT + 1,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_write_json_wraps_os_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(generate_profile.ProfileError):
+                generate_profile.write_json(Path(tmp), {})
+
+    def test_rejects_manifest_placeholder_xml_characters(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": 'Bad "Label"',
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_manifest_placeholder_iso_control_characters(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Bad\x7fLabel",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_default_package_name_is_neutral(self):
+        """default_package_name must not embed 'lantern' or 'stealth' tokens."""
+        pkg = generate_profile.default_package_name("stl_abcdef")
+        self.assertNotIn("lantern", pkg.lower())
+        self.assertNotIn("stealth", pkg.lower())
+        # Must still be a valid Android application ID
+        import re
+        self.assertRegex(pkg, r"^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$")
+
+    def test_stealth_build_requires_app_name(self):
+        """build_profile must fail-fast when --app-name is absent for stealth modes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--session-name",
+                    "BeaconLink",
+                    "--output",
+                    str(Path(tmp) / "profile.json"),
+                ]
+            )
+            self.assertNotEqual(exit_code, 0)
+
+    def test_stealth_build_requires_session_name(self):
+        """build_profile must fail-fast when --session-name is absent for stealth modes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--app-name",
+                    "Beacon",
+                    "--output",
+                    str(Path(tmp) / "profile.json"),
+                ]
+            )
+            self.assertNotEqual(exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- adds `scripts/stealth/generate_profile.py` for private stealth-vpn/stealth-novpn build profiles
- wires profile values through Make targets, Flutter dart defines, Android Gradle, manifest app label, session name, and Go build tags
- records private artifact metadata with the Go obfuscation seed redacted to a hash
- documents profile generation, support metadata, and package-name migration tradeoffs

Closes getlantern/engineering#3571

## Validation
- `python3 -m unittest discover -s scripts/stealth -p *_test.py`
- `python3 -m py_compile scripts/stealth/generate_profile.py scripts/stealth/generate_profile_test.py`
- `dart format --set-exit-if-changed lib/core/common/app_build_info.dart lib/core/common/app_secrets.dart`
- `python3 scripts/stealth/generate_profile.py --mode stealth-novpn ... --output /tmp/lantern-8763-profile.json ...`
- `python3 scripts/stealth/generate_profile.py --input /tmp/lantern-8763-profile.json --go-tags-suffix`
- `make -n android-apk-release`
- `make -n android-apk-release STEALTH_MODE=stealth-vpn STEALTH_GO_OBFUSCATION_SEED=testseed`
- `make -n build-android ANDROID_SDK_ROOT=/tmp STEALTH_MODE=stealth-vpn STEALTH_GO_OBFUSCATION_SEED=testseed`
- `git diff --cached --check`

## Not run
- Full Android/Flutter builds: no Android SDK/Gradle wrapper available in this environment.