### PR TITLE
Continue to turn on the VPN when the extension is installed.

### DIFF
--- a/lib/features/macos_extension/macos_extension_dialog.dart
+++ b/lib/features/macos_extension/macos_extension_dialog.dart
@@ -43,7 +43,7 @@ class _MacOSExtensionDialogState extends ConsumerState<MacOSExtensionDialog> {
           appLogger.info(
             "System Extension is installed and activated. Closing dialog.",
           );
-          appRouter.pop();
+          appRouter.pop(true);
         });
       }
       return null;

--- a/lib/features/vpn/vpn_switch.dart
+++ b/lib/features/vpn/vpn_switch.dart
@@ -89,8 +89,9 @@ class VPNSwitch extends HookConsumerWidget {
     if (PlatformUtils.isMacOS) {
       final systemExtensionStatus = ref.read(macosExtensionProvider);
       if (!systemExtensionStatus.isReady) {
-        appRouter.push(const MacOSExtensionDialog());
-        return;
+        await appRouter.push(const MacOSExtensionDialog());
+        if (!context.mounted) return;
+        if (!ref.read(macosExtensionProvider).isReady) return;
       }
     }
 

--- a/lib/features/vpn/vpn_switch.dart
+++ b/lib/features/vpn/vpn_switch.dart
@@ -13,16 +13,14 @@ class VPNSwitch extends HookConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    ref.listen<AsyncValue<LanternStatus>>(
-      vPNStatusProvider,
-      (previous, next) {
-        if (next is AsyncData<LanternStatus> &&
-            next.value.status == VPNStatus.error) {
-          context.showSnackBar(
-              next.value.error ?? 'error_while_vpn_connection'.i18n);
-        }
-      },
-    );
+    ref.listen<AsyncValue<LanternStatus>>(vPNStatusProvider, (previous, next) {
+      if (next is AsyncData<LanternStatus> &&
+          next.value.status == VPNStatus.error) {
+        context.showSnackBar(
+          next.value.error ?? 'error_while_vpn_connection'.i18n,
+        );
+      }
+    });
     final vpnStatus = ref.watch(vpnProvider);
     final isVPNOn = (vpnStatus == VPNStatus.connected);
     return CustomAnimatedToggleSwitch<bool>(
@@ -89,45 +87,41 @@ class VPNSwitch extends HookConsumerWidget {
     if (PlatformUtils.isMacOS) {
       final systemExtensionStatus = ref.read(macosExtensionProvider);
       if (!systemExtensionStatus.isReady) {
-        await appRouter.push(const MacOSExtensionDialog());
-        if (!context.mounted) return;
-        if (!ref.read(macosExtensionProvider).isReady) return;
+        appRouter.push(const MacOSExtensionDialog()).then((value) {
+          if (value != null && value as bool) {
+            onVPNStateChange(ref, context);
+          }
+        });
+        return;
       }
     }
 
-    final result =
-        await ref.read(vpnProvider.notifier).onVPNStateChange(context);
+    final result = await ref
+        .read(vpnProvider.notifier)
+        .onVPNStateChange(context);
 
     if (!context.mounted) return;
-    result.fold(
-      (failure) {
-        if (failure is VpnConflictFailure) {
-          AppDialog.vpnConflictDialog(
-            context: context,
-            onConnectAnyway: () async {
-              appRouter.maybePop();
-              final retryResult = await ref
-                  .read(vpnProvider.notifier)
-                  .startVPN(skipConflictCheck: true);
-              if (!context.mounted) return;
-              retryResult.fold(
-                (failure) {
-                  context.showSnackBar(failure.localizedErrorMessage);
-                  appLogger.error(
-                      "Error changing VPN state: ${failure.error}");
-                },
-                (_) => null,
-              );
-            },
-          );
-        } else {
-          context.showSnackBar(failure.localizedErrorMessage);
-          appLogger.error(
-              "Error changing VPN state: ${failure.error}");
-        }
-      },
-      (_) => null,
-    );
+    result.fold((failure) {
+      if (failure is VpnConflictFailure) {
+        AppDialog.vpnConflictDialog(
+          context: context,
+          onConnectAnyway: () async {
+            appRouter.maybePop();
+            final retryResult = await ref
+                .read(vpnProvider.notifier)
+                .startVPN(skipConflictCheck: true);
+            if (!context.mounted) return;
+            retryResult.fold((failure) {
+              context.showSnackBar(failure.localizedErrorMessage);
+              appLogger.error("Error changing VPN state: ${failure.error}");
+            }, (_) => null);
+          },
+        );
+      } else {
+        context.showSnackBar(failure.localizedErrorMessage);
+        appLogger.error("Error changing VPN state: ${failure.error}");
+      }
+    }, (_) => null);
   }
 
   Color _wrapperColor(VPNStatus vpnStatus, BuildContext context) {

--- a/lib/features/vpn/vpn_switch.dart
+++ b/lib/features/vpn/vpn_switch.dart
@@ -88,7 +88,13 @@ class VPNSwitch extends HookConsumerWidget {
       final systemExtensionStatus = ref.read(macosExtensionProvider);
       if (!systemExtensionStatus.isReady) {
         appRouter.push(const MacOSExtensionDialog()).then((value) {
+          appLogger.info(
+            'Returned from MacOS Extension Dialog with value: $value',
+          );
           if (value != null && value as bool) {
+            appLogger.info(
+              'Retrying VPN state change after MacOS Extension setup',
+            );
             onVPNStateChange(ref, context);
           }
         });


### PR DESCRIPTION
This pull request improves the handling of the macOS extension dialog in the `VPNSwitch` widget to ensure better user experience and state management. The main change is to wait for the dialog to complete before proceeding and to check the widget's mount status and extension readiness after the dialog.

**macOS Extension Dialog Handling:**

* Changed the logic in `VPNSwitch` to `await` the result of `MacOSExtensionDialog`, ensuring the dialog completes before proceeding.
* Added checks to confirm the widget is still mounted (`context.mounted`) and that the extension is ready after the dialog, preventing potential errors if the widget was disposed or the extension is still not ready.