### PR TITLE
Fix Play Billing fallback country handling

### DIFF
--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -321,7 +321,7 @@ func (lc *LanternCore) listenConfigEvents() {
 	err := lc.client.ConfigEvents(lc.ctx, func() {
 		slog.Debug("Config updated, notifying Flutter")
 		lc.notifyFlutter(EventTypeConfig, "")
-		// We got the config fetch coutry code
+		// Forward the country from the latest config fetch.
 		countryCode, _ := lc.settings()[settings.CountryCodeKey].(string)
 		if countryCode != "" {
 			slog.Debug("Config event: country code updated", "countryCode", countryCode)

--- a/lib/core/common/common.dart
+++ b/lib/core/common/common.dart
@@ -119,6 +119,13 @@ bool isStoreVersion() {
   return !sl<StoreUtils>().isSideLoaded();
 }
 
+bool canUsePlayBilling() {
+  if (!PlatformUtils.isAndroid || !CountryCode.isKnown) {
+    return false;
+  }
+  return isStoreVersion();
+}
+
 //copy to clipboard
 void copyToClipboard(String text) {
   Clipboard.setData(ClipboardData(text: text));

--- a/lib/core/common/common.dart
+++ b/lib/core/common/common.dart
@@ -120,10 +120,7 @@ bool isStoreVersion() {
 }
 
 bool canUsePlayBilling() {
-  if (!PlatformUtils.isAndroid || !CountryCode.isKnown) {
-    return false;
-  }
-  return isStoreVersion();
+  return PlatformUtils.isAndroid && isStoreVersion();
 }
 
 //copy to clipboard

--- a/lib/core/common/common.dart
+++ b/lib/core/common/common.dart
@@ -97,9 +97,8 @@ bool isStoreVersion() {
     return false;
   }
 
-  /// In censored regions Google Play Billing is unreachable, so Play-Store
-  /// builds must take the non-store payment path (Stripe). For iOS
-  /// there is no other way
+  // In censored regions Google Play Billing is unreachable, so Android
+  // Play Store builds use the non-store payment path.
   if (PlatformUtils.isAndroid && CountryCode.isCensoredRegion) {
     return false;
   }

--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -113,10 +113,8 @@ class AppPurchase {
       }
     }
 
-    /// All retries exhausted. On Android, treat this as a strong signal that
-    /// Google Play Billing is unreachable (typical in CN/RU/IR even when the
-    /// ipinfo.io country lookup itself is blocked) and flip the censored-region
-    /// flag so isStoreVersion() routes the user to the Stripe flow.
+    // All retries are exhausted. On Android this is a useful signal that
+    // Play Billing is blocked or unavailable, so offer the non-store flow.
     if (Platform.isAndroid && !CountryCode.isCensoredRegion) {
       appLogger.warning(
         '[AppPurchase] Play Billing unreachable after $maxAttempts attempts; '

--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:ui';
 
 import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:in_app_purchase_android/in_app_purchase_android.dart';
@@ -41,18 +40,11 @@ class AppPurchase {
   bool _restoreReceivedAny = false;
 
   void init() {
-    if (PlatformUtils.isDesktop || _subscription != null) {
-      return;
-    }
-    // Subscribing to purchaseStream initializes BillingClient, which OOMs
-    // the Dalvik heap via an internal reconnect loop when Play Billing
-    // isn't reachable. See getlantern/engineering#3485.
-    if (Platform.isAndroid && _shouldSkipAndroidBillingInit()) {
+    if (!_canInitializeStorePurchases()) {
       return;
     }
 
-    final purchaseUpdated = _inAppPurchase.purchaseStream;
-    _subscription = purchaseUpdated.listen(
+    _subscription = _inAppPurchase.purchaseStream.listen(
       _onPurchaseUpdates,
       onDone: _updateStreamOnDone,
       onError: _updateStreamOnError,
@@ -64,27 +56,29 @@ class AppPurchase {
     );
   }
 
-  bool _shouldSkipAndroidBillingInit() {
-    if (!isStoreVersion()) {
+  bool _canInitializeStorePurchases() {
+    if (PlatformUtils.isDesktop || _subscription != null) {
+      return false;
+    }
+    if (!Platform.isAndroid) {
       return true;
     }
+    // Subscribing to purchaseStream initializes BillingClient, which OOMs
+    // the Dalvik heap via an internal reconnect loop when Play Billing
+    // isn't reachable. See getlantern/engineering#3485.
+    return canUsePlayBilling();
+  }
 
-    if (CountryCode.current.isNotEmpty) {
-      return false;
+  Future<bool> _initPlayBillingIfAllowed() async {
+    init();
+    if (_subscription != null) {
+      return true;
     }
-
-    final localeCountry = PlatformDispatcher.instance.locale.countryCode
-        ?.trim()
-        .toUpperCase();
-    if (!CountryCode.censoredRegions.contains(localeCountry)) {
-      return false;
+    if (Platform.isAndroid && !CountryCode.isKnown) {
+      await CountryCode.waitUntilKnown();
+      init();
     }
-
-    appLogger.info(
-      '[AppPurchase] Skipping Play Billing init from startup locale hint '
-      'while config country is pending: $localeCountry',
-    );
-    return true;
+    return _subscription != null;
   }
 
   Future<void> fetchSubscriptions({int maxAttempts = 3}) async {
@@ -189,6 +183,13 @@ class AppPurchase {
     // Store the exact plan id user chose (ex: "1y-usd-10")
     _pendingPlanId = plan;
 
+    if (!await _initPlayBillingIfAllowed()) {
+      _onError?.call(
+        "Unable to load App Store products. Check your network and try again.",
+      );
+      return;
+    }
+
     try {
       await _waitForProducts();
     } catch (_) {
@@ -245,6 +246,16 @@ class AppPurchase {
     _isRestoreFlow = true;
     _restoreReceivedAny = false;
     _pendingPlanId = null;
+
+    if (!await _initPlayBillingIfAllowed()) {
+      _isRestoreFlow = false;
+      final onError = _onError;
+      clearCallbacks();
+      onError?.call(
+        "Unable to load App Store products. Check your network and try again.",
+      );
+      return;
+    }
 
     try {
       appLogger.info('[AppPurchase] Initiating restore purchases');

--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -44,6 +44,10 @@ class AppPurchase {
       return;
     }
 
+    appLogger.info(
+      '[AppPurchase] Subscribing to purchaseStream '
+      '(platform=${Platform.operatingSystem}, country=${CountryCode.current})',
+    );
     _subscription = _inAppPurchase.purchaseStream.listen(
       _onPurchaseUpdates,
       onDone: _updateStreamOnDone,
@@ -57,7 +61,12 @@ class AppPurchase {
   }
 
   bool _canInitializeStorePurchases() {
-    if (PlatformUtils.isDesktop || _subscription != null) {
+    if (PlatformUtils.isDesktop) {
+      appLogger.debug('[AppPurchase] Skipping init: desktop platform');
+      return false;
+    }
+    if (_subscription != null) {
+      appLogger.debug('[AppPurchase] Skipping init: already subscribed');
       return false;
     }
     if (!Platform.isAndroid) {
@@ -66,19 +75,44 @@ class AppPurchase {
     // Subscribing to purchaseStream initializes BillingClient, which OOMs
     // the Dalvik heap via an internal reconnect loop when Play Billing
     // isn't reachable. See getlantern/engineering#3485.
-    return canUsePlayBilling();
+    final allowed = canUsePlayBilling();
+    if (!allowed) {
+      appLogger.info(
+        '[AppPurchase] Skipping Play Billing init: canUsePlayBilling=false '
+        '(country=${CountryCode.current}, censored=${CountryCode.isCensoredRegion})',
+      );
+    }
+    return allowed;
   }
 
   Future<bool> _initPlayBillingIfAllowed() async {
+    appLogger.info(
+      '[AppPurchase] _initPlayBillingIfAllowed: '
+      'country=${CountryCode.current}, isKnown=${CountryCode.isKnown}, '
+      'subscribed=${_subscription != null}',
+    );
     init();
     if (_subscription != null) {
+      appLogger.info('[AppPurchase] _initPlayBillingIfAllowed: ready');
       return true;
     }
     if (Platform.isAndroid && !CountryCode.isKnown) {
-      await CountryCode.waitUntilKnown();
+      appLogger.info(
+        '[AppPurchase] _initPlayBillingIfAllowed: country unknown, '
+        'waiting for country-code event…',
+      );
+      final known = await CountryCode.waitUntilKnown();
+      appLogger.info(
+        '[AppPurchase] _initPlayBillingIfAllowed: waitUntilKnown returned '
+        '$known (country=${CountryCode.current}); retrying init',
+      );
       init();
     }
-    return _subscription != null;
+    final ready = _subscription != null;
+    appLogger.info(
+      '[AppPurchase] _initPlayBillingIfAllowed: ready=$ready',
+    );
+    return ready;
   }
 
   Future<void> fetchSubscriptions({int maxAttempts = 3}) async {

--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:io';
+import 'dart:ui';
 
 import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:in_app_purchase_android/in_app_purchase_android.dart';
@@ -46,7 +47,7 @@ class AppPurchase {
     // Subscribing to purchaseStream initializes BillingClient, which OOMs
     // the Dalvik heap via an internal reconnect loop when Play Billing
     // isn't reachable. See getlantern/engineering#3485.
-    if (Platform.isAndroid && !isStoreVersion()) {
+    if (Platform.isAndroid && _shouldSkipAndroidBillingInit()) {
       return;
     }
 
@@ -61,6 +62,29 @@ class AppPurchase {
         appLogger.error('[AppPurchase] init: fetchSubscriptions failed', e, st);
       }),
     );
+  }
+
+  bool _shouldSkipAndroidBillingInit() {
+    if (!isStoreVersion()) {
+      return true;
+    }
+
+    if (CountryCode.current.isNotEmpty) {
+      return false;
+    }
+
+    final localeCountry = PlatformDispatcher.instance.locale.countryCode
+        ?.trim()
+        .toUpperCase();
+    if (!CountryCode.censoredRegions.contains(localeCountry)) {
+      return false;
+    }
+
+    appLogger.info(
+      '[AppPurchase] Skipping Play Billing init from startup locale hint '
+      'while config country is pending: $localeCountry',
+    );
+    return true;
   }
 
   Future<void> fetchSubscriptions({int maxAttempts = 3}) async {

--- a/lib/core/services/injection_container.dart
+++ b/lib/core/services/injection_container.dart
@@ -45,9 +45,11 @@ Future<void> injectServices() async {
 
   appLogger.debug('Initializing AppPurchase...');
   final appPurchase = AppPurchase();
-  appPurchase.init();
   sl.registerSingleton<AppPurchase>(appPurchase);
-  appLogger.debug('AppPurchase initialized');
+  if (!PlatformUtils.isAndroid) {
+    appPurchase.init();
+  }
+  appLogger.debug('AppPurchase registered');
 
   sl.registerSingleton<LanternPlatformService>(LanternPlatformService());
   sl.registerSingleton<LanternFFIService>(
@@ -56,22 +58,20 @@ Future<void> injectServices() async {
         : MockLanternFFIService(),
   );
 
-  sl.registerSingletonAsync<LanternService>(
-    () async {
-      final service = LanternService(
-        ffiService: sl<LanternFFIService>(),
-        platformService: sl<LanternPlatformService>(),
-        appPurchase: sl<AppPurchase>(),
-      );
-      try {
-        await service.init();
-        appLogger.debug('LanternService initialized');
-      } catch (e, st) {
-        appLogger.error('LanternService init failed', e, st);
-      }
-      return service;
-    },
-  );
+  sl.registerSingletonAsync<LanternService>(() async {
+    final service = LanternService(
+      ffiService: sl<LanternFFIService>(),
+      platformService: sl<LanternPlatformService>(),
+      appPurchase: sl<AppPurchase>(),
+    );
+    try {
+      await service.init();
+      appLogger.debug('LanternService initialized');
+    } catch (e, st) {
+      appLogger.error('LanternService init failed', e, st);
+    }
+    return service;
+  });
 
   appLogger.debug('Initializing notification/Stripe services...');
   final notificationService = NotificationService();

--- a/lib/core/utils/country_code.dart
+++ b/lib/core/utils/country_code.dart
@@ -1,12 +1,16 @@
+import 'dart:async';
+
 class CountryCode {
   static const censoredRegions = ['CN', 'RU', 'IR'];
 
   static String _current = '';
   static bool _playBillingFallback = false;
+  static final _knownCompleter = Completer<void>();
 
   /// Latest country code received from core. Empty string until the first
   /// `country-code` event arrives (or when core sends an empty value).
   static String get current => _current;
+  static bool get isKnown => _current.isNotEmpty;
 
   /// True when core reports a censored country or Play Billing has failed
   /// enough times that the app should offer the non-store payment path.
@@ -15,6 +19,23 @@ class CountryCode {
 
   static void update(String code) {
     _current = code.trim().toUpperCase();
+    if (isKnown && !_knownCompleter.isCompleted) {
+      _knownCompleter.complete();
+    }
+  }
+
+  static Future<bool> waitUntilKnown({
+    Duration timeout = const Duration(seconds: 3),
+  }) async {
+    if (isKnown) {
+      return true;
+    }
+    try {
+      await _knownCompleter.future.timeout(timeout);
+    } catch (_) {
+      // The caller decides how to proceed when config country is unavailable.
+    }
+    return isKnown;
   }
 
   /// Force-flag the current region as censored without a known country code.

--- a/lib/core/utils/country_code.dart
+++ b/lib/core/utils/country_code.dart
@@ -2,21 +2,19 @@ class CountryCode {
   static const censoredRegions = ['CN', 'RU', 'IR'];
 
   static String _current = '';
-  static bool _isCensoredRegion = false;
+  static bool _playBillingFallback = false;
 
   /// Latest country code received from core. Empty string until the first
   /// `country-code` event arrives (or when core sends an empty value).
   static String get current => _current;
 
-  /// True once we've observed a censored country code from core, or when
-  /// [markCensored] was called (e.g. Play Billing unreachable on Android).
-  static bool get isCensoredRegion => _isCensoredRegion;
+  /// True when core reports a censored country or Play Billing has failed
+  /// enough times that the app should offer the non-store payment path.
+  static bool get isCensoredRegion =>
+      censoredRegions.contains(_current) || _playBillingFallback;
 
   static void update(String code) {
-    _current = code;
-    if (code.isNotEmpty && censoredRegions.contains(code.toUpperCase())) {
-      _isCensoredRegion = true;
-    }
+    _current = code.trim().toUpperCase();
   }
 
   /// Force-flag the current region as censored without a known country code.
@@ -24,6 +22,6 @@ class CountryCode {
   /// that the user is in a censored region even if the country lookup is
   /// blocked.
   static void markCensored() {
-    _isCensoredRegion = true;
+    _playBillingFallback = true;
   }
 }

--- a/lib/core/widgets/oauth_login.dart
+++ b/lib/core/widgets/oauth_login.dart
@@ -60,9 +60,9 @@ class OAuthLogin extends HookConsumerWidget {
     WidgetRef ref,
     BuildContext context,
   ) async {
-    if (await _isRegionAllowed(ref, context)) {
-      await oAuthLogin(type, ref, context);
-    }
+    final allowed = await _isRegionAllowed(ref, context);
+    if (!allowed || !context.mounted) return;
+    await oAuthLogin(type, ref, context);
   }
 
   Future<bool> _isRegionAllowed(WidgetRef ref, BuildContext context) async {
@@ -71,7 +71,7 @@ class OAuthLogin extends HookConsumerWidget {
 
     final country = ref.read(countryCodeProvider);
 
-    /// Proceed if country is unknown or not censored.
+    // Proceed if country is unknown or not censored.
     if (country.isEmpty ||
         !CountryCode.censoredRegions.contains(country.toUpperCase())) {
       return true;
@@ -113,7 +113,7 @@ class OAuthLogin extends HookConsumerWidget {
             }
           });
 
-          /// For mobile we have to use system default browser
+          // Mobile sign-in needs the system browser for the deep link.
           UrlUtils.openWithSystemBrowser(url);
         } else {
           UrlUtils.openWebview<Map<String, dynamic>>(

--- a/lib/features/home/provider/country_code_notifier.dart
+++ b/lib/features/home/provider/country_code_notifier.dart
@@ -1,3 +1,7 @@
+import 'dart:io';
+
+import 'package:lantern/core/services/app_purchase.dart';
+import 'package:lantern/core/services/injection_container.dart';
 import 'package:lantern/core/utils/country_code.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -16,5 +20,8 @@ class CountryCodeNotifier extends _$CountryCodeNotifier {
     CountryCode.update(code);
     state = CountryCode.current;
     appLogger.debug('Updating country code to: $state');
+    if (Platform.isAndroid && sl.isRegistered<AppPurchase>()) {
+      sl<AppPurchase>().init();
+    }
   }
 }

--- a/lib/features/home/provider/country_code_notifier.dart
+++ b/lib/features/home/provider/country_code_notifier.dart
@@ -21,7 +21,10 @@ class CountryCodeNotifier extends _$CountryCodeNotifier {
     state = CountryCode.current;
     appLogger.debug('Updating country code to: $state');
     if (Platform.isAndroid && sl.isRegistered<AppPurchase>()) {
-      sl<AppPurchase>().init();
+      final appPurchase = sl<AppPurchase>();
+      if (!CountryCode.isCensoredRegion) {
+        appPurchase.init();
+      }
     }
   }
 }

--- a/lib/features/home/provider/country_code_notifier.dart
+++ b/lib/features/home/provider/country_code_notifier.dart
@@ -1,5 +1,3 @@
-import 'dart:ui';
-
 import 'package:lantern/core/utils/country_code.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -11,19 +9,12 @@ part 'country_code_notifier.g.dart';
 class CountryCodeNotifier extends _$CountryCodeNotifier {
   @override
   String build() {
-    /// Seed with the system locale's country as a best-effort guess.
-    final initial =
-        PlatformDispatcher.instance.locale.countryCode?.toUpperCase() ?? '';
-    if (initial.isNotEmpty) {
-      appLogger.debug('Seeding country code from system locale: $initial');
-      CountryCode.update(initial);
-    }
-    return initial;
+    return CountryCode.current;
   }
 
   void update(String code) {
-    appLogger.debug('Updating country code to: $code');
     CountryCode.update(code);
-    state = code;
+    state = CountryCode.current;
+    appLogger.debug('Updating country code to: $state');
   }
 }

--- a/lib/features/plans/plans.dart
+++ b/lib/features/plans/plans.dart
@@ -405,9 +405,7 @@ class _PlansState extends ConsumerState<Plans>
     }, (_) {});
   }
 
-  /// When Play Billing fails to load products, [AppPurchase.fetchSubscriptions]
-  /// flips [CountryCode.isCensoredRegion]. Route the user straight to the Stripe
-  /// signup flow on the same tap so they don't have to retry.
+  // When Play Billing cannot load products, route the same tap to Stripe.
   bool _redirectToSignupIfPlayBlocked() {
     if (!Platform.isAndroid || !CountryCode.isCensoredRegion) return false;
     appLogger.info(


### PR DESCRIPTION
- Uses core/config country as the source of truth instead of device locale for censored-region routing
- Keeps Play Billing fallback state separate from the reported country code
- Normalizes country codes before checking censored regions
