### PR TITLE
deps: bump radiance for kindling smart-strategy bypass

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260515182814-84bde61ac0fe
+	github.com/getlantern/radiance v0.0.0-20260516121708-5f3ce9dd5949
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.41.0
@@ -171,7 +171,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260112160750-05100563bd0d // indirect
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 // indirect
-	github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5 // indirect
+	github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03 // indirect
 	github.com/getlantern/lantern-box v0.0.82 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260317143726-e0ee64a11d90 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694 h1:iLWm6S/47Hfk7FjW6yaD+1h6kO7C/iauV0DkVia/bXU=
 github.com/getlantern/keepcurrent v0.0.0-20260422161259-54a4d9a93694/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5 h1:ukTEQ2S16zMK2BJxIM0qKz+WiiyiPwvmLCWlK1EOvVU=
-github.com/getlantern/kindling v0.0.0-20260507163327-92a44d03bdc5/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
+github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03 h1:dUTN7mnTTBcSvsURNs1rTlyKrD1uXUEPqxEZDfl+hb4=
+github.com/getlantern/kindling v0.0.0-20260516120759-a9712f95df03/go.mod h1:TGTxpoNVwc8Be4qkBNtf5oj2psJaEIZEq47GOPS7zkA=
 github.com/getlantern/lantern-box v0.0.82 h1:hCXqpCxLOQNxYtQZQDYVh3aj3t8NqSBqJjCn2mIBtK0=
 github.com/getlantern/lantern-box v0.0.82/go.mod h1:wJhPQKdnwD6qW/ghAfzsrj/IfHZbvFSAfr52+Tu6dbw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260515182814-84bde61ac0fe h1:rEhwKLRF6TDBSl9x8FrNehbS3a0p/35r6VpGOXYO5zY=
-github.com/getlantern/radiance v0.0.0-20260515182814-84bde61ac0fe/go.mod h1:OWxfQRKKT/W13sKURvdLrgU/fYgUfWbmkgrREMzAEtk=
+github.com/getlantern/radiance v0.0.0-20260516121708-5f3ce9dd5949 h1:nBlPswwDjV1EkBBV2ACPQw2AElMiBJ5KKQi1qt1xE2I=
+github.com/getlantern/radiance v0.0.0-20260516121708-5f3ce9dd5949/go.mod h1:sX6xqbFpHlPXcRF+26iNhKbD+1h9IKcFTesWEDIaMjY=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974 h1:k+/qNo5YNO+8M8LVUp6G5Evm1OQdEs3Z4ye8top4AhI=
 github.com/getlantern/samizdat v0.0.3-0.20260327203406-ef7323341974/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Bumps `github.com/getlantern/radiance` to `5f3ce9d` ([radiance#485](https://github.com/getlantern/radiance/pull/485)) and transitively `github.com/getlantern/kindling` to `a9712f9` ([kindling#35](https://github.com/getlantern/kindling/pull/35)).

Net behavior change: kindling's smart strategy now routes every DNS/TLS probe through radiance's bypass dialer instead of paying for the probes and then discarding them via a post-construction `DialContext` override. Kindling config-fetch traffic stays out of the VPN TUN even when the smart path wins the race.

Originated from [this Slack thread](https://wdynhnkxvsdx.slack.com/archives/C01K9DJ1ES2/p1778881001409919).

## Test plan

- [x] `go build ./...` clean
- [ ] Smoke against a live VPN session: confirm kindling config-fetch traffic doesn't appear in the TUN's PCAP

🤖 Generated with [Claude Code](https://claude.com/claude-code)