### PR TITLE
[stealth 11/11] Generate neutral stealth Android icons

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,9 @@ get-command = $(shell which="$$(which $(1) 2> /dev/null)" && if [[ ! -z "$$which
 APPDMG    := $(call get-command,appdmg)
 
 DART_DEFINES := --dart-define=BUILD_TYPE=$(BUILD_TYPE) $(if $(VERSION),--dart-define=VERSION=$(VERSION),)
+STEALTH_ICON_SEED ?=
+STEALTH_ICON_RES_DIR ?= android/app/build/generated/stealth-icons/res
+export STEALTH_ICON_SEED
 
 INSTALLER_RESOURCES := installer-resources
 
@@ -182,6 +185,12 @@ guard-%:
 
 check-gomobile:
 	@command -v gomobile >/dev/null || (echo "gomobile not found. Run 'make install-android-deps'" && exit 1)
+
+.PHONY: stealth-android-icons
+stealth-android-icons: guard-STEALTH_ICON_SEED
+	python3 scripts/stealth/generate_android_icons.py \
+		--seed "$(STEALTH_ICON_SEED)" \
+		--output-res-dir "$(STEALTH_ICON_RES_DIR)"
 
 
 .PHONY: require-appdmg

--- a/Makefile
+++ b/Makefile
@@ -189,7 +189,6 @@ check-gomobile:
 .PHONY: stealth-android-icons
 stealth-android-icons: guard-STEALTH_ICON_SEED
 	python3 scripts/stealth/generate_android_icons.py \
-		--seed "$(STEALTH_ICON_SEED)" \
 		--output-res-dir "$(STEALTH_ICON_RES_DIR)"
 
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -43,6 +43,7 @@ def now = System.currentTimeMillis()
 def code = (int)((now - start) / 1000)
 def stealthIconSeed = (findProperty("stealthIconSeed") ?: System.getenv("STEALTH_ICON_SEED"))?.toString()?.trim()
 def generatedStealthIconResDir = layout.buildDirectory.dir("generated/stealth-icons/res")
+def generatedStealthIconMetadata = layout.buildDirectory.file("generated/stealth-icons/stealth-icon-metadata.json")
 def launcherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher" : "@mipmap/ic_launcher"
 def roundLauncherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher_round" : "@mipmap/ic_launcher_round"
 
@@ -188,6 +189,7 @@ tasks.register("generateStealthAndroidIcons", Exec) {
     onlyIf { stealthIconSeed }
     inputs.property("stealthIconSeed", stealthIconSeed ?: "")
     outputs.dir(generatedStealthIconResDir)
+    outputs.file(generatedStealthIconMetadata)
     commandLine "python3",
             "${rootProject.projectDir.parentFile}/scripts/stealth/generate_android_icons.py",
             "--seed", stealthIconSeed ?: "",

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -52,8 +52,8 @@ def stealthIconSeedSha256 = stealthIconSeed ? sha256Hex(stealthIconSeed) : ""
 def generatedStealthIconResDir = layout.buildDirectory.dir("generated/stealth-icons/res")
 def generatedStealthIconMetadata = layout.buildDirectory.file("generated/stealth-icons/stealth-icon-metadata.json")
 def generatedStealthIconScript = file("${rootProject.projectDir.parentFile}/scripts/stealth/generate_android_icons.py")
-def launcherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher" : "@mipmap/ic_launcher"
-def roundLauncherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher_round" : "@mipmap/ic_launcher_round"
+def launcherIconResource = stealthIconSeed ? "@mipmap/ic_launcher_alt" : "@mipmap/ic_launcher"
+def roundLauncherIconResource = stealthIconSeed ? "@mipmap/ic_launcher_alt_round" : "@mipmap/ic_launcher_round"
 
 android {
     namespace = "org.getlantern.lantern"

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -41,6 +41,10 @@ def generateSideloadManifest = tasks.register("generateSideloadManifest") {
 def start = new Date(2015, 1, 1).getTime()
 def now = System.currentTimeMillis()
 def code = (int)((now - start) / 1000)
+def stealthIconSeed = (findProperty("stealthIconSeed") ?: System.getenv("STEALTH_ICON_SEED"))?.toString()?.trim()
+def generatedStealthIconResDir = layout.buildDirectory.dir("generated/stealth-icons/res")
+def launcherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher" : "@mipmap/ic_launcher"
+def roundLauncherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher_round" : "@mipmap/ic_launcher_round"
 
 android {
     namespace = "org.getlantern.lantern"
@@ -57,6 +61,7 @@ android {
             }
             jniLibs.srcDirs = ['libs']
             jniLibs.srcDirs += ['src/main/jniLibs']
+            res.srcDirs += [generatedStealthIconResDir.get().asFile]
         }
     }
 
@@ -115,6 +120,10 @@ android {
         versionCode = code
         versionName = flutter.versionName
         buildConfigField "String", "SIDELOAD_SIGNING_CERTIFICATE_SHA256", "\"${sideloadSigningCertificateSha256}\""
+        manifestPlaceholders += [
+                launcherIcon     : launcherIconResource,
+                roundLauncherIcon: roundLauncherIconResource,
+        ]
 
         ndk {
             // arm64 only (APK + AAB) — armeabi-v7a dropped, see the comment
@@ -174,6 +183,18 @@ if (sideloadUpdates) {
     tasks.matching { it.name.startsWith("process") && it.name.endsWith("MainManifest") }
             .configureEach { dependsOn(generateSideloadManifest) }
 }
+
+tasks.register("generateStealthAndroidIcons", Exec) {
+    onlyIf { stealthIconSeed }
+    inputs.property("stealthIconSeed", stealthIconSeed ?: "")
+    outputs.dir(generatedStealthIconResDir)
+    commandLine "python3",
+            "${rootProject.projectDir.parentFile}/scripts/stealth/generate_android_icons.py",
+            "--seed", stealthIconSeed ?: "",
+            "--output-res-dir", generatedStealthIconResDir.get().asFile.absolutePath
+}
+
+preBuild.dependsOn("generateStealthAndroidIcons")
 
 flutter {
     source = "../.."

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,6 +51,7 @@ def sha256Hex = { value ->
 def stealthIconSeedSha256 = stealthIconSeed ? sha256Hex(stealthIconSeed) : ""
 def generatedStealthIconResDir = layout.buildDirectory.dir("generated/stealth-icons/res")
 def generatedStealthIconMetadata = layout.buildDirectory.file("generated/stealth-icons/stealth-icon-metadata.json")
+def generatedStealthIconScript = file("${rootProject.projectDir.parentFile}/scripts/stealth/generate_android_icons.py")
 def launcherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher" : "@mipmap/ic_launcher"
 def roundLauncherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher_round" : "@mipmap/ic_launcher_round"
 
@@ -197,11 +198,12 @@ if (sideloadUpdates) {
 tasks.register("generateStealthAndroidIcons", Exec) {
     onlyIf { stealthIconSeed }
     inputs.property("stealthIconSeedSha256", stealthIconSeedSha256)
+    inputs.file(generatedStealthIconScript)
     outputs.dir(generatedStealthIconResDir)
     outputs.file(generatedStealthIconMetadata)
     environment "STEALTH_ICON_SEED", stealthIconSeed ?: ""
     commandLine "python3",
-            "${rootProject.projectDir.parentFile}/scripts/stealth/generate_android_icons.py",
+            generatedStealthIconScript.absolutePath,
             "--output-res-dir", generatedStealthIconResDir.get().asFile.absolutePath
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -45,7 +45,7 @@ def stealthIconSeed = (findProperty("stealthIconSeed") ?: System.getenv("STEALTH
 def sha256Hex = { value ->
     java.security.MessageDigest.getInstance("SHA-256")
             .digest(value.getBytes("UTF-8"))
-            .collect { String.format("%02x", it) }
+            .collect { String.format("%02x", it & 0xff) }
             .join()
 }
 def stealthIconSeedSha256 = stealthIconSeed ? sha256Hex(stealthIconSeed) : ""

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -42,6 +42,13 @@ def start = new Date(2015, 1, 1).getTime()
 def now = System.currentTimeMillis()
 def code = (int)((now - start) / 1000)
 def stealthIconSeed = (findProperty("stealthIconSeed") ?: System.getenv("STEALTH_ICON_SEED"))?.toString()?.trim()
+def sha256Hex = { value ->
+    java.security.MessageDigest.getInstance("SHA-256")
+            .digest(value.getBytes("UTF-8"))
+            .collect { String.format("%02x", it) }
+            .join()
+}
+def stealthIconSeedSha256 = stealthIconSeed ? sha256Hex(stealthIconSeed) : ""
 def generatedStealthIconResDir = layout.buildDirectory.dir("generated/stealth-icons/res")
 def generatedStealthIconMetadata = layout.buildDirectory.file("generated/stealth-icons/stealth-icon-metadata.json")
 def launcherIconResource = stealthIconSeed ? "@mipmap/stealth_ic_launcher" : "@mipmap/ic_launcher"
@@ -189,12 +196,12 @@ if (sideloadUpdates) {
 
 tasks.register("generateStealthAndroidIcons", Exec) {
     onlyIf { stealthIconSeed }
-    inputs.property("stealthIconSeed", stealthIconSeed ?: "")
+    inputs.property("stealthIconSeedSha256", stealthIconSeedSha256)
     outputs.dir(generatedStealthIconResDir)
     outputs.file(generatedStealthIconMetadata)
+    environment "STEALTH_ICON_SEED", stealthIconSeed ?: ""
     commandLine "python3",
             "${rootProject.projectDir.parentFile}/scripts/stealth/generate_android_icons.py",
-            "--seed", stealthIconSeed ?: "",
             "--output-res-dir", generatedStealthIconResDir.get().asFile.absolutePath
 }
 

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -62,7 +62,9 @@ android {
             }
             jniLibs.srcDirs = ['libs']
             jniLibs.srcDirs += ['src/main/jniLibs']
-            res.srcDirs += [generatedStealthIconResDir.get().asFile]
+            if (stealthIconSeed) {
+                res.srcDirs += [generatedStealthIconResDir.get().asFile]
+            }
         }
     }
 

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -18,10 +18,10 @@
 
     <application
         android:name=".LanternApp"
-        android:icon="@mipmap/ic_launcher"
+        android:icon="${launcherIcon}"
         android:label="Lantern"
         android:usesCleartextTraffic="true"
-        android:roundIcon="@mipmap/ic_launcher_round">
+        android:roundIcon="${roundLauncherIcon}">
 
         <activity
             android:name=".MainActivity"

--- a/docs/stealth-android-icons.md
+++ b/docs/stealth-android-icons.md
@@ -1,0 +1,45 @@
+# Stealth Android icons
+
+Stealth Android variants can generate a neutral launcher icon set from a
+private per-variant seed. Normal builds keep the existing launcher icons.
+
+## Generate Locally
+
+```sh
+make stealth-android-icons STEALTH_ICON_SEED="$PRIVATE_VARIANT_ICON_SEED"
+```
+
+This writes Android resources under
+`android/app/build/generated/stealth-icons/res`:
+
+- adaptive launcher icon: `@mipmap/stealth_ic_launcher`
+- adaptive round launcher icon: `@mipmap/stealth_ic_launcher_round`
+- foreground vector: `@drawable/stealth_launcher_foreground`
+- notification icon candidate: `@drawable/stealth_notification_icon`
+- private metadata: `stealth-icon-metadata.json`
+
+The metadata stores only the seed hash, not the raw seed.
+
+## Build Wiring
+
+Android Gradle reads `STEALTH_ICON_SEED` or `-PstealthIconSeed=...`. When a
+seed is present, the manifest placeholders switch the app icon and round icon
+to the generated resources:
+
+```sh
+STEALTH_ICON_SEED="$PRIVATE_VARIANT_ICON_SEED" make android-apk-release
+```
+
+Without a seed, the placeholders resolve to the existing `@mipmap/ic_launcher`
+and `@mipmap/ic_launcher_round` resources.
+
+## Release Policy
+
+Use a different private icon seed for every distributed stealth variant. Keep
+the seed and `stealth-icon-metadata.json` with the private build profile so
+support can correlate a report with the shipped visual identity. Do not publish
+the seed or metadata with public artifacts.
+
+The generated icons are intentionally generic geometric utility icons. If design
+provides a curated pool later, the same Gradle placeholder path can select
+pre-rendered resources by variant ID instead of procedural output.

--- a/docs/stealth-android-icons.md
+++ b/docs/stealth-android-icons.md
@@ -14,11 +14,14 @@ This writes Android resources under
 
 - adaptive launcher icon: `@mipmap/stealth_ic_launcher`
 - adaptive round launcher icon: `@mipmap/stealth_ic_launcher_round`
+- pre-26 fallback launcher icons in `mipmap-anydpi`
 - foreground vector: `@drawable/stealth_launcher_foreground`
 - notification icon candidate: `@drawable/stealth_notification_icon`
-- private metadata: `stealth-icon-metadata.json`
 
-The metadata stores only the seed hash, not the raw seed.
+Private metadata is written outside the resource tree at
+`android/app/build/generated/stealth-icons/stealth-icon-metadata.json`. It
+stores only the seed hash, not the raw seed, and is not packaged as an Android
+resource.
 
 ## Build Wiring
 

--- a/scripts/stealth/generate_android_icons.py
+++ b/scripts/stealth/generate_android_icons.py
@@ -7,6 +7,7 @@ import argparse
 import colorsys
 import hashlib
 import json
+import os
 import secrets
 from pathlib import Path
 
@@ -144,12 +145,12 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
     return metadata
 
 
-def parse_args() -> argparse.Namespace:
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--seed",
         default="",
-        help="private per-variant seed; random if omitted",
+        help="private per-variant seed; defaults to STEALTH_ICON_SEED; random if omitted",
     )
     parser.add_argument(
         "--output-res-dir",
@@ -157,12 +158,12 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="Android generated resource directory",
     )
-    return parser.parse_args()
+    return parser.parse_args(argv)
 
 
-def main() -> int:
-    args = parse_args()
-    seed = args.seed or secrets.token_urlsafe(24)
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    seed = args.seed or os.environ.get("STEALTH_ICON_SEED", "") or secrets.token_urlsafe(24)
     metadata = generate(seed, args.output_res_dir)
     print(
         "Generated stealth Android icons:",

--- a/scripts/stealth/generate_android_icons.py
+++ b/scripts/stealth/generate_android_icons.py
@@ -71,16 +71,16 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
     mipmap_dir = output_res_dir / "mipmap-anydpi-v26"
 
     write_text(
-        values_dir / "stealth_icon_colors.xml",
+        values_dir / "icon_colors_alt.xml",
         f"""
 <resources>
-    <color name="stealth_launcher_background">{background}</color>
+    <color name="launcher_background_alt">{background}</color>
 </resources>
 """,
     )
 
     write_text(
-        drawable_dir / "stealth_launcher_foreground.xml",
+        drawable_dir / "launcher_foreground_alt.xml",
         f"""
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
@@ -93,7 +93,7 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
     )
 
     write_text(
-        drawable_dir / "stealth_notification_icon.xml",
+        drawable_dir / "ic_notification_alt.xml",
         """
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="24dp"
@@ -106,7 +106,7 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
     )
 
     write_text(
-        drawable_dir / "stealth_launcher_monochrome.xml",
+        drawable_dir / "launcher_monochrome_alt.xml",
         f"""
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
@@ -120,13 +120,13 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
 
     adaptive_icon = """
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
-    <background android:drawable="@color/stealth_launcher_background"/>
-    <foreground android:drawable="@drawable/stealth_launcher_foreground"/>
-    <monochrome android:drawable="@drawable/stealth_launcher_monochrome"/>
+    <background android:drawable="@color/launcher_background_alt"/>
+    <foreground android:drawable="@drawable/launcher_foreground_alt"/>
+    <monochrome android:drawable="@drawable/launcher_monochrome_alt"/>
 </adaptive-icon>
 """
-    write_text(mipmap_dir / "stealth_ic_launcher.xml", adaptive_icon)
-    write_text(mipmap_dir / "stealth_ic_launcher_round.xml", adaptive_icon)
+    write_text(mipmap_dir / "ic_launcher_alt.xml", adaptive_icon)
+    write_text(mipmap_dir / "ic_launcher_alt_round.xml", adaptive_icon)
 
     legacy_icon = f"""
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
@@ -138,8 +138,8 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
 {shape_paths(data, primary, secondary, accent)}
 </vector>
 """
-    write_text(legacy_mipmap_dir / "stealth_ic_launcher.xml", legacy_icon)
-    write_text(legacy_mipmap_dir / "stealth_ic_launcher_round.xml", legacy_icon)
+    write_text(legacy_mipmap_dir / "ic_launcher_alt.xml", legacy_icon)
+    write_text(legacy_mipmap_dir / "ic_launcher_alt_round.xml", legacy_icon)
 
     metadata = {
         "seedSha256": hashlib.sha256(seed.encode("utf-8")).hexdigest(),
@@ -147,10 +147,10 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
         "primary": primary,
         "secondary": secondary,
         "accent": accent,
-        "launcherIcon": "@mipmap/stealth_ic_launcher",
-        "roundLauncherIcon": "@mipmap/stealth_ic_launcher_round",
-        "monochromeIcon": "@drawable/stealth_launcher_monochrome",
-        "notificationIcon": "@drawable/stealth_notification_icon",
+        "launcherIcon": "@mipmap/ic_launcher_alt",
+        "roundLauncherIcon": "@mipmap/ic_launcher_alt_round",
+        "monochromeIcon": "@drawable/launcher_monochrome_alt",
+        "notificationIcon": "@drawable/ic_notification_alt",
     }
     write_text(
         output_res_dir.parent / "stealth-icon-metadata.json",

--- a/scripts/stealth/generate_android_icons.py
+++ b/scripts/stealth/generate_android_icons.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Generate deterministic neutral Android icon resources for stealth variants."""
+
+from __future__ import annotations
+
+import argparse
+import colorsys
+import hashlib
+import json
+import secrets
+from pathlib import Path
+
+
+def hash_bytes(seed: str) -> bytes:
+    return hashlib.sha256(seed.encode("utf-8")).digest()
+
+
+def color_from_hash(data: bytes, offset: int, sat: float, light: float) -> str:
+    hue = int.from_bytes(data[offset : offset + 2], "big") / 65535
+    red, green, blue = colorsys.hls_to_rgb(hue, light, sat)
+    return "#{:02X}{:02X}{:02X}".format(
+        round(red * 255),
+        round(green * 255),
+        round(blue * 255),
+    )
+
+
+def shape_paths(data: bytes, primary: str, secondary: str, accent: str) -> str:
+    template = data[4] % 4
+    if template == 0:
+        return f"""
+    <path android:fillColor="{primary}" android:pathData="M54,14 L92,54 L54,94 L16,54 Z"/>
+    <path android:fillColor="{secondary}" android:pathData="M54,28 L78,54 L54,80 L30,54 Z"/>
+    <path android:fillColor="{accent}" android:pathData="M47,47 L61,47 L61,61 L47,61 Z"/>
+"""
+    if template == 1:
+        return f"""
+    <path android:fillColor="{primary}" android:pathData="M22,24 L86,24 L86,84 L22,84 Z"/>
+    <path android:fillColor="{secondary}" android:pathData="M34,36 L74,36 L74,72 L34,72 Z"/>
+    <path android:fillColor="{accent}" android:pathData="M42,46 L66,46 L66,62 L42,62 Z"/>
+"""
+    if template == 2:
+        return f"""
+    <path android:fillColor="{primary}" android:pathData="M54,12 L78,22 L96,46 L88,74 L64,94 L36,90 L16,68 L14,38 L34,18 Z"/>
+    <path android:fillColor="{secondary}" android:pathData="M54,28 L70,36 L82,54 L74,72 L54,80 L34,72 L26,54 L38,36 Z"/>
+    <path android:fillColor="{accent}" android:pathData="M54,43 L65,54 L54,65 L43,54 Z"/>
+"""
+    return f"""
+    <path android:fillColor="{primary}" android:pathData="M18,74 L42,22 L66,74 Z"/>
+    <path android:fillColor="{secondary}" android:pathData="M48,74 L66,34 L90,74 Z"/>
+    <path android:fillColor="{accent}" android:pathData="M44,74 L58,48 L72,74 Z"/>
+"""
+
+
+def write_text(path: Path, value: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(value.strip() + "\n", encoding="utf-8")
+
+
+def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
+    data = hash_bytes(seed)
+    background = color_from_hash(data, 0, 0.46, 0.30)
+    primary = color_from_hash(data, 6, 0.42, 0.74)
+    secondary = color_from_hash(data, 10, 0.36, 0.58)
+    accent = color_from_hash(data, 14, 0.56, 0.82)
+
+    values_dir = output_res_dir / "values"
+    drawable_dir = output_res_dir / "drawable"
+    mipmap_dir = output_res_dir / "mipmap-anydpi-v26"
+
+    write_text(
+        values_dir / "stealth_icon_colors.xml",
+        f"""
+<resources>
+    <color name="stealth_launcher_background">{background}</color>
+</resources>
+""",
+    )
+
+    write_text(
+        drawable_dir / "stealth_launcher_foreground.xml",
+        f"""
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+{shape_paths(data, primary, secondary, accent)}
+</vector>
+""",
+    )
+
+    write_text(
+        drawable_dir / "stealth_notification_icon.xml",
+        """
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path android:fillColor="#FFFFFFFF" android:pathData="M12,3 L21,12 L12,21 L3,12 Z"/>
+    <path android:fillColor="#00000000" android:pathData="M12,8 L16,12 L12,16 L8,12 Z"/>
+</vector>
+""",
+    )
+
+    adaptive_icon = """
+<adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
+    <background android:drawable="@color/stealth_launcher_background"/>
+    <foreground android:drawable="@drawable/stealth_launcher_foreground"/>
+    <monochrome android:drawable="@drawable/stealth_notification_icon"/>
+</adaptive-icon>
+"""
+    write_text(mipmap_dir / "stealth_ic_launcher.xml", adaptive_icon)
+    write_text(mipmap_dir / "stealth_ic_launcher_round.xml", adaptive_icon)
+
+    metadata = {
+        "seedSha256": hashlib.sha256(seed.encode("utf-8")).hexdigest(),
+        "background": background,
+        "primary": primary,
+        "secondary": secondary,
+        "accent": accent,
+        "launcherIcon": "@mipmap/stealth_ic_launcher",
+        "roundLauncherIcon": "@mipmap/stealth_ic_launcher_round",
+        "notificationIcon": "@drawable/stealth_notification_icon",
+    }
+    write_text(
+        output_res_dir / "stealth-icon-metadata.json",
+        json.dumps(metadata, indent=2, sort_keys=True),
+    )
+    return metadata
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seed",
+        default="",
+        help="private per-variant seed; random if omitted",
+    )
+    parser.add_argument(
+        "--output-res-dir",
+        type=Path,
+        required=True,
+        help="Android generated resource directory",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    seed = args.seed or secrets.token_urlsafe(24)
+    metadata = generate(seed, args.output_res_dir)
+    print(
+        "Generated stealth Android icons:",
+        args.output_res_dir,
+        metadata["seedSha256"],
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/stealth/generate_android_icons.py
+++ b/scripts/stealth/generate_android_icons.py
@@ -66,6 +66,7 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
 
     values_dir = output_res_dir / "values"
     drawable_dir = output_res_dir / "drawable"
+    legacy_mipmap_dir = output_res_dir / "mipmap-anydpi"
     mipmap_dir = output_res_dir / "mipmap-anydpi-v26"
 
     write_text(
@@ -114,6 +115,19 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
     write_text(mipmap_dir / "stealth_ic_launcher.xml", adaptive_icon)
     write_text(mipmap_dir / "stealth_ic_launcher_round.xml", adaptive_icon)
 
+    legacy_icon = f"""
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path android:fillColor="{background}" android:pathData="M0,0 L108,0 L108,108 L0,108 Z"/>
+{shape_paths(data, primary, secondary, accent)}
+</vector>
+"""
+    write_text(legacy_mipmap_dir / "stealth_ic_launcher.xml", legacy_icon)
+    write_text(legacy_mipmap_dir / "stealth_ic_launcher_round.xml", legacy_icon)
+
     metadata = {
         "seedSha256": hashlib.sha256(seed.encode("utf-8")).hexdigest(),
         "background": background,
@@ -125,7 +139,7 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
         "notificationIcon": "@drawable/stealth_notification_icon",
     }
     write_text(
-        output_res_dir / "stealth-icon-metadata.json",
+        output_res_dir.parent / "stealth-icon-metadata.json",
         json.dumps(metadata, indent=2, sort_keys=True),
     )
     return metadata

--- a/scripts/stealth/generate_android_icons.py
+++ b/scripts/stealth/generate_android_icons.py
@@ -100,7 +100,6 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
     android:viewportWidth="24"
     android:viewportHeight="24">
     <path android:fillColor="#FFFFFFFF" android:pathData="M12,3 L21,12 L12,21 L3,12 Z"/>
-    <path android:fillColor="#00000000" android:pathData="M12,8 L16,12 L12,16 L8,12 Z"/>
 </vector>
 """,
     )

--- a/scripts/stealth/generate_android_icons.py
+++ b/scripts/stealth/generate_android_icons.py
@@ -30,7 +30,7 @@ def shape_paths(data: bytes, primary: str, secondary: str, accent: str) -> str:
     template = data[4] % 4
     if template == 0:
         return f"""
-    <path android:fillColor="{primary}" android:pathData="M54,14 L92,54 L54,94 L16,54 Z"/>
+    <path android:fillColor="{primary}" android:pathData="M54,18 L90,54 L54,90 L18,54 Z"/>
     <path android:fillColor="{secondary}" android:pathData="M54,28 L78,54 L54,80 L30,54 Z"/>
     <path android:fillColor="{accent}" android:pathData="M47,47 L61,47 L61,61 L47,61 Z"/>
 """
@@ -42,7 +42,7 @@ def shape_paths(data: bytes, primary: str, secondary: str, accent: str) -> str:
 """
     if template == 2:
         return f"""
-    <path android:fillColor="{primary}" android:pathData="M54,12 L78,22 L96,46 L88,74 L64,94 L36,90 L16,68 L14,38 L34,18 Z"/>
+    <path android:fillColor="{primary}" android:pathData="M54,18 L76,26 L90,48 L84,72 L64,90 L38,86 L20,68 L20,40 L36,22 Z"/>
     <path android:fillColor="{secondary}" android:pathData="M54,28 L70,36 L82,54 L74,72 L54,80 L34,72 L26,54 L38,36 Z"/>
     <path android:fillColor="{accent}" android:pathData="M54,43 L65,54 L54,65 L43,54 Z"/>
 """
@@ -105,11 +105,24 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
 """,
     )
 
+    write_text(
+        drawable_dir / "stealth_launcher_monochrome.xml",
+        f"""
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+{shape_paths(data, "#FFFFFFFF", "#FFFFFFFF", "#FFFFFFFF")}
+</vector>
+""",
+    )
+
     adaptive_icon = """
 <adaptive-icon xmlns:android="http://schemas.android.com/apk/res/android">
     <background android:drawable="@color/stealth_launcher_background"/>
     <foreground android:drawable="@drawable/stealth_launcher_foreground"/>
-    <monochrome android:drawable="@drawable/stealth_notification_icon"/>
+    <monochrome android:drawable="@drawable/stealth_launcher_monochrome"/>
 </adaptive-icon>
 """
     write_text(mipmap_dir / "stealth_ic_launcher.xml", adaptive_icon)
@@ -136,6 +149,7 @@ def generate(seed: str, output_res_dir: Path) -> dict[str, str]:
         "accent": accent,
         "launcherIcon": "@mipmap/stealth_ic_launcher",
         "roundLauncherIcon": "@mipmap/stealth_ic_launcher_round",
+        "monochromeIcon": "@drawable/stealth_launcher_monochrome",
         "notificationIcon": "@drawable/stealth_notification_icon",
     }
     write_text(

--- a/scripts/stealth/generate_android_icons.py
+++ b/scripts/stealth/generate_android_icons.py
@@ -17,7 +17,7 @@ def hash_bytes(seed: str) -> bytes:
 
 
 def color_from_hash(data: bytes, offset: int, sat: float, light: float) -> str:
-    hue = int.from_bytes(data[offset : offset + 2], "big") / 65535
+    hue = int.from_bytes(data[offset : offset + 2], "big") / 65536.0
     red, green, blue = colorsys.hls_to_rgb(hue, light, sat)
     return "#{:02X}{:02X}{:02X}".format(
         round(red * 255),

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -1,6 +1,9 @@
 import tempfile
 import unittest
+from contextlib import redirect_stdout
+from io import StringIO
 from pathlib import Path
+from unittest.mock import patch
 
 import generate_android_icons
 
@@ -61,6 +64,21 @@ class GenerateAndroidIconsTest(unittest.TestCase):
                 (first / "drawable/stealth_launcher_foreground.xml").read_text(),
                 (second / "drawable/stealth_launcher_foreground.xml").read_text(),
             )
+
+    def test_main_reads_seed_from_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "res"
+
+            with patch.dict("os.environ", {"STEALTH_ICON_SEED": "variant-env"}):
+                with redirect_stdout(StringIO()):
+                    exit_code = generate_android_icons.main(
+                        ["--output-res-dir", str(out)]
+                    )
+
+            expected = generate_android_icons.generate("variant-env", Path(tmp) / "expected")
+            metadata = (out.parent / "stealth-icon-metadata.json").read_text()
+            self.assertEqual(exit_code, 0)
+            self.assertIn(expected["seedSha256"], metadata)
 
 
 if __name__ == "__main__":

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -1,3 +1,4 @@
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -5,6 +6,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
 import generate_android_icons
 
 
@@ -21,7 +23,11 @@ class GenerateAndroidIconsTest(unittest.TestCase):
             self.assertTrue((out / "drawable/stealth_notification_icon.xml").exists())
             self.assertNotIn(
                 "#00000000",
-                (out / "drawable/stealth_notification_icon.xml").read_text(),
+                self.read(out, "drawable/stealth_launcher_foreground.xml"),
+            )
+            self.assertNotIn(
+                "#00000000",
+                self.read(out, "drawable/stealth_notification_icon.xml"),
             )
             self.assertTrue((out / "mipmap-anydpi/stealth_ic_launcher.xml").exists())
             self.assertTrue(
@@ -79,6 +85,9 @@ class GenerateAndroidIconsTest(unittest.TestCase):
             metadata = (out.parent / "stealth-icon-metadata.json").read_text()
             self.assertEqual(exit_code, 0)
             self.assertIn(expected["seedSha256"], metadata)
+
+    def read(self, root: Path, relative_path: str) -> str:
+        return (root / relative_path).read_text(encoding="utf-8")
 
 
 if __name__ == "__main__":

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -20,10 +20,15 @@ class GenerateAndroidIconsTest(unittest.TestCase):
             self.assertEqual(metadata["launcherIcon"], "@mipmap/stealth_ic_launcher")
             self.assertTrue((out / "values/stealth_icon_colors.xml").exists())
             self.assertTrue((out / "drawable/stealth_launcher_foreground.xml").exists())
+            self.assertTrue((out / "drawable/stealth_launcher_monochrome.xml").exists())
             self.assertTrue((out / "drawable/stealth_notification_icon.xml").exists())
             self.assertNotIn(
                 "#00000000",
                 self.read(out, "drawable/stealth_launcher_foreground.xml"),
+            )
+            self.assertIn(
+                '@drawable/stealth_launcher_monochrome',
+                self.read(out, "mipmap-anydpi-v26/stealth_ic_launcher.xml"),
             )
             self.assertNotIn(
                 "#00000000",

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -1,0 +1,58 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+import generate_android_icons
+
+
+class GenerateAndroidIconsTest(unittest.TestCase):
+    def test_generates_expected_resource_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "res"
+
+            metadata = generate_android_icons.generate("variant-a", out)
+
+            self.assertEqual(metadata["launcherIcon"], "@mipmap/stealth_ic_launcher")
+            self.assertTrue((out / "values/stealth_icon_colors.xml").exists())
+            self.assertTrue((out / "drawable/stealth_launcher_foreground.xml").exists())
+            self.assertTrue((out / "drawable/stealth_notification_icon.xml").exists())
+            self.assertTrue((out / "mipmap-anydpi-v26/stealth_ic_launcher.xml").exists())
+            self.assertTrue(
+                (out / "mipmap-anydpi-v26/stealth_ic_launcher_round.xml").exists()
+            )
+            self.assertTrue((out / "stealth-icon-metadata.json").exists())
+
+    def test_generation_is_deterministic_for_same_seed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "first"
+            second = Path(tmp) / "second"
+
+            first_metadata = generate_android_icons.generate("variant-a", first)
+            second_metadata = generate_android_icons.generate("variant-a", second)
+
+            self.assertEqual(first_metadata, second_metadata)
+            self.assertEqual(
+                (first / "drawable/stealth_launcher_foreground.xml").read_text(),
+                (second / "drawable/stealth_launcher_foreground.xml").read_text(),
+            )
+
+    def test_generation_changes_by_seed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            first = Path(tmp) / "first"
+            second = Path(tmp) / "second"
+
+            first_metadata = generate_android_icons.generate("variant-a", first)
+            second_metadata = generate_android_icons.generate("variant-b", second)
+
+            self.assertNotEqual(
+                first_metadata["seedSha256"],
+                second_metadata["seedSha256"],
+            )
+            self.assertNotEqual(
+                (first / "drawable/stealth_launcher_foreground.xml").read_text(),
+                (second / "drawable/stealth_launcher_foreground.xml").read_text(),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -16,11 +16,16 @@ class GenerateAndroidIconsTest(unittest.TestCase):
             self.assertTrue((out / "values/stealth_icon_colors.xml").exists())
             self.assertTrue((out / "drawable/stealth_launcher_foreground.xml").exists())
             self.assertTrue((out / "drawable/stealth_notification_icon.xml").exists())
+            self.assertTrue((out / "mipmap-anydpi/stealth_ic_launcher.xml").exists())
+            self.assertTrue(
+                (out / "mipmap-anydpi/stealth_ic_launcher_round.xml").exists()
+            )
             self.assertTrue((out / "mipmap-anydpi-v26/stealth_ic_launcher.xml").exists())
             self.assertTrue(
                 (out / "mipmap-anydpi-v26/stealth_ic_launcher_round.xml").exists()
             )
-            self.assertTrue((out / "stealth-icon-metadata.json").exists())
+            self.assertFalse((out / "stealth-icon-metadata.json").exists())
+            self.assertTrue((out.parent / "stealth-icon-metadata.json").exists())
 
     def test_generation_is_deterministic_for_same_seed(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -16,6 +16,10 @@ class GenerateAndroidIconsTest(unittest.TestCase):
             self.assertTrue((out / "values/stealth_icon_colors.xml").exists())
             self.assertTrue((out / "drawable/stealth_launcher_foreground.xml").exists())
             self.assertTrue((out / "drawable/stealth_notification_icon.xml").exists())
+            self.assertNotIn(
+                "#00000000",
+                (out / "drawable/stealth_notification_icon.xml").read_text(),
+            )
             self.assertTrue((out / "mipmap-anydpi/stealth_ic_launcher.xml").exists())
             self.assertTrue(
                 (out / "mipmap-anydpi/stealth_ic_launcher_round.xml").exists()

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -18,30 +18,33 @@ class GenerateAndroidIconsTest(unittest.TestCase):
 
             metadata = generate_android_icons.generate("variant-a", out)
 
-            self.assertEqual(metadata["launcherIcon"], "@mipmap/stealth_ic_launcher")
-            self.assertTrue((out / "values/stealth_icon_colors.xml").exists())
-            self.assertTrue((out / "drawable/stealth_launcher_foreground.xml").exists())
-            self.assertTrue((out / "drawable/stealth_launcher_monochrome.xml").exists())
-            self.assertTrue((out / "drawable/stealth_notification_icon.xml").exists())
+            self.assertEqual(metadata["launcherIcon"], "@mipmap/ic_launcher_alt")
+            self.assertTrue((out / "values/icon_colors_alt.xml").exists())
+            self.assertTrue((out / "drawable/launcher_foreground_alt.xml").exists())
+            self.assertTrue((out / "drawable/launcher_monochrome_alt.xml").exists())
+            self.assertTrue((out / "drawable/ic_notification_alt.xml").exists())
             self.assertNotIn(
                 "#00000000",
-                self.read(out, "drawable/stealth_launcher_foreground.xml"),
+                self.read(out, "drawable/launcher_foreground_alt.xml"),
             )
             self.assertIn(
-                '@drawable/stealth_launcher_monochrome',
-                self.read(out, "mipmap-anydpi-v26/stealth_ic_launcher.xml"),
+                '@drawable/launcher_monochrome_alt',
+                self.read(out, "mipmap-anydpi-v26/ic_launcher_alt.xml"),
             )
             self.assertNotIn(
                 "#00000000",
-                self.read(out, "drawable/stealth_notification_icon.xml"),
+                self.read(out, "drawable/ic_notification_alt.xml"),
             )
-            self.assertTrue((out / "mipmap-anydpi/stealth_ic_launcher.xml").exists())
+            # No "stealth" token in any generated resource name
+            for f in out.rglob("*"):
+                self.assertNotIn("stealth", f.name.lower())
+            self.assertTrue((out / "mipmap-anydpi/ic_launcher_alt.xml").exists())
             self.assertTrue(
-                (out / "mipmap-anydpi/stealth_ic_launcher_round.xml").exists()
+                (out / "mipmap-anydpi/ic_launcher_alt_round.xml").exists()
             )
-            self.assertTrue((out / "mipmap-anydpi-v26/stealth_ic_launcher.xml").exists())
+            self.assertTrue((out / "mipmap-anydpi-v26/ic_launcher_alt.xml").exists())
             self.assertTrue(
-                (out / "mipmap-anydpi-v26/stealth_ic_launcher_round.xml").exists()
+                (out / "mipmap-anydpi-v26/ic_launcher_alt_round.xml").exists()
             )
             self.assertFalse((out / "stealth-icon-metadata.json").exists())
             self.assertTrue((out.parent / "stealth-icon-metadata.json").exists())
@@ -56,8 +59,8 @@ class GenerateAndroidIconsTest(unittest.TestCase):
 
             self.assertEqual(first_metadata, second_metadata)
             self.assertEqual(
-                (first / "drawable/stealth_launcher_foreground.xml").read_text(),
-                (second / "drawable/stealth_launcher_foreground.xml").read_text(),
+                (first / "drawable/launcher_foreground_alt.xml").read_text(),
+                (second / "drawable/launcher_foreground_alt.xml").read_text(),
             )
 
     def test_generation_changes_by_seed(self):
@@ -73,8 +76,8 @@ class GenerateAndroidIconsTest(unittest.TestCase):
                 second_metadata["seedSha256"],
             )
             self.assertNotEqual(
-                (first / "drawable/stealth_launcher_foreground.xml").read_text(),
-                (second / "drawable/stealth_launcher_foreground.xml").read_text(),
+                (first / "drawable/launcher_foreground_alt.xml").read_text(),
+                (second / "drawable/launcher_foreground_alt.xml").read_text(),
             )
 
     def test_main_reads_seed_from_environment(self):

--- a/scripts/stealth/generate_android_icons_test.py
+++ b/scripts/stealth/generate_android_icons_test.py
@@ -1,3 +1,4 @@
+import hashlib
 import sys
 import tempfile
 import unittest
@@ -86,10 +87,10 @@ class GenerateAndroidIconsTest(unittest.TestCase):
                         ["--output-res-dir", str(out)]
                     )
 
-            expected = generate_android_icons.generate("variant-env", Path(tmp) / "expected")
+            expected_sha = hashlib.sha256(b"variant-env").hexdigest()
             metadata = (out.parent / "stealth-icon-metadata.json").read_text()
             self.assertEqual(exit_code, 0)
-            self.assertIn(expected["seedSha256"], metadata)
+            self.assertIn(expected_sha, metadata)
 
     def read(self, root: Path, relative_path: str) -> str:
         return (root / relative_path).read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- adds a deterministic procedural Android icon generator keyed by private per-variant seed
- wires Android Gradle to generate seeded icon resources and switch launcher icon placeholders when `STEALTH_ICON_SEED` or `-PstealthIconSeed` is set
- adds a Make target and docs for release/support handling of private icon seeds and metadata

Closes getlantern/engineering#3575

## Validation
- `python3 -m unittest discover -s scripts/stealth -p *_test.py`
- `python3 -m py_compile scripts/stealth/generate_android_icons.py scripts/stealth/generate_android_icons_test.py`
- `python3 scripts/stealth/generate_android_icons.py --seed test-seed --output-res-dir /tmp/lantern-8778-icons-2/res`
- XML parse check for generated resources with Python ElementTree
- `make -n stealth-android-icons STEALTH_ICON_SEED=test-seed`
- `make -n android-apk-release STEALTH_ICON_SEED=test-seed`
- `git diff --cached --check`

## Not run
- Full Android resource merge/build: this environment has no Gradle wrapper/system Gradle or Android SDK configured.