### PR TITLE
android: trim unused sing-box tags from gomobile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,6 +141,10 @@ IOS_FRAMEWORK_BUILD := $(BIN_DIR)/ios/$(IOS_FRAMEWORK)
 IOS_DEBUG_BUILD := $(BUILD_DIR)/ios/iphoneos/Runner.app
 
 TAGS=with_gvisor,with_quic,with_wireguard,with_utls,with_clash_api,with_grpc,with_conntrack,with_dhcp,with_acme
+# Android ships the largest installer and does not use sing-box's Clash API,
+# DHCP, or ACME server/control-plane features. Keep the slimmer tag set scoped
+# to gomobile so desktop/iOS behavior is unchanged.
+ANDROID_TAGS ?= with_gvisor,with_quic,with_wireguard,with_utls,with_grpc,with_conntrack
 
 WINDOWS_CGO_LDFLAGS=-static-libgcc -static-libstdc++ -static -lwinpthread
 
@@ -504,7 +508,7 @@ build-android: check-android-sdk check-gomobile
 		-androidapi=23 \
 		-target="$(GOMOBILE_ANDROID_TARGET)" \
 		-javapkg=lantern.io \
-		-tags=$(TAGS) -trimpath \
+		-tags=$(ANDROID_TAGS) -trimpath \
 		-o=$(ANDROID_LIB_BUILD) \
 		-ldflags="$(ANDROID_GOMOBILE_LDFLAGS) $(EXTRA_LDFLAGS)" \
 		$(GOMOBILE_REPOS)


### PR DESCRIPTION
## Summary

Small follow-up to #8774. Android now uses its own slimmer gomobile tag set and drops sing-box with_clash_api, with_dhcp, and with_acme from the Android native library build only.

Desktop and iOS continue using the existing full TAGS value.

## Size impact

Measured from a rebuilt AAR against the #8774 Slack APK baseline:

- libgojni.so arm64 compressed estimate drops from about 24.2 MB to about 23.7 MB
- Expected sideload APK savings: about 545 KB

Small, but clean and scoped to the Android artifact that matters most for sideload users.

## Verification

- go list -deps with Android tag set: passed
- Earlier local make build-android succeeded with this tag set while measuring the AAR

Full local flutter build apk is blocked in this worktree by missing gitignored app.env; CI generates it from secrets.