### PR TITLE
macos: continue sysext downgrade when stale deactivation is already missing

### DIFF
--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -5,21 +5,34 @@ import SystemExtensions
 
 /// Decides whether a failed system extension request should trigger a
 /// stale-registry recovery attempt. macOS occasionally surfaces
-/// `extensionNotFound` on an activation request when its registry holds a
-/// reference to a previously-installed extension that no longer matches the
-/// app on disk — e.g. after the .app bundle was replaced under an existing
-/// install. Submitting a deactivation request first clears that state and
-/// gives the subsequent activation a clean slot. The decision is gated to a
-/// single attempt per session so a persistent failure doesn't loop.
+/// `extensionNotFound` when its registry holds a reference to a
+/// previously-installed extension that no longer matches the app on disk —
+/// e.g. after the .app bundle was replaced under an existing install.
+/// Activation failures recover by deactivating first; replacement
+/// deactivation failures recover by continuing to the activation that was
+/// already planned. Activation retry is gated to a single attempt per session
+/// so a persistent failure doesn't loop.
 internal enum StaleRegistryRecovery {
+  private static func isExtensionNotFound(_ error: NSError) -> Bool {
+    error.domain == OSSystemExtensionErrorDomain
+      && error.code == OSSystemExtensionError.extensionNotFound.rawValue
+  }
+
   static func shouldRecover(
     from error: NSError,
     activationFailed: Bool,
     alreadyAttempted: Bool
   ) -> Bool {
     guard !alreadyAttempted, activationFailed else { return false }
-    return error.domain == OSSystemExtensionErrorDomain
-      && error.code == OSSystemExtensionError.extensionNotFound.rawValue
+    return isExtensionNotFound(error)
+  }
+
+  static func shouldContinueAfterMissingReplacement(
+    from error: NSError,
+    replacementDeactivationFailed: Bool
+  ) -> Bool {
+    guard replacementDeactivationFailed else { return false }
+    return isExtensionNotFound(error)
   }
 }
 
@@ -45,10 +58,10 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
 
   @Published private(set) var status: ExtensionStatus = .notInstalled
 
-  /// Set when we've issued a stale-registry recovery (deactivate-then-activate
-  /// in response to `extensionNotFound`). Reset on the next successful
-  /// completion. Single-shot per session to prevent an infinite retry loop if
-  /// the same error reproduces after the recovery deactivation.
+  /// Set when we've taken a stale-registry recovery path for
+  /// `extensionNotFound`. Reset on the next successful activation. Single-shot
+  /// per session to prevent an infinite retry loop if the same error reproduces
+  /// after recovery.
   private var didAttemptStaleRegistryRecovery = false
 
   override init() {
@@ -179,6 +192,19 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
       submitDeactivationRequest(
         reason: "stale-registry recovery after extensionNotFound",
         activateAfter: true)
+      return
+    }
+
+    if StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+      from: nsError,
+      replacementDeactivationFailed: context?.activatesAfterDeactivation ?? false)
+    {
+      didAttemptStaleRegistryRecovery = true
+      appLogger.info(
+        "Replacement deactivation failed with extensionNotFound — continuing with bundled activation (context=\(context?.logDescription ?? "unknown"))"
+      )
+      submitActivationRequest(
+        reason: "activating bundled extension after missing stale extension during replacement")
       return
     }
 
@@ -371,6 +397,11 @@ private enum RequestContext: Equatable {
 
   var isActivation: Bool {
     if case .activate = self { return true }
+    return false
+  }
+
+  var activatesAfterDeactivation: Bool {
+    if case .deactivateThenActivate(_, true) = self { return true }
     return false
   }
 

--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -27,11 +27,11 @@ internal enum StaleRegistryRecovery {
     return isExtensionNotFound(error)
   }
 
-  static func shouldContinueAfterMissingReplacement(
+  static func shouldContinueAfterMissingDeactivation(
     from error: NSError,
-    replacementDeactivationFailed: Bool
+    activateAfterDeactivation: Bool
   ) -> Bool {
-    guard replacementDeactivationFailed else { return false }
+    guard activateAfterDeactivation else { return false }
     return isExtensionNotFound(error)
   }
 }
@@ -195,9 +195,9 @@ class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
       return
     }
 
