### PR TITLE
Add desktop payment redirect FFI error handling

### DIFF
--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -757,6 +757,7 @@ class LanternFFIService implements LanternCoreService {
             .toDartString();
       });
 
+      checkAPIError(result);
       return right(result);
     } catch (e) {
       return Left(e.toFailure());
@@ -923,6 +924,7 @@ class LanternFFIService implements LanternCoreService {
             )
             .toDartString();
       });
+      checkAPIError(result);
       return Right(result);
     } catch (e, stackTrace) {
       appLogger.error('error payment redirect', e, stackTrace);

--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -747,19 +747,27 @@ class LanternFFIService implements LanternCoreService {
     try {
       appLogger.debug('Starting Stripe Subscription Payment Redirect');
       final result = await runInBackground<String>(() async {
-        return _ffiService
-            .stripeSubscriptionPaymentRedirect(
-              type.name.toCharPtr,
-              planId.toCharPtr,
-              email.toCharPtr,
-              idempotencyKey.toCharPtr,
-            )
-            .toDartString();
+        final resultPtr = _ffiService.stripeSubscriptionPaymentRedirect(
+          type.name.toCharPtr,
+          planId.toCharPtr,
+          email.toCharPtr,
+          idempotencyKey.toCharPtr,
+        );
+        try {
+          return resultPtr.toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
 
       checkAPIError(result);
       return right(result);
-    } catch (e) {
+    } catch (e, stackTrace) {
+      appLogger.error(
+        'Error getting stripe subscription payment redirect',
+        e,
+        stackTrace,
+      );
       return Left(e.toFailure());
     }
   }
@@ -776,8 +784,14 @@ class LanternFFIService implements LanternCoreService {
   Future<Either<Failure, String>> stripeBillingPortal() async {
     try {
       final result = await runInBackground<String>(() async {
-        return _ffiService.stripeBillingPortalUrl().toDartString();
+        final resultPtr = _ffiService.stripeBillingPortalUrl();
+        try {
+          return resultPtr.toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
+      checkAPIError(result);
       return Right(result);
     } catch (e, stackTrace) {
       appLogger.error('Error getting stipe billing', e, stackTrace);
@@ -915,14 +929,17 @@ class LanternFFIService implements LanternCoreService {
   }) async {
     try {
       final result = await runInBackground<String>(() async {
-        return _ffiService
-            .paymentRedirect(
-              planId.toCharPtr,
-              provider.toCharPtr,
-              email.toCharPtr,
-              idempotencyKey.toCharPtr,
-            )
-            .toDartString();
+        final resultPtr = _ffiService.paymentRedirect(
+          planId.toCharPtr,
+          provider.toCharPtr,
+          email.toCharPtr,
+          idempotencyKey.toCharPtr,
+        );
+        try {
+          return resultPtr.toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
       checkAPIError(result);
       return Right(result);


### PR DESCRIPTION
Partially addresses https://github.com/getlantern/engineering/issues/3530

Updates the desktop FFI payment redirect flows to check Go error responses before returning redirect URLs. This prevents {"error": ...} responses from being treated as valid URLs and surfacing as misleading “invalid redirect URL” payment failures.





