### PR TITLE
Prevent ConfirmEmail back from deleting signup accounts

### DIFF
--- a/lib/features/auth/confirm_email.dart
+++ b/lib/features/auth/confirm_email.dart
@@ -7,9 +7,7 @@ import 'package:lantern/core/common/common.dart' hide BackButton;
 import 'package:lantern/core/widgets/app_pin_field.dart';
 import 'package:lantern/core/widgets/app_rich_text.dart';
 import 'package:lantern/features/auth/provider/auth_notifier.dart';
-import 'package:lantern/features/home/provider/app_setting_notifier.dart';
 import 'package:lantern/features/home/provider/home_notifier.dart';
-import 'package:lantern/features/plans/provider/payment_notifier.dart';
 
 @RoutePage(name: 'ConfirmEmail')
 class ConfirmEmail extends HookConsumerWidget {
@@ -36,13 +34,13 @@ class ConfirmEmail extends HookConsumerWidget {
       canPop: false,
       onPopInvokedWithResult: (didPop, result) {
         if (didPop) return;
-        onBackPresses(ref, context);
+        onBackPresses();
       },
       child: BaseScreen(
         title: '',
         appBar: CustomAppBar(
           title: Text('confirm_email'.i18n),
-          leading: BackButton(onPressed: () => onBackPresses(ref, context)),
+          leading: BackButton(onPressed: onBackPresses),
         ),
         body: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -97,78 +95,9 @@ class ConfirmEmail extends HookConsumerWidget {
     );
   }
 
-  Future<void> onBackPresses(WidgetRef ref, BuildContext context) async {
+  void onBackPresses() {
     appLogger.info('Back button pressed in ConfirmEmail screen');
-    if (password == null) {
-      appRouter.pop();
-      return;
-    }
-    final appSettings = ref.read(appSettingProvider);
-    final isLoggedIn = appSettings.userLoggedIn;
-
-    /// In case of logged in user just pop the screen
-    /// we do not want to delete user since account is created but user do not have pro
-    if (isLoggedIn) {
-      appRouter.pop();
-      return;
-    }
-
-    /// Defensive: never delete a Pro account on back-press, even if every other
-    /// guard somehow missed this case. A successful Apple/Google IAP promotes
-    /// the legacy user to `pro` inline server-side, so a paid user that
-    /// reaches this screen is already Pro and must be preserved.
-    if (ref.read(isUserProProvider)) {
-      appLogger.info(
-        'Back press in ConfirmEmail with pro user; preserving account',
-      );
-      appRouter.pop();
-      return;
-    }
-
-    if (authFlow != AuthFlow.signUp) {
-      appRouter.pop();
-      return;
-    }
-
-    /// If the user just initiated an external (e.g. Alipay/shepherd) payment,
-    /// Deleting that account here would orphan a paid subscription
-    final paymentRedirectInitiated = ref.read(paymentSessionProvider);
-    if (paymentRedirectInitiated) {
-      appLogger.info(
-        'Back press in ConfirmEmail with payment redirect in flight; '
-        'preserving anonymous account to avoid orphaning payment',
-      );
-      appRouter.pop();
-      return;
-    }
-
-    appLogger.info(
-      'Back button pressed in ConfirmEmail screen Deleting account',
-    );
-    assert(
-      password != null,
-      'Password must be provided to delete account on back press',
-    );
-    context.showLoadingDialog();
-
-    /// This back-press deletion is part of the email/password signup flow,
-    /// so isSSO is always false because this is not an OAuth user.
-    final result = await ref
-        .read(authProvider.notifier)
-        .deleteAccount(email, password!, false);
-
-    result.fold(
-      (failure) {
-        context.hideLoadingDialog();
-        context.showSnackBar(failure.localizedErrorMessage);
-      },
-      (_) {
-        ///reset login status
-        ref.read(appSettingProvider.notifier).setUserLoggedIn(false);
-        context.hideLoadingDialog();
-        appRouter.pop();
-      },
-    );
+    appRouter.pop();
   }
 
   void onContinueTap(BuildContext context, WidgetRef ref, String code) {

--- a/test/features/auth/confirm_email_test.dart
+++ b/test/features/auth/confirm_email_test.dart
@@ -1,0 +1,111 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/common/app_eum.dart';
+import 'package:lantern/core/common/app_theme.dart';
+import 'package:lantern/core/models/user.dart';
+import 'package:lantern/core/router/router.dart';
+import 'package:lantern/core/services/injection_container.dart';
+import 'package:lantern/core/utils/failure.dart';
+import 'package:lantern/features/auth/confirm_email.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
+import 'package:loader_overlay/loader_overlay.dart';
+
+class _RecordingAppRouter extends AppRouter {
+  int popCount = 0;
+
+  @override
+  void pop<T extends Object?>([T? result]) {
+    popCount += 1;
+  }
+}
+
+class _FakeLanternService implements LanternService {
+  int deleteAccountCalls = 0;
+
+  @override
+  Future<Either<Failure, UserResponseModel>> deleteAccount({
+    required String email,
+    required String password,
+    bool isSSO = false,
+  }) async {
+    deleteAccountCalls += 1;
+    return right(
+      const UserResponseModel(
+        legacyID: 0,
+        legacyToken: '',
+        emailConfirmed: false,
+        success: true,
+      ),
+    );
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  group('ConfirmEmail', () {
+    late _RecordingAppRouter router;
+    late _FakeLanternService lanternService;
+
+    setUp(() async {
+      await sl.reset();
+      router = _RecordingAppRouter();
+      lanternService = _FakeLanternService();
+      sl.registerSingleton<AppRouter>(router);
+    });
+
+    tearDown(() async {
+      await sl.reset();
+    });
+
+    Widget buildHarness() {
+      return ProviderScope(
+        overrides: [lanternServiceProvider.overrideWithValue(lanternService)],
+        child: ScreenUtilInit(
+          designSize: const Size(390, 844),
+          child: GlobalLoaderOverlay(
+            child: MaterialApp(
+              theme: AppTheme.appTheme(),
+              home: const ConfirmEmail(
+                email: 'person@example.com',
+                password: 'temp-password',
+                authFlow: AuthFlow.signUp,
+              ),
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('signup back press pops without deleting the account', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildHarness());
+      await tester.pump();
+
+      await tester.tap(find.byType(BackButton));
+      await tester.pump();
+
+      expect(router.popCount, 1);
+      expect(lanternService.deleteAccountCalls, 0);
+    });
+
+    testWidgets('system back press pops without deleting the account', (
+      tester,
+    ) async {
+      await tester.pumpWidget(buildHarness());
+      await tester.pump();
+
+      await tester.binding.handlePopRoute();
+      await tester.pump();
+
+      expect(router.popCount, 1);
+      expect(lanternService.deleteAccountCalls, 0);
+    });
+  });
+}


### PR DESCRIPTION
Resolves https://github.com/getlantern/engineering/issues/3532

I think the server should own cleanup of abandoned, unverified, unpaid signups by TTL