-    if StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+    if StaleRegistryRecovery.shouldContinueAfterMissingDeactivation(
       from: nsError,
-      replacementDeactivationFailed: context?.activatesAfterDeactivation ?? false)
+      activateAfterDeactivation: context?.activatesAfterDeactivation ?? false)
     {
       didAttemptStaleRegistryRecovery = true
       appLogger.info(

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -458,11 +458,9 @@ final class RunnerTests: XCTestCase {
     }
   }
 
-  // Recovery is scoped to activation requests. If a properties-query or
-  // deactivation fails with extensionNotFound, we should not attempt to
-  // recover via a second deactivation — those request types don't suffer
-  // from the same stale-activation-slot bug, and retrying would mask real
-  // errors.
+  // Activation retry is scoped to activation requests. If a properties-query
+  // or deactivation fails with extensionNotFound, shouldRecover must not
+  // submit another deactivation request.
   func testStaleRegistryRecoveryDoesNotFireForNonActivationContexts() {
     let error = NSError(
       domain: OSSystemExtensionErrorDomain,
@@ -473,6 +471,45 @@ final class RunnerTests: XCTestCase {
         from: error,
         activationFailed: false,
         alreadyAttempted: false
+      )
+    )
+  }
+
+  func testStaleRegistryRecoveryContinuesAfterMissingReplacementDeactivation() {
+    let error = NSError(
+      domain: OSSystemExtensionErrorDomain,
+      code: OSSystemExtensionError.extensionNotFound.rawValue
+    )
+    XCTAssertTrue(
+      StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+        from: error,
+        replacementDeactivationFailed: true
+      )
+    )
+  }
+
+  func testStaleRegistryRecoveryDoesNotContinueAfterManualDeactivation() {
+    let error = NSError(
+      domain: OSSystemExtensionErrorDomain,
+      code: OSSystemExtensionError.extensionNotFound.rawValue
+    )
+    XCTAssertFalse(
+      StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+        from: error,
+        replacementDeactivationFailed: false
+      )
+    )
+  }
+
+  func testStaleRegistryRecoveryDoesNotContinueAfterOtherDeactivationErrors() {
+    let error = NSError(
+      domain: OSSystemExtensionErrorDomain,
+      code: OSSystemExtensionError.validationFailed.rawValue
+    )
+    XCTAssertFalse(
+      StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+        from: error,
+        replacementDeactivationFailed: true
       )
     )
   }

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -481,9 +481,9 @@ final class RunnerTests: XCTestCase {
       code: OSSystemExtensionError.extensionNotFound.rawValue
     )
     XCTAssertTrue(
-      StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+      StaleRegistryRecovery.shouldContinueAfterMissingDeactivation(
         from: error,
-        replacementDeactivationFailed: true
+        activateAfterDeactivation: true
       )
     )
   }
@@ -494,9 +494,9 @@ final class RunnerTests: XCTestCase {
       code: OSSystemExtensionError.extensionNotFound.rawValue
     )
     XCTAssertFalse(
-      StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+      StaleRegistryRecovery.shouldContinueAfterMissingDeactivation(
         from: error,
-        replacementDeactivationFailed: false
+        activateAfterDeactivation: false
       )
     )
   }
@@ -507,9 +507,9 @@ final class RunnerTests: XCTestCase {
       code: OSSystemExtensionError.validationFailed.rawValue
     )
     XCTAssertFalse(
-      StaleRegistryRecovery.shouldContinueAfterMissingReplacement(
+      StaleRegistryRecovery.shouldContinueAfterMissingDeactivation(
         from: error,
-        replacementDeactivationFailed: true
+        activateAfterDeactivation: true
       )
     )
   }


### PR DESCRIPTION
Fixes a macOS system extension downgrade edge case where the downgrade flow could fail with `OSSystemExtensionErrorDomain error 4` (`extensionNotFound`) during the deactivation step

## Changes

- Treat `extensionNotFound` during replacement deactivation as recoverable when `activateAfter=true`
- Continue by activating the bundled system extension
- Keep manual deactivation behavior unchanged
- Add focused tests for replacement deactivation recovery and non-recovery cases
