### PR TITLE
deps: bump radiance to main (84bde61)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260515161028-4a3befb460f1
+	github.com/getlantern/radiance v0.0.0-20260515182814-84bde61ac0fe
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0

--- a/go.sum
+++ b/go.sum
@@ -261,12 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260513193454-271d3857b2a1 h1:DydQGwsX0lkmfkKjGivJyVEMBqkpHrwDz8A1nFo1Fz8=
-github.com/getlantern/radiance v0.0.0-20260513193454-271d3857b2a1/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
-github.com/getlantern/radiance v0.0.0-20260515160728-65ce277013f3 h1:8FhnhtdroGPU3KW72C5JGOThu4Q4BLLWLFjN4OREFSk=
-github.com/getlantern/radiance v0.0.0-20260515160728-65ce277013f3/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
-github.com/getlantern/radiance v0.0.0-20260515161028-4a3befb460f1 h1:zUQJ4UvTnT+FxIUoW40gZQa114Eyd9PvKdStqMvbKGg=
-github.com/getlantern/radiance v0.0.0-20260515161028-4a3befb460f1/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
+github.com/getlantern/radiance v0.0.0-20260515182814-84bde61ac0fe h1:rEhwKLRF6TDBSl9x8FrNehbS3a0p/35r6VpGOXYO5zY=
+github.com/getlantern/radiance v0.0.0-20260515182814-84bde61ac0fe/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Bumps `github.com/getlantern/radiance` to the current tip of main.

- **From:** `v0.0.0-20260515161028-4a3befb460f1`
- **To:** `v0.0.0-20260515182814-84bde61ac0fe`

## Radiance commits picked up

- [getlantern/radiance#482](https://github.com/getlantern/radiance/pull/482) — `backend, vpn: preserve user state on config refresh`

Keeps user-applied selections (manually-selected outbound, etc.) intact when the config-handler refresh fires, instead of getting reset on every config tick.

## Files changed

`go.mod` (one-line version bump) and `go.sum` (corresponding hash entries). No code changes.

## Test plan

- [ ] CI green
- [ ] No transitive bumps surfaced by `go mod tidy` (verified locally — only the radiance line and its go.sum hashes changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)