### PR TITLE
Fix flag size issue

### DIFF
--- a/lib/core/widgets/flag.dart
+++ b/lib/core/widgets/flag.dart
@@ -37,6 +37,7 @@ class Flag extends StatelessWidget {
       child: FittedBox(
         // Normalize cross-platform glyph-height variance into the caller's box.
         fit: BoxFit.cover,
+        clipBehavior: Clip.hardEdge,
         child: Text(
           _countryCodeToEmoji(countryCode),
           style: TextStyle(fontSize: size.height),

--- a/lib/core/widgets/flag.dart
+++ b/lib/core/widgets/flag.dart
@@ -1,20 +1,9 @@
 import 'package:flutter/material.dart';
 
-/// Flag renders a country flag from a two-letter ISO 3166-1 alpha-2 code.
-///
-/// Uses Unicode regional indicator emoji (e.g. "IR" → 🇮🇷) — rendered by the
-/// system emoji font, zero asset weight. Switched away from the
-/// `country_flags` Dart package on 2026-05-15, which shipped pre-rasterized
-/// vector flags totaling ~2.6 MB uncompressed (Serbia's coat of arms alone
-/// was 513 KB). At our render size (24–30 px wide), the fine detail was
-/// invisible anyway, and the bandwidth saving matters for Iranian sideload
-/// users on constrained connections.
-///
-/// Behavior on platforms that don't carry the regional-indicator flag set
-/// in their emoji font (some de-Googled Android forks, Chinese
-/// vendor-customized fonts that drop the Taiwan flag): the text falls back
-/// to the two letter glyphs (e.g. "IR") rendered with the emoji style.
-/// Functional, less pretty — acceptable trade for the size cut.
+/// Country flag from an ISO 3166-1 alpha-2 code, rendered as a regional
+/// indicator emoji by the system font (e.g. "IR" → 🇮🇷). Platforms that
+/// drop part of the flag set (some de-Googled Android forks, vendor fonts
+/// without TW) fall back to the two-letter glyphs.
 class Flag extends StatelessWidget {
   final String countryCode;
   final Size size;
@@ -25,10 +14,7 @@ class Flag extends StatelessWidget {
     this.size = const Size(25, 18),
   });
 
-  /// Converts an ISO 3166-1 alpha-2 country code into the corresponding
-  /// regional indicator emoji sequence. Returns the white-flag emoji 🏳️
-  /// for invalid input rather than throwing, so a malformed country code
-  /// in the location list doesn't blow up the UI.
+  /// Returns 🏳️ for invalid input so a malformed code can't blow up the UI.
   static String _countryCodeToEmoji(String code) {
     if (code.length != 2) return '\u{1F3F3}\u{FE0F}'; // 🏳️
     final upper = code.toUpperCase();
@@ -49,12 +35,8 @@ class Flag extends StatelessWidget {
     return SizedBox.fromSize(
       size: size,
       child: FittedBox(
-        // BoxFit.contain keeps the emoji aspect ratio inside the requested
-        // box. The system emoji font draws regional-indicator pairs at the
-        // requested fontSize but the actual rendered glyph height varies
-        // across Android versions; FittedBox normalizes that to the size
-        // the caller asked for.
-        fit: BoxFit.contain,
+        // Normalize cross-platform glyph-height variance into the caller's box.
+        fit: BoxFit.cover,
         child: Text(
           _countryCodeToEmoji(countryCode),
           style: TextStyle(fontSize: size.height),


### PR DESCRIPTION
This pull request makes small refinements to the `Flag` widget in `lib/core/widgets/flag.dart`, focusing on simplifying documentation and improving cross-platform visual consistency.

Key improvements:

Documentation simplification:
* Updated the `Flag` widget and `_countryCodeToEmoji` method comments to be more concise, removing detailed historical and technical explanations while retaining essential usage information. [[1]](diffhunk://#diff-a97fcdea3bd42d2f8129e82deed49cbd410c874a89555342c1ee965626549bdaL3-R6) [[2]](diffhunk://#diff-a97fcdea3bd42d2f8129e82deed49cbd410c874a89555342c1ee965626549bdaL28-R17)

Visual consistency:
* Changed the `FittedBox` fit mode from `BoxFit.contain` to `BoxFit.cover` to better normalize flag emoji rendering across different platforms and font metrics.