### PR TITLE
purchase: skip BillingClient init on non-store Android builds

### DIFF
--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -42,14 +42,9 @@ class AppPurchase {
     if (PlatformUtils.isDesktop || _subscription != null) {
       return;
     }
-    // Skip BillingClient initialization on non-store Android builds
-    // (sideload, nightly, emulator/dev). Subscribing to purchaseStream
-    // triggers BillingClient.startConnection, and in_app_purchase_android's
-    // BillingClientManager auto-reconnects on every serviceDisconnected
-    // without backoff — on builds where Play Billing isn't available the
-    // reconnect runs hot and queues ~100 PLAY_BILLING_LIBRARY datatransport
-    // events per second, OOMing the Dalvik heap in ~3 minutes.
-    // See getlantern/engineering#3485.
+    // Subscribing to purchaseStream initializes BillingClient, which OOMs
+    // the Dalvik heap via an internal reconnect loop when Play Billing
+    // isn't reachable. See getlantern/engineering#3485.
     if (Platform.isAndroid && !isStoreVersion()) {
       return;
     }

--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -42,6 +42,17 @@ class AppPurchase {
     if (PlatformUtils.isDesktop || _subscription != null) {
       return;
     }
+    // Skip BillingClient initialization on non-store Android builds
+    // (sideload, nightly, emulator/dev). Subscribing to purchaseStream
+    // triggers BillingClient.startConnection, and in_app_purchase_android's
+    // BillingClientManager auto-reconnects on every serviceDisconnected
+    // without backoff — on builds where Play Billing isn't available the
+    // reconnect runs hot and queues ~100 PLAY_BILLING_LIBRARY datatransport
+    // events per second, OOMing the Dalvik heap in ~3 minutes.
+    // See getlantern/engineering#3485.
+    if (Platform.isAndroid && !isStoreVersion()) {
+      return;
+    }
 
     final purchaseUpdated = _inAppPurchase.purchaseStream;
     _subscription = purchaseUpdated.listen(


### PR DESCRIPTION
## Summary

`AppPurchase.init()` unconditionally subscribes to `InAppPurchase.purchaseStream` on Android — even when `isStoreVersion()` is false. That subscription kicks off `BillingClient.startConnection()` inside the Flutter plugin, and on builds where Play Billing isn't reachable, the plugin's `BillingClientManager` gets stuck in a no-backoff reconnect loop that OOMs the heap.

This PR adds the missing guard:

```dart
if (Platform.isAndroid && !isStoreVersion()) return;
```

so non-store Android builds (sideload installs, nightlies, dev, emulator) skip BillingClient initialization entirely.

## Why

Heap-dump evidence from a fresh nightly emulator session (full diagnosis in [getlantern/engineering#3485](https://github.com/getlantern/engineering/issues/3485)):

| Class | Instances | Retained |
|---|---:|---:|
| `LinkedBlockingQueue$Node` (the ThreadPoolExecutor work queue) | **526,217** | **154 MB (85.4% of heap)** |
| `SafeLoggingExecutor$SafeLoggingRunnable` | 526,208 | 146 MB |
| `DefaultScheduler$$ExternalSyntheticLambda*` | 526,207 | 138 MB |
| `AutoValue_EventInternal` | 526,208 | 112 MB |

A sample `AutoValue_EventInternal.transportName` field decoded to `"PLAY_BILLING_LIBRARY"`. Logcat counted ~85k `BillingClient.startConnection()` calls in a 12-minute window — **~118 calls per second**.

The mechanism: `BillingClientManager` (introduced in plugin 0.2.5) auto-reconnects on every `BillingResponse.serviceDisconnected` without backoff. On builds where Play Billing isn't available the service disconnects immediately on every bind attempt, the manager reconnects immediately, the loop runs hot. Each cycle enqueues a `PLAY_BILLING_LIBRARY` datatransport event; the queue is durable (SQLite-backed) but never drains. After ~3 minutes it fills the 192 MB Dalvik cap → OOM.

## Why this guard is the right place

- `isStoreVersion()` already exists in `lib/core/common/common.dart` and is consulted elsewhere — `payment_notifier.dart:27` (`_isAndroidStoreBuild`), `plans.dart:322` — to choose between Play Billing and Stripe/Shepherd payment paths.
- `AppPurchase.init()` is the only place that uses `purchaseStream` unconditionally. Adding the guard here makes init consistent with the rest of the billing-path policy.
- Real Play Store users keep the existing behavior (their `isStoreVersion()` returns true).

## ⚠️ What this does NOT fix

Play Store-downloaded users are still vulnerable. If their device's Play Billing service has any transient disconnect, the same no-backoff reconnect loop fires inside the plugin, the queue fills, OOM in ~3 min. This PR narrows the blast radius (eliminates the bug for sideload/dev/emulator) but the underlying plugin bug is unfixed.

Issue [#3485](https://github.com/getlantern/engineering/issues/3485) lists four follow-ups for the store-channel fix. Most likely path: upstream a backoff to `BillingClientManager` (or fork the plugin with one applied).

## Test plan

- [x] `flutter analyze` clean on the changed file (one pre-existing info-level lint about `in_app_purchase_android` import, unrelated to this change).
- [ ] Confirm OOM is gone on `lantern_test` AVD (Android 15, arm64-v8a, `google_apis`): launch, wait 5+ min, verify `dumpsys meminfo` Dalvik allocated stays low and no `BillingClient` lines in logcat.
- [ ] Sanity-check the Play Store build path still works: confirm `isStoreVersion()` returns true on a Play Store install so `init()` proceeds normally.
- [ ] Non-store Android: confirm the plans screen still gracefully reports "subscriptions unavailable" (or whatever the existing sideload UX is) instead of crashing.

cc @atavism — same area as `5f1800e64`; issue #3485 has the full diagnostic chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)