### PR TITLE
Restore macOS window when app icon is clicked

### DIFF
--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -15,6 +15,20 @@ class AppDelegate: FlutterAppDelegate {
     return false
   }
 
+  override func applicationShouldHandleReopen(
+    _ sender: NSApplication,
+    hasVisibleWindows flag: Bool
+  ) -> Bool {
+    guard !flag else {
+      return true
+    }
+
+    mainFlutterWindow?.deminiaturize(nil)
+    mainFlutterWindow?.makeKeyAndOrderFront(nil)
+    sender.activate(ignoringOtherApps: true)
+    return false
+  }
+
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
     return true
   }

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -23,10 +23,13 @@ class AppDelegate: FlutterAppDelegate {
       return true
     }
 
-    mainFlutterWindow?.deminiaturize(nil)
-    mainFlutterWindow?.makeKeyAndOrderFront(nil)
+    sender.unhide(nil)
+    if let window = mainFlutterWindow {
+      window.deminiaturize(nil)
+      window.makeKeyAndOrderFront(nil)
+    }
     sender.activate(ignoringOtherApps: true)
-    return false
+    return true
   }
 
   override func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {


### PR DESCRIPTION
Resolves https://github.com/getlantern/engineering/issues/3537 and https://github.com/getlantern/lantern/issues/8731

- Adds a macOS reopen handler for the hidden main Flutter window
- Restores the window when the app is reopened with no visible windows
