### PR TITLE
don't delete tags on failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -845,7 +845,7 @@ jobs:
           while [ "$attempt" -lt "$max_retries" ]; do
             attempt=$((attempt + 1))
             echo "Deleting release $RELEASE_TAG (attempt $attempt/$max_retries)..."
-            if delete_output="$(gh release delete "$RELEASE_TAG" --yes --cleanup-tag 2>&1)"; then
+            if delete_output="$(gh release delete "$RELEASE_TAG" --yes 2>&1)"; then
               echo "$delete_output"
               echo "Release $RELEASE_TAG deleted"
               break


### PR DESCRIPTION
Deleting a tag on build failure can be confusing.
https://wdynhnkxvsdx.slack.com/archives/C04T8M4AB1Q/p1779494717571219?thread_ts=1779411374.549329&cid=C04T8M4AB1Q

Let's stop doing that.