### PR TITLE
windows: gate installer at Win10 1903 to fix cryptic icu.dll launch failure

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -126,17 +126,20 @@ jobs:
 
       - name: Install unofficial Inno Setup translations
         shell: pwsh
-        # Farsi/Persian is not a bundled Inno translation; copy the vendored
-        # .isl into Inno's Languages dir so inno_setup.iss can reference it as
-        # compiler:Languages\Farsi.isl. (Russian is bundled; en is Default.isl.)
+        # Chinese Simplified and Farsi/Persian are not bundled Inno translations;
+        # copy the vendored .isl files into Inno's Languages dir so inno_setup.iss
+        # can reference them as compiler:Languages\<name>.isl. (Russian is bundled;
+        # en is Default.isl.)
         run: |
           $langDir = "C:\Program Files (x86)\Inno Setup 6\Languages"
           if (-not (Test-Path $langDir)) {
             Write-Error "Inno Setup Languages dir not found: $langDir"
             exit 1
           }
-          Copy-Item "windows\packaging\exe\isl\Farsi.isl" "$langDir\Farsi.isl" -Force
-          Write-Host "Installed Farsi.isl -> $langDir"
+          foreach ($isl in 'ChineseSimplified.isl', 'Farsi.isl') {
+            Copy-Item "windows\packaging\exe\isl\$isl" "$langDir\$isl" -Force
+            Write-Host "Installed $isl -> $langDir"
+          }
 
       - name: Read app version from pubspec.yaml
         shell: pwsh

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -120,7 +120,23 @@ jobs:
 
       - name: Install Inno Setup 6
         shell: pwsh
-        run: choco install -y innosetup
+        # Pinned to 6.5.0 so the vendored Farsi.isl (6.5.0+) matches the
+        # compiler exactly and the Languages dir path is deterministic.
+        run: choco install -y innosetup --version=6.5.0
+
+      - name: Install unofficial Inno Setup translations
+        shell: pwsh
+        # Farsi/Persian is not a bundled Inno translation; copy the vendored
+        # .isl into Inno's Languages dir so inno_setup.iss can reference it as
+        # compiler:Languages\Farsi.isl. (Russian is bundled; en is Default.isl.)
+        run: |
+          $langDir = "C:\Program Files (x86)\Inno Setup 6\Languages"
+          if (-not (Test-Path $langDir)) {
+            Write-Error "Inno Setup Languages dir not found: $langDir"
+            exit 1
+          }
+          Copy-Item "windows\packaging\exe\isl\Farsi.isl" "$langDir\Farsi.isl" -Force
+          Write-Host "Installed Farsi.isl -> $langDir"
 
       - name: Read app version from pubspec.yaml
         shell: pwsh

--- a/windows/packaging/exe/inno_setup.iss
+++ b/windows/packaging/exe/inno_setup.iss
@@ -268,12 +268,24 @@ SetupLogging=yes
 UninstallLogging=yes
 CloseApplications=yes
 RestartApplications=no
+; v9 is a Flutter app; flutter_windows.dll links the system combined icu.dll,
+; first shipped in Windows 10 1903 (build 18362). Gate here so pre-1903 / Win7
+; users get a clear message instead of a cryptic "icu.dll missing" launch crash.
+MinVersion=10.0.18362
 
 [Languages]
 {% for locale in LOCALES %}
 {% if locale == 'en' %}Name: "english"; MessagesFile: "compiler:Default.isl"{% endif %}
 {% if locale == 'zh' %}Name: "chinesesimplified"; MessagesFile: "compiler:Languages\\ChineseSimplified.isl"{% endif %}
 {% if locale == 'ja' %}Name: "japanese"; MessagesFile: "compiler:Languages\\Japanese.isl"{% endif %}
+{% endfor %}
+
+[Messages]
+; Shown when MinVersion blocks install on pre-1903 Windows (no system icu.dll).
+{% for locale in LOCALES %}
+{% if locale == 'en' %}english.WindowsVersionNotSupported=Lantern 9 requires Windows 10 version 1903 (May 2019) or later.%n%nYour version of Windows is no longer supported by this release.{% endif %}
+{% if locale == 'zh' %}chinesesimplified.WindowsVersionNotSupported=Lantern 9 需要 Windows 10 1903 版本（2019 年 5 月）或更高版本。%n%n此版本不再支持您当前的 Windows 系统。{% endif %}
+{% if locale == 'ja' %}japanese.WindowsVersionNotSupported=Lantern 9 を実行するには Windows 10 バージョン 1903（2019年5月）以降が必要です。%n%nお使いの Windows はこのリリースではサポートされていません。{% endif %}
 {% endfor %}
 
 [Tasks]

--- a/windows/packaging/exe/inno_setup.iss
+++ b/windows/packaging/exe/inno_setup.iss
@@ -272,12 +272,16 @@ RestartApplications=no
 ; first shipped in Windows 10 1903 (build 18362). Gate here so pre-1903 / Win7
 ; users get a clear message instead of a cryptic "icu.dll missing" launch crash.
 MinVersion=10.0.18362
+; Multi-language installer: auto-detect from system UI locale, no picker dialog.
+ShowLanguageDialog=no
 
 [Languages]
 {% for locale in LOCALES %}
 {% if locale == 'en' %}Name: "english"; MessagesFile: "compiler:Default.isl"{% endif %}
 {% if locale == 'zh' %}Name: "chinesesimplified"; MessagesFile: "compiler:Languages\\ChineseSimplified.isl"{% endif %}
 {% if locale == 'ja' %}Name: "japanese"; MessagesFile: "compiler:Languages\\Japanese.isl"{% endif %}
+{% if locale == 'ru' %}Name: "russian"; MessagesFile: "compiler:Languages\\Russian.isl"{% endif %}
+{% if locale == 'fa' %}Name: "farsi"; MessagesFile: "compiler:Languages\\Farsi.isl"{% endif %}
 {% endfor %}
 
 [Messages]
@@ -286,6 +290,8 @@ MinVersion=10.0.18362
 {% if locale == 'en' %}english.WindowsVersionNotSupported=Lantern 9 requires Windows 10 version 1903 (May 2019) or later.%n%nYour version of Windows is no longer supported by this release.{% endif %}
 {% if locale == 'zh' %}chinesesimplified.WindowsVersionNotSupported=Lantern 9 需要 Windows 10 1903 版本（2019 年 5 月）或更高版本。%n%n此版本不再支持您当前的 Windows 系统。{% endif %}
 {% if locale == 'ja' %}japanese.WindowsVersionNotSupported=Lantern 9 を実行するには Windows 10 バージョン 1903（2019年5月）以降が必要です。%n%nお使いの Windows はこのリリースではサポートされていません。{% endif %}
+{% if locale == 'ru' %}russian.WindowsVersionNotSupported=Lantern 9 требует Windows 10 версии 1903 (май 2019 г.) или новее.%n%nВаша версия Windows больше не поддерживается в этом выпуске.{% endif %}
+{% if locale == 'fa' %}farsi.WindowsVersionNotSupported=Lantern 9 به Windows 10 نسخه 1903 (مه ۲۰۱۹) یا جدیدتر نیاز دارد.%n%nنسخه ویندوز شما دیگر در این نسخه پشتیبانی نمی‌شود.{% endif %}
 {% endfor %}
 
 [Tasks]

--- a/windows/packaging/exe/isl/ChineseSimplified.isl
+++ b/windows/packaging/exe/isl/ChineseSimplified.isl
@@ -1,0 +1,419 @@
+; *** Inno Setup version 6.5.0+ Chinese Simplified messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Maintainer: Zhenghan Yang (Kira)
+; Email: 847320916@QQ.com
+; Github: https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+; Encoding: UTF-8
+; Translation based on network resource
+;
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=简体中文
+; If Language Name display incorrect, uncomment next line
+; LanguageName=<7B80><4F53><4E2D><6587>
+; About LanguageID, to reference link:
+; https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-lcid/a9eac961-e77d-41a6-90a5-ce1a8b0cdb9c
+LanguageID=$0804
+; LanguageCodePage should always be set if possible, even if this file is Unicode
+; For English it's set to zero anyway because English only uses ASCII characters
+LanguageCodePage=936
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=9
+;DialogFontBaseScaleWidth=7
+;DialogFontBaseScaleHeight=15
+;WelcomeFontName=Segoe UI
+;WelcomeFontSize=14
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=安装
+SetupWindowTitle=安装 - %1
+UninstallAppTitle=卸载
+UninstallAppFullTitle=%1 卸载
+
+; *** Misc. common
+InformationTitle=信息
+ConfirmTitle=确认
+ErrorTitle=错误
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=现在将安装 %1。您想要继续吗？
+LdrCannotCreateTemp=无法创建临时文件。安装程序已中止
+LdrCannotExecTemp=无法执行临时目录中的文件。安装程序已中止
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1。%n%n错误 %2: %3
+SetupFileMissing=安装目录中缺少文件 %1。请修正这个问题或者获取程序的新副本。
+SetupFileCorrupt=安装文件已损坏。请获取程序的新副本。
+SetupFileCorruptOrWrongVer=安装文件已损坏，或是与这个安装程序的版本不兼容。请修正这个问题或获取新的程序副本。
+InvalidParameter=无效的命令行参数：%n%n%1
+SetupAlreadyRunning=安装程序正在运行。
+WindowsVersionNotSupported=此程序不支持当前计算机运行的 Windows 版本。
+WindowsServicePackRequired=此程序需要 %1 服务包 %2 或更高版本。
+NotOnThisPlatform=此程序不能在 %1 上运行。
+OnlyOnThisPlatform=此程序只能在 %1 上运行。
+OnlyOnTheseArchitectures=此程序只能安装到为下列处理器架构设计的 Windows 版本中：%n%n%1
+WinVersionTooLowError=此程序需要 %1 版本 %2 或更高。
+WinVersionTooHighError=此程序不能安装于 %1 版本 %2 或更高。
+AdminPrivilegesRequired=在安装此程序时您必须以管理员身份登录。
+PowerUserPrivilegesRequired=在安装此程序时您必须以管理员身份或有权限的用户组身份登录。
+SetupAppRunningError=安装程序发现 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+UninstallAppRunningError=卸载程序发现 %1 当前正在运行。%n%n请先关闭正在运行的程序，然后点击“确定”继续，或点击“取消”退出。
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=选择安装程序模式
+PrivilegesRequiredOverrideInstruction=选择安装模式
+PrivilegesRequiredOverrideText1=%1 可以为所有用户安装（需要管理员权限），或仅为您安装。
+PrivilegesRequiredOverrideText2=%1 可以仅为您安装，或为所有用户安装（需要管理员权限）。
+PrivilegesRequiredOverrideAllUsers=为所有用户安装(&A)
+PrivilegesRequiredOverrideAllUsersRecommended=为所有用户安装(&A)（建议选项）
+PrivilegesRequiredOverrideCurrentUser=仅为我安装(&M)
+PrivilegesRequiredOverrideCurrentUserRecommended=仅为我安装(&M)（建议选项）
+
+; *** Misc. errors
+ErrorCreatingDir=安装程序无法创建目录“%1”
+ErrorTooManyFilesInDir=无法在目录“%1”中创建文件，因为里面包含太多文件
+
+; *** Setup common messages
+ExitSetupTitle=退出安装程序
+ExitSetupMessage=安装程序尚未完成。如果现在退出，将不会安装该程序。%n%n您之后可以再次运行安装程序完成安装。%n%n现在退出安装程序吗？
+AboutSetupMenuItem=关于安装程序(&A)...
+AboutSetupTitle=关于安装程序
+AboutSetupMessage=%1 版本 %2%n%3%n%n%1 主页：%n%4
+AboutSetupNote=
+TranslatorNote=简体中文翻译由 Kira（847320916@qq.com）维护。项目地址：https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation
+
+; *** Buttons
+ButtonBack=< 上一步(&B)
+ButtonNext=下一步(&N) >
+ButtonInstall=安装(&I)
+ButtonOK=确定
+ButtonCancel=取消
+ButtonYes=是(&Y)
+ButtonYesToAll=全是(&A)
+ButtonNo=否(&N)
+ButtonNoToAll=全否(&O)
+ButtonFinish=完成(&F)
+ButtonBrowse=浏览(&B)...
+ButtonWizardBrowse=浏览(&R)...
+ButtonNewFolder=新建文件夹(&M)
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=选择安装语言
+SelectLanguageLabel=选择安装时使用的语言。
+
+; *** Common wizard text
+ClickNext=点击“下一步”继续，或点击“取消”退出安装程序。
+BeveledLabel=
+BrowseDialogTitle=浏览文件夹
+BrowseDialogLabel=在下面的列表中选择一个文件夹，然后点击“确定”。
+NewFolderName=新建文件夹
+
+; *** "Welcome" wizard page
+WelcomeLabel1=欢迎使用 [name] 安装向导
+WelcomeLabel2=即将在您的计算机上安装 [name/ver]。%n%n建议您在继续安装前关闭所有其他应用程序。
+
+; *** "Password" wizard page
+WizardPassword=密码
+PasswordLabel1=此安装程序需要密码验证。
+PasswordLabel3=请输入密码，然后点击“下一步”继续。密码区分大小写。
+PasswordEditLabel=密码(&P)：
+IncorrectPassword=您输入的密码不正确，请重新输入。
+
+; *** "License Agreement" wizard page
+WizardLicense=许可协议
+LicenseLabel=请在继续安装前阅读以下重要信息。
+LicenseLabel3=请仔细阅读下列许可协议。在继续安装前您必须同意这些协议条款。
+LicenseAccepted=我同意此协议(&A)
+LicenseNotAccepted=我不同意此协议(&D)
+
+; *** "Information" wizard pages
+WizardInfoBefore=信息
+InfoBeforeLabel=请在继续安装前阅读以下重要信息。
+InfoBeforeClickLabel=准备好继续安装后，点击“下一步”。
+WizardInfoAfter=信息
+InfoAfterLabel=请在继续安装前阅读以下重要信息。
+InfoAfterClickLabel=准备好继续安装后，点击“下一步”。
+
+; *** "User Information" wizard page
+WizardUserInfo=用户信息
+UserInfoDesc=请输入您的信息。
+UserInfoName=用户名(&U)：
+UserInfoOrg=组织(&O)：
+UserInfoSerial=序列号(&S)：
+UserInfoNameRequired=请输入用户名。
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=选择目标位置
+SelectDirDesc=您想将 [name] 安装在哪里？
+SelectDirLabel3=安装程序将安装 [name] 到下面的文件夹中。
+SelectDirBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+DiskSpaceGBLabel=至少需要有 [gb] GB 的可用磁盘空间。
+DiskSpaceMBLabel=至少需要有 [mb] MB 的可用磁盘空间。
+CannotInstallToNetworkDrive=安装程序无法安装到一个网络驱动器。
+CannotInstallToUNCPath=安装程序无法安装到一个 UNC 路径。
+InvalidPath=您必须输入一个带驱动器卷标的完整路径，例如：%n%nC:\APP%n%n或UNC路径：%n%n\\server\share
+InvalidDrive=您选定的驱动器或 UNC 共享不存在或不能访问。请选择其他位置。
+DiskSpaceWarningTitle=磁盘空间不足
+DiskSpaceWarning=安装程序至少需要 %1 KB 的可用空间才能安装，但选定驱动器只有 %2 KB 的可用空间。%n%n您一定要继续吗？
+DirNameTooLong=文件夹名称或路径太长。
+InvalidDirName=文件夹名称无效。
+BadDirName32=文件夹名称不能包含下列任何字符：%n%n%1
+DirExistsTitle=文件夹已存在
+DirExists=文件夹：%n%n%1%n%n已经存在。您一定要安装到这个文件夹中吗？
+DirDoesntExistTitle=文件夹不存在
+DirDoesntExist=文件夹：%n%n%1%n%n不存在。您想要创建此文件夹吗？
+
+; *** "Select Components" wizard page
+WizardSelectComponents=选择组件
+SelectComponentsDesc=您想安装哪些程序组件？
+SelectComponentsLabel2=选中您想安装的组件；取消您不想安装的组件。然后点击“下一步”继续。
+FullInstallation=完全安装
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=简洁安装
+CustomInstallation=自定义安装
+NoUninstallWarningTitle=组件已存在
+NoUninstallWarning=安装程序检测到下列组件已安装在您的计算机中：%n%n%1%n%n取消选中这些组件不会卸载它们。%n%n确定要继续吗？
+ComponentSize1=%1 KB
+ComponentSize2=%1 MB
+ComponentsDiskSpaceGBLabel=当前选择的组件需要至少 [gb] GB 的磁盘空间。
+ComponentsDiskSpaceMBLabel=当前选择的组件需要至少 [mb] MB 的磁盘空间。
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=选择附加任务
+SelectTasksDesc=您想要安装程序执行哪些附加任务？
+SelectTasksLabel2=选择您想要安装程序在安装 [name] 时执行的附加任务，然后点击“下一步”。
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=选择开始菜单文件夹
+SelectStartMenuFolderDesc=安装程序应该在哪里放置程序的快捷方式？
+SelectStartMenuFolderLabel3=安装程序将在下列“开始”菜单文件夹中创建程序的快捷方式。
+SelectStartMenuFolderBrowseLabel=点击“下一步”继续。如果您想选择其他文件夹，点击“浏览”。
+MustEnterGroupName=您必须输入一个文件夹名。
+GroupNameTooLong=文件夹名或路径太长。
+InvalidGroupName=无效的文件夹名字。
+BadGroupName=文件夹名不能包含下列任何字符：%n%n%1
+NoProgramGroupCheck2=不创建开始菜单文件夹(&D)
+
+; *** "Ready to Install" wizard page
+WizardReady=准备安装
+ReadyLabel1=安装程序准备就绪，现在可以开始安装 [name] 到您的计算机。
+ReadyLabel2a=点击“安装”继续此安装程序。如果您想重新考虑或修改任何设置，点击“上一步”。
+ReadyLabel2b=点击“安装”继续此安装程序。
+ReadyMemoUserInfo=用户信息：
+ReadyMemoDir=目标位置：
+ReadyMemoType=安装类型：
+ReadyMemoComponents=已选择组件：
+ReadyMemoGroup=开始菜单文件夹：
+ReadyMemoTasks=附加任务：
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=正在下载文件...
+ButtonStopDownload=停止下载(&S)
+StopDownload=您确定要停止下载吗？
+ErrorDownloadAborted=下载已中止
+ErrorDownloadFailed=下载失败：%1 %2
+ErrorDownloadSizeFailed=获取大小失败：%1 %2
+ErrorProgress=无效的进度：%1 / %2
+ErrorFileSize=文件大小错误：预期 %1，实际 %2
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=正在提取文件...
+ButtonStopExtraction=停止提取(&S)
+StopExtraction=您确定要停止提取吗？
+ErrorExtractionAborted=提取已中止
+ErrorExtractionFailed=提取失败：%1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=密码不正确
+ArchiveIsCorrupted=压缩包已损坏
+ArchiveUnsupportedFormat=不支持的压缩包格式
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=正在准备安装
+PreparingDesc=安装程序正在准备安装 [name] 到您的计算机。
+PreviousInstallNotCompleted=先前的程序安装或卸载未完成，需要您重启计算机。%n%n在重启计算机后，再次运行安装程序以完成 [name] 的安装。
+CannotContinue=安装程序不能继续。请点击“取消”退出。
+ApplicationsFound=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。
+ApplicationsFound2=以下应用程序正在使用将由安装程序更新的文件。建议您允许安装程序自动关闭这些应用程序。安装完成后，安装程序将尝试重新启动这些应用程序。
+CloseApplications=自动关闭应用程序(&A)
+DontCloseApplications=不要关闭应用程序(&D)
+ErrorCloseApplications=安装程序无法自动关闭所有应用程序。建议您在继续之前，关闭所有在使用需要由安装程序更新的文件的应用程序。
+PrepareToInstallNeedsRestart=安装程序必须重启您的计算机。计算机重启后，请再次运行安装程序以完成 [name] 的安装。%n%n要立即重启吗？
+
+; *** "Installing" wizard page
+WizardInstalling=正在安装
+InstallingLabel=安装程序正在安装 [name] 到您的计算机，请稍候。
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=[name] 安装完成
+FinishedLabelNoIcons=安装程序已在您的计算机中安装了 [name]。
+FinishedLabel=安装程序已在您的计算机中安装了 [name]。您可以通过已安装的快捷方式运行此应用程序。
+ClickFinish=点击“完成”退出安装程序。
+FinishedRestartLabel=为完成 [name] 的安装，安装程序必须重新启动您的计算机。要立即重启吗？
+FinishedRestartMessage=为完成 [name] 的安装，安装程序必须重新启动您的计算机。%n%n要立即重启吗？
+ShowReadmeCheck=是，我想查阅自述文件
+YesRadio=是，立即重启计算机(&Y)
+NoRadio=否，稍后重启计算机(&N)
+; used for example as 'Run MyProg.exe'
+RunEntryExec=运行 %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=查阅 %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=安装程序需要下一张磁盘
+SelectDiskLabel2=请插入磁盘 %1 并点击“确定”。%n%n如果这个磁盘中的文件可以在下列文件夹之外的文件夹中找到，请输入正确的路径或点击“浏览”。
+PathLabel=路径(&P)：
+FileNotInDir2=“%2”中找不到文件“%1”。请插入正确的磁盘或选择其他文件夹。
+SelectDirectoryLabel=请指定下一张磁盘的位置。
+
+; *** Installation phase messages
+SetupAborted=安装程序未完成安装。%n%n请修正这个问题并重新运行安装程序。
+AbortRetryIgnoreSelectAction=选择操作
+AbortRetryIgnoreRetry=重试(&T)
+AbortRetryIgnoreIgnore=忽略错误并继续(&I)
+AbortRetryIgnoreCancel=关闭安装程序
+RetryCancelSelectAction=选择操作
+RetryCancelRetry=重试(&T)
+RetryCancelCancel=取消
+
+; *** Installation status messages
+StatusClosingApplications=正在关闭应用程序...
+StatusCreateDirs=正在创建目录...
+StatusExtractFiles=正在提取文件...
+StatusDownloadFiles=正在下载文件...
+StatusCreateIcons=正在创建快捷方式...
+StatusCreateIniEntries=正在创建 INI 条目...
+StatusCreateRegistryEntries=正在创建注册表条目...
+StatusRegisterFiles=正在注册文件...
+StatusSavingUninstall=正在保存卸载信息...
+StatusRunProgram=正在完成安装...
+StatusRestartingApplications=正在重启应用程序...
+StatusRollback=正在撤销更改...
+
+; *** Misc. errors
+ErrorInternal2=内部错误：%1
+ErrorFunctionFailedNoCode=%1 失败
+ErrorFunctionFailed=%1 失败；错误代码 %2
+ErrorFunctionFailedWithMessage=%1 失败；错误代码 %2.%n%3
+ErrorExecutingProgram=无法执行文件：%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=打开注册表项时出错：%n%1\%2
+ErrorRegCreateKey=创建注册表项时出错：%n%1\%2
+ErrorRegWriteKey=写入注册表项时出错：%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=在文件“%1”中创建 INI 条目时出错。
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=跳过此文件(&S)（不推荐）
+FileAbortRetryIgnoreIgnoreNotRecommended=忽略错误并继续(&I)（不推荐）
+SourceIsCorrupted=源文件已损坏
+SourceDoesntExist=源文件“%1”不存在
+SourceVerificationFailed=源文件验证失败：%1
+VerificationSignatureDoesntExist=签名文件“%1”不存在
+VerificationSignatureInvalid=签名文件“%1”无效
+VerificationKeyNotFound=签名文件“%1”使用了未知的密钥
+VerificationFileNameIncorrect=文件名不正确
+VerificationFileTagIncorrect=文件标签不正确
+VerificationFileSizeIncorrect=文件大小不正确
+VerificationFileHashIncorrect=文件校验和不匹配
+ExistingFileReadOnly2=无法替换现有文件，它是只读的。
+ExistingFileReadOnlyRetry=移除只读属性并重试(&R)
+ExistingFileReadOnlyKeepExisting=保留现有文件(&K)
+ErrorReadingExistingDest=尝试读取现有文件时出错：
+FileExistsSelectAction=选择操作
+FileExists2=文件已经存在。
+FileExistsOverwriteExisting=覆盖已存在的文件(&O)
+FileExistsKeepExisting=保留现有的文件(&K)
+FileExistsOverwriteOrKeepAll=为所有冲突文件执行此操作(&D)
+ExistingFileNewerSelectAction=选择操作
+ExistingFileNewer2=现有的文件比安装程序将要安装的文件还要新。
+ExistingFileNewerOverwriteExisting=覆盖已存在的文件(&O)
+ExistingFileNewerKeepExisting=保留现有的文件(&K)（推荐）
+ExistingFileNewerOverwriteOrKeepAll=为所有冲突文件执行此操作(&D)
+ErrorChangingAttr=尝试更改下列现有文件的属性时出错：
+ErrorCreatingTemp=尝试在目标目录创建文件时出错：
+ErrorReadingSource=尝试读取下列源文件时出错：
+ErrorCopying=尝试复制下列文件时出错：
+ErrorDownloading=尝试下载文件时出错：
+ErrorExtracting=尝试提取压缩包时出错：
+ErrorReplacingExistingFile=尝试替换现有文件时出错：
+ErrorRestartReplace=重启并替换失败：
+ErrorRenamingTemp=尝试重命名下列目标目录中的一个文件时出错：
+ErrorRegisterServer=无法注册 DLL/OCX：%1
+ErrorRegSvr32Failed=RegSvr32 失败；退出代码 %1
+ErrorRegisterTypeLib=无法注册类库：%1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2, %3)
+UninstallDisplayNameMark32Bit=32 位
+UninstallDisplayNameMark64Bit=64 位
+UninstallDisplayNameMarkAllUsers=所有用户
+UninstallDisplayNameMarkCurrentUser=当前用户
+
+; *** Post-installation errors
+ErrorOpeningReadme=尝试打开自述文件时出错。
+ErrorRestartingComputer=安装程序无法重启计算机，请手动重启。
+
+; *** Uninstaller messages
+UninstallNotFound=文件“%1”不存在。无法卸载。
+UninstallOpenError=文件“%1”不能被打开。无法卸载。
+UninstallUnsupportedVer=此版本的卸载程序无法识别卸载日志文件“%1”的格式。无法卸载
+UninstallUnknownEntry=卸载日志中遇到一个未知条目（%1）
+ConfirmUninstall=您确认要完全移除 %1 及其所有组件吗？
+UninstallOnlyOnWin64=仅允许在 64 位 Windows 中卸载此程序。
+OnlyAdminCanUninstall=仅使用管理员权限的用户能完成此卸载。
+UninstallStatusLabel=正在从您的计算机中移除 %1，请稍候。
+UninstalledAll=已顺利从您的计算机中移除 %1。
+UninstalledMost=%1 卸载完成。%n%n有部分内容未能被删除，但您可以手动删除它们。
+UninstalledAndNeedsRestart=为完成 %1 的卸载，需要重启您的计算机。%n%n要立即重启吗？
+UninstallDataCorrupted=文件“%1”已损坏。无法卸载
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=删除共享的文件吗？
+ConfirmDeleteSharedFile2=系统表示下列共享的文件已不有其他程序使用。您希望卸载程序删除这些共享的文件吗？%n%n如果删除这些文件，但仍有程序在使用这些文件，则这些程序可能出现异常。如果您不能确定，请选择“否”，在系统中保留这些文件以免引发问题。
+SharedFileNameLabel=文件名：
+SharedFileLocationLabel=位置：
+WizardUninstalling=卸载状态
+StatusUninstalling=正在卸载 %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=正在安装 %1。
+ShutdownBlockReasonUninstallingApp=正在卸载 %1。
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 版本 %2
+AdditionalIcons=附加快捷方式：
+CreateDesktopIcon=创建桌面快捷方式(&D)
+CreateQuickLaunchIcon=创建快速启动栏快捷方式(&Q)
+ProgramOnTheWeb=%1 网站
+UninstallProgram=卸载 %1
+LaunchProgram=运行 %1
+AssocFileExtension=将 %2 文件扩展名与 %1 建立关联(&A)
+AssocingFileExtension=正在将 %2 文件扩展名与 %1 建立关联...
+AutoStartProgramGroupDescription=启动：
+AutoStartProgram=自动启动 %1
+AddonHostProgramNotFound=您选择的文件夹中无法找到 %1。%n%n您要继续吗？

--- a/windows/packaging/exe/isl/Farsi.isl
+++ b/windows/packaging/exe/isl/Farsi.isl
@@ -1,0 +1,412 @@
+; *** Inno Setup version 6.5.0+ Farsi messages ***
+;
+; To download user-contributed translations of this file, go to:
+;   https://jrsoftware.org/files/istrans/
+;
+; Note: When translating this text, do not add periods (.) to the end of
+; messages that didn't have them already, because on those messages Inno
+; Setup adds the periods automatically (appending a period would result in
+; two periods being displayed).
+;
+; Translated by:
+;   Peyman Mohammadi (peymanr34@outlook.com)
+
+[LangOptions]
+; The following three entries are very important. Be sure to read and 
+; understand the '[LangOptions] section' topic in the help file.
+LanguageName=Farsi
+LanguageID=$0429
+LanguageCodePage=1256
+RightToLeft=yes
+; If the language you are translating to requires special font faces or
+; sizes, uncomment any of the following entries and change them accordingly.
+;DialogFontName=
+;DialogFontSize=8
+;WelcomeFontName=Verdana
+;WelcomeFontSize=12
+;TitleFontName=Arial
+;TitleFontSize=29
+;CopyrightFontName=Arial
+;CopyrightFontSize=8
+
+[Messages]
+
+; *** Application titles
+SetupAppTitle=نصب کننده
+SetupWindowTitle=نصب کننده - %1
+UninstallAppTitle=حذف کننده
+UninstallAppFullTitle=%1 حذف کننده
+
+; *** Misc. common
+InformationTitle=اطلاعات
+ConfirmTitle=تایید
+ErrorTitle=خطا
+
+; *** SetupLdr messages
+SetupLdrStartupMessage=این %1 را نصب می‌کند. آیا مایل به ادامه هستید؟
+LdrCannotCreateTemp=خطا در ایجاد یک فایل موقت. برنامه نصب لغو شد
+LdrCannotExecTemp=خطا در اجرای فایل در پوشه موقت. برنامه نصب لغو شد
+HelpTextNote=
+
+; *** Startup error messages
+LastErrorMessage=%1.%n%nخطا %2: %3
+SetupFileMissing=فایل %1 در پوشه نصب وجود ندارد. لطفاً مشکل را برطرف کرده و یا یک کپی جدید از برنامه را دریافت کنید.
+SetupFileCorrupt=فایل های نصب کننده آسیب دیده‌اند. لطفاً یک کپی جدید از برنامه را دریافت کنید.
+SetupFileCorruptOrWrongVer=فایل های نصب کننده آسیب دیده‌اند، یا با این نسخه از نصب کننده سازگار نیستند. لطفاً مشکل را برطرف کرده و یا یک کپی جدید از برنامه را دریافت کنید.
+InvalidParameter=یک پارامتر نامعتبر به خط فرمان ارسال شده است:%n%n%1
+SetupAlreadyRunning=نصب کننده از قبل در حال اجراست.
+WindowsVersionNotSupported=این برنامه از نسخه ویندوزی که بر روی کامپیوتر شما در حال اجراست پشتیبانی نمی‌کند.
+WindowsServicePackRequired=این برنامه نیازمند %1 سرویس پک %2 یا بالاتر است.
+NotOnThisPlatform=این برنامه روی %1 اجرا نمی‌شود.
+OnlyOnThisPlatform=این برنامه باید بر روی %1 اجرا شود.
+OnlyOnTheseArchitectures=این برنامه تنها می‌تواند بر روی نسخه های ویندوزی نصب شود که برای معماری های پردازنده زیر طراحی شده‌اند:%n%n%1
+WinVersionTooLowError=این برنامه نیازمند %1 نسخه %2 یا بالاتر است.
+WinVersionTooHighError=این برنامه نمی‌تواند بر روی %1 نسخه %2 یا بالاتر نصب شود.
+AdminPrivilegesRequired=هنگام نصب این برنامه، شما باید به عنوان یک کاربر مدیر وارد سیستم شده باشید.
+PowerUserPrivilegesRequired=در هنگام نصب این برنامه، شما باید به عنوان کاربر مدیر وارد سیستم شده باشید و یا اینکه عضو گروه Power Users باشید.
+SetupAppRunningError=نصب کننده %1 هم اکنون در حال اجراست.%n%nلطفاً اکنون تمام نمونه های آن را بسته، و سپس برای ادامه بر روی تایید، و یا برای خروج بر روی انصراف کلیک کنید.
+UninstallAppRunningError=حذف کننده تشخیص داده است که %1 هم اکنون در حال اجراست.%n%nلطفاً اکنون تمام نمونه های آن را بسته، و سپس برای ادامه بر روی تایید، و یا برای خروج بر روی انصراف کلیک کنید.
+
+; *** Startup questions
+PrivilegesRequiredOverrideTitle=انتخاب نحوه نصب توسط نصب کننده
+PrivilegesRequiredOverrideInstruction=انتخاب نحوه نصب
+PrivilegesRequiredOverrideText1=%1 را می‌توان برای تمامی کاربران (نیازمند دسترسی مدیر سیستم)، و یا تنها برای شما نصب کرد.‏
+PrivilegesRequiredOverrideText2=%1 را می‌توان تنها برای شما، و یا تمامی کاربران (نیازمند دسترسی مدیر سیستم) است.‏
+PrivilegesRequiredOverrideAllUsers=نصب برای &تمامی کاربران
+PrivilegesRequiredOverrideAllUsersRecommended=نصب برای &تمامی کاربران (پیشنهاد می‌شود)‏
+PrivilegesRequiredOverrideCurrentUser=نصب تنها برای &من
+PrivilegesRequiredOverrideCurrentUserRecommended=نصب تنها برای &من (پیشنهاد می‌شود)‏
+
+; *** Misc. errors
+ErrorCreatingDir=نصب کننده قادر به ایجاد پوشه نبود "%1"
+ErrorTooManyFilesInDir=ایجاد یک فایل در پوشه "%1" بدلیل آنکه حاوی تعداد زیادی فایل است امکان پذیر نیست
+
+; *** Setup common messages
+ExitSetupTitle=خروج از نصب کننده
+ExitSetupMessage=نصب به پایان نرسیده است. در صورتی که اکنون خارج شوید برنامه نصب نخواهد شد.‏%n%nشما می‌توانید نصب کننده را مجدداً در زمانی دیگر برای تکمیل عملیات نصب اجرا کنید.‏%n%nآیا مایل به خروج هستید؟
+AboutSetupMenuItem=&درباره نصب کننده...
+AboutSetupTitle=درباره نصب کننده
+AboutSetupMessage=%1 نسخه %2%n%3%n%n%1 وب سایت:%n%4
+AboutSetupNote=
+TranslatorNote=
+
+; *** Buttons
+ButtonBack=< &قبلی
+ButtonNext=&بعدی >
+ButtonInstall=&نصب
+ButtonOK=تایید
+ButtonCancel=انصراف
+ButtonYes=&بله
+ButtonYesToAll=بله برای &همه
+ButtonNo=&خیر
+ButtonNoToAll=ن&ه برای همه
+ButtonFinish=&پایان
+ButtonBrowse=&مرور...
+ButtonWizardBrowse=م&رور...‏
+ButtonNewFolder=&ایجاد پوشه جدید
+
+; *** "Select Language" dialog messages
+SelectLanguageTitle=انتخاب زبان نصب کننده
+SelectLanguageLabel=زبانی را که می‌خواهید در حین نصب استفاده کنید را انتخاب کنید.
+
+; *** Common wizard text
+ClickNext=برای ادامه بر روی بعدی کلیک کنید، برای خروج از نصب کننده بر روی انصراف کلیک کنید.‏
+BeveledLabel=
+BrowseDialogTitle=مرور برای پوشه
+BrowseDialogLabel=از لیست زیر یک پوشه را انتخاب کرده و سپس بر روی تایید کلیک کنید.‏
+NewFolderName=پوشه جدید
+
+; *** "Welcome" wizard page
+WelcomeLabel1=به ویزارد نصب کننده [name] خوش آمدید
+WelcomeLabel2=این [name/ver] را بر روی کامپیوتر شما نصب می‌کند.‏%n%nپیشنهاد می‌شود قبل از ادامه تمامی اپلیکیشن های دیگر را ببندید.‏ 
+
+; *** "Password" wizard page
+WizardPassword=گذرواژه
+PasswordLabel1=این نصب کننده با گذرواژه محافظت شده است.‏
+PasswordLabel3=لطفاً یک گذرواژه را وارد کنید، سپس بر روی بعدی کلیک کنید. گذرواژه ها حساس به حروف بزرگ و کوچک هستند.‏
+PasswordEditLabel=&گذرواژه:‏
+IncorrectPassword=گذرواژه وارد شده اشتباه است. لطفاً مجدداً تلاش کنید.‏
+
+; *** "License Agreement" wizard page
+WizardLicense=توافقنامه استفاده
+LicenseLabel=لطفاً اطلاعات مهم زیر را قبل از ادامه مطالعه کنید.‏
+LicenseLabel3=لطفاً توافقنامه زیر را مطالعه کنید. شما باید مفاد این توافقنامه را پیش از ادامه نصب برنامه بپذیرید.
+LicenseAccepted=من توافقنامه را &می‌پذیرم
+LicenseNotAccepted=من توافقنامه را &نمی‌پذیرم
+
+; *** "Information" wizard pages
+WizardInfoBefore=اطلاعات
+InfoBeforeLabel=لطفاً اطلاعات مهم زیر را قبل از ادامه مطالعه کنید.‏‏
+InfoBeforeClickLabel=زمانی که آماده برای ادامه نصب هستید، بر روی بعدی کلیک کنید‏.‏
+WizardInfoAfter=اطلاعات
+InfoAfterLabel=لطفاً اطلاعات مهم زیر را قبل از ادامه مطالعه کنید.‏
+InfoAfterClickLabel=زمانی که آماده برای ادامه‌ی نصب هستید، بر روی بعدی کلیک کنید‏.‏
+
+; *** "User Information" wizard page
+WizardUserInfo=اطلاعات کاربر
+UserInfoDesc=لطفاً اطلاعات خود را وارد کنید.‏
+UserInfoName=&نام کاربری:‏
+UserInfoOrg=&سازمان:‏
+UserInfoSerial=&شماره سریال:‏
+UserInfoNameRequired=شما باید یک نام را وارد کنید.
+
+; *** "Select Destination Location" wizard page
+WizardSelectDir=انتخاب محل مقصد
+SelectDirDesc=کجا باید [name] نصب شود؟
+SelectDirLabel3=نصب کننده [name] را در پوشه زیر نصب می‌کند.‏
+SelectDirBrowseLabel=برای ادامه، بر روی بعدی کلیک کنید. اگر مایل به انتخاب پوشه دیگری هستید، بر روی مرور کلیک کنید.‏
+DiskSpaceGBLabel=حداقل [gb] گیگابایت از فضای خالی دیسک مورد نیاز است.‏
+DiskSpaceMBLabel=حداقل [mb] مگابایت از فضای خالی دیسک مورد نیاز است.‏
+CannotInstallToNetworkDrive=نصب کننده نمی‌تواند در یک درایو شبکه نصب را انجام دهد.
+CannotInstallToUNCPath=نصب کننده نمی‌تواند در یک UNC path نصب را انجام دهد.
+InvalidPath=شما باید یک آدرس کامل همراه با اسم درایو وارد کنید؛ به عنوان مثال:%n%nC:\APP%n%nو یا یک مسیر UNC به شکل مقابل:%n%n\\server\share
+InvalidDrive=درایو یا UNC share انتخاب شده وجود ندارد و یا غیر قابل دسترسی است. لطفاً یک مسیر دیگر را انتخاب کنید.
+DiskSpaceWarningTitle=فضای خالی دیسک کافی نیست
+DiskSpaceWarning=نصب کننده به حداقل %1 کیلوبایت فضای خالی برای نصب نیاز دارد، اما درایو انتخاب شده فقط %2 کیلوبایت فضای آزاد دارد.%n%nآیا مایل به ادامه هستید؟
+DirNameTooLong=نام پوشه یا مسیر بسیار طولانی است.‏
+InvalidDirName=نام پوشه صحیح نیست.‏
+BadDirName32=نام پوشه‌ها نمی‌تواند شامل کاراکتر های مقابل باشد:%n%n%1
+DirExistsTitle=پوشه از قبل وجود دارد
+DirExists=این پوشه:%n%n%1%n%nاز قبل وجود دارد. آیا بهرحال مایل به نصب در آن پوشه هستید؟
+DirDoesntExistTitle=پوشه وجود ندارد
+DirDoesntExist=این پوشه:%n%n%1%n%nوجود ندارد. آیا مایل به ساختن آن هستید؟
+
+; *** "Select Components" wizard page
+WizardSelectComponents=انتخاب اجزاء
+SelectComponentsDesc=کدام اجزاء باید نصب شوند؟
+SelectComponentsLabel2=اجزایی که مایل به نصب آن‌ها هستید را انتخاب کنید؛ اجزایی را که نمی‌خواهید نصب کنید را از حالت انتخاب بردارید.‏ زمانی که آماده برای ادامه بودید بر روی بعدی کلیک کنید.
+FullInstallation=نصب کامل
+; if possible don't translate 'Compact' as 'Minimal' (I mean 'Minimal' in your language)
+CompactInstallation=نصب فشرده
+CustomInstallation=نصب سفارشی
+NoUninstallWarningTitle=اجزاء وجود دارند
+NoUninstallWarning=نصب کننده تشخیص داده است که اجزای فوق از قبل بر روی کامپیوتر شما نصب شده است:%n%n%1%n%nعدم انتخاب این اجزاء باعث حذف شدن آن‌ها نمی‌شود.%n%nآیا مایل به ادامه هستید؟
+ComponentSize1=%1 کیلوبایت
+ComponentSize2=%1 مگابایت
+ComponentsDiskSpaceGBLabel=انتخاب فعلی به حداقل [gb] گیگابایت فضای خالی دیسک نیاز دارد.‏
+ComponentsDiskSpaceMBLabel=انتخاب فعلی به حداقل [mb] مگابایت فضای خالی دیسک نیاز دارد.‏
+
+; *** "Select Additional Tasks" wizard page
+WizardSelectTasks=انتخاب وظایف اضافی
+SelectTasksDesc=کدام وظایف اضافی باید انجام شود؟
+SelectTasksLabel2=وظایف اضافی را که تمایل دارید در هنگام نصب [name] انجام داده شود را انتخاب کرده، سپس بر روی بعدی کلیک کنید.‏
+
+; *** "Select Start Menu Folder" wizard page
+WizardSelectProgramGroup=انتخاب پوشه منوی استارت
+SelectStartMenuFolderDesc=نصب کننده در کجا باید میانبر های برنامه را قرار دهد؟ 
+SelectStartMenuFolderLabel3=نصب کننده میانبر های برنامه را در پوشه زیر در منوی استارت ایجاد خواهد کرد.
+SelectStartMenuFolderBrowseLabel=برای ادامه، بر روی بعدی کلیک کنید. در صورتی که تمایل به انتخاب پوشه دیگری دارید، بر روی مرور کلیک کنید.
+MustEnterGroupName=شما باید یک اسم پوشه را وارد کنید.
+GroupNameTooLong=نام پوشه و یا مسیر آن بسیار طولانی است.
+InvalidGroupName=نام پوشه صحیح نیست.
+BadGroupName=نام پوشه نباید شامل هر یک از کاراکتر های زیر باشد:%n%n%1
+NoProgramGroupCheck2=پوشه‌ای در منوی استارت ایجاد &نشود
+
+; *** "Ready to Install" wizard page
+WizardReady=آماده نصب
+ReadyLabel1=نصب کننده آماده شروع نصب [name] بر روی کامپیوتر شماست.‏
+ReadyLabel2a=برای ادامه نصب بر روی نصب کلیک کنید، و یا اگر تمایل به بازبینی یا تغییر تنظیمات دارید بر روی قبلی کلیک کنید.
+ReadyLabel2b=برای ادامه نصب بر روی نصب کلیک کنید.‏
+ReadyMemoUserInfo=اطلاعات کاربر:
+ReadyMemoDir=محل مقصد:
+ReadyMemoType=نوع نصب:
+ReadyMemoComponents=اجزاء انتخاب شده:
+ReadyMemoGroup=پوشه منوی استارت:
+ReadyMemoTasks=وظایف اضافی:
+
+; *** TDownloadWizardPage wizard page and DownloadTemporaryFile
+DownloadingLabel2=در حال دانلود فایل ها...
+ButtonStopDownload=&توقف دانلود
+StopDownload=آیا مطمئن هستید که می‌خواهید دانلود را متوقف کنید؟
+ErrorDownloadAborted=دانلود متوقف شد
+ErrorDownloadFailed=دانلود ناموفق بود: %1 %2
+ErrorDownloadSizeFailed=دریافت حجم ناموفق بود: %1 %2
+ErrorProgress=پیشرفت نامعتبر: %1 از %2
+ErrorFileSize=اندازه فایل نامعتبر: مورد انتظار %، پیدا شده %2
+
+; *** TExtractionWizardPage wizard page and ExtractArchive
+ExtractingLabel=در حال استخراج فایل ها...
+ButtonStopExtraction=&توقف استخراج
+StopExtraction=آیا مطمئن هستید که می‌خواهید استخراج را متوقف کنید؟
+ErrorExtractionAborted=استخراج متوقف شد
+ErrorExtractionFailed=استخراج ناموفق: %1
+
+; *** Archive extraction failure details
+ArchiveIncorrectPassword=گذرواژه اشتباه است
+ArchiveIsCorrupted=فایل فشرده آسیب دیده است
+ArchiveUnsupportedFormat=فرمت فایل فشرده پشتیبانی نمی‌شود
+
+; *** "Preparing to Install" wizard page
+WizardPreparing=در حال آماده سازی برای نصب
+PreparingDesc=نصب کننده در حال آماده سازی برای نصب [name] بر روی کامپیوتر شماست.
+PreviousInstallNotCompleted=نصب/حذف برنامه قبلی تکمیل نشده است. شما باید کامپیوتر خود را برای تکمیل عملیات نصب مجدداً راه‌اندازی کنید.%n%nپس از ری‌استارت کامپیوتر، نصب کننده را مجدداً برای تکمیل عملیات نصب [name] اجرا کنید.
+CannotContinue=نصب کننده قادر به ادامه نیست. لطفاً برای خروج بر روی انصراف کلیک کنید.
+ApplicationsFound=اپلیکیشن های زیر در حال استفاده از فایل هایی هستند که نیازمند بروزرسانی توسط نصب کننده هستند. پیشنهاد می‌شود به نصب کننده اجازه دهید تا این اپلیکیشن ها به صورت خودکار بسته شوند.
+ApplicationsFound2=اپلیکیشن های زیر در حال استفاده از فایل هایی هستند که نیازمند بروزرسانی توسط نصب کننده هستند. پیشنهاد می‌شود به نصب کننده اجازه دهید تا این اپلیکیشن ها به صورت خودکار بسته شوند. پس از پایان نصب، نصب کننده تلاش می‌کند تا این اپلیکیشن ها را مجدداً اجرا کند.
+CloseApplications=بستن &خودکار اپلیکیشن ها
+DontCloseApplications=اپلیکیشن ها بسته &نشوند
+ErrorCloseApplications=نصب کننده قادر به بستن خودکار تمام اپلیکیشن ها نبود. پیشنهاد می‌شود تمام اپلیکیشن هایی که از فایل هایی که نیاز به بروزرسانی توسط نصب کننده را دارند را قبل از ادامه ببندید.
+PrepareToInstallNeedsRestart=نصب کننده باید کامپیوتر را مجدداً راه‌اندازی کند. پس از ری‌استارت کامپیوتر، نصب کننده را برای تکمیل عملیات نصب [name] مجدداً اجرا کنید.%n%nآیا مایل به راه‌اندازی مجدد هستید؟
+
+; *** "Installing" wizard page
+WizardInstalling=در حال نصب
+InstallingLabel=لطفاً تا زمانی که نصب کننده [name] را بر روی کامپیوتر شما نصب می‌کند، صبر کنید.
+
+; *** "Setup Completed" wizard page
+FinishedHeadingLabel=در حال تکمیل ویزارد نصب کننده [name]
+FinishedLabelNoIcons=نصب کننده، عملیات نصب [name] بر روی کامپیوتر شما را به پایان رساند.
+FinishedLabel=نصب کننده، عملیات نصب [name] بر روی کامپیوتر شما را به پایان رساند. اپلیکیشن می‌تواند با انتخاب میانبر های نصب شده اجرا شود.
+ClickFinish=برای خروج از نصب کننده بر روی پایان کلیک کنید.
+FinishedRestartLabel=برای تکمیل عملیات نصب [name]، نصب کننده باید کامپیوتر شما راه مجدداً راه‌اندازی کند. آیا هم اکنون مایل به ری‌استارت هستید؟
+FinishedRestartMessage=برای تکمیل عملیات نصب [name]، نصب کننده باید کامپیوتر شما را مجدداً راه‌اندازی کند.%n%nآیا هم اکنون مایل به ری‌استارت هستید؟
+ShowReadmeCheck=بله، مایل به مشاهده فایل README هستم.
+YesRadio=&بله، اکنون کامپیوتر را دوباره راه‌اندازی کن
+NoRadio=&نه، بعداً خودم کامپیوتر را راه‌اندازی مجدد خواهم کرد
+; used for example as 'Run MyProg.exe'
+RunEntryExec=اجرای %1
+; used for example as 'View Readme.txt'
+RunEntryShellExec=مشاهده‌ی %1
+
+; *** "Setup Needs the Next Disk" stuff
+ChangeDiskTitle=نصب کننده به دیسک بعدی نیاز دارد
+SelectDiskLabel2=لطفاً دیسک %1 را وارد کرده و بر روی تایید کلیک کنید.%n%nدر صورتی که فایل های روی این دیسک در پوشه‌ای غیر از پوشه نمایش داده شده قابل پیدا شدن است، مسیر صحیح را وارد کرده و یا بر روی مرور کلیک کنید.
+PathLabel=&مسیر:
+FileNotInDir2=فایل "%1" در مسیر "%2" پیدا نشد. لطفاً دیسک صحیح را وارد کرده و یا یک پوشه دیگر را انتخاب کنید.
+SelectDirectoryLabel=لطفاً آدرس دیسک بعدی را تعیین کنید.
+
+; *** Installation phase messages
+SetupAborted=نصب کننده تکمیل نشد.%n%nلطفاً مشکل را برطرف کرده و سپس نصب کننده را مجدداً اجرا کنید.
+AbortRetryIgnoreSelectAction=انتخاب عمل
+AbortRetryIgnoreRetry=&تلاش مجدد
+AbortRetryIgnoreIgnore=&صرف نظر از خطا و ادامه
+AbortRetryIgnoreCancel=انصراف از عملیات نصب
+RetryCancelSelectAction=انتخاب عملیات
+RetryCancelRetry=&تلاش مجدد
+RetryCancelCancel=انصراف
+
+; *** Installation status messages
+StatusClosingApplications=درحال بستن اپلیکیشن ها...
+StatusCreateDirs=در حال ایجاد پوشه ها...
+StatusExtractFiles=در حال استخراج فایل ها...
+StatusDownloadFiles=در حال دانلود فایل ها...
+StatusCreateIcons=در حال ایجاد میانبر ها...
+StatusCreateIniEntries=در حال ایجاد ورودی های INI...
+StatusCreateRegistryEntries=در حال ایجاد ورودی های ریجستری...
+StatusRegisterFiles=در حال ریجستر فایل ها...
+StatusSavingUninstall=در حال ذخیره اطلاعات حذف کننده...
+StatusRunProgram=در حال پایان نصب...
+StatusRestartingApplications=در حال راه‌اندازی مجدد اپلیکیشن ها...
+StatusRollback=درحال بازگردانی تغییرات...
+
+; *** Misc. errors
+ErrorInternal2=خطای داخلی: %1
+ErrorFunctionFailedNoCode=%1 ناموفق
+ErrorFunctionFailed=%1 ناموفق؛ کد %2
+ErrorFunctionFailedWithMessage=%1 ناموفق؛ کد %2.%n%3
+ErrorExecutingProgram=خطا در اجرای فایل:%n%1
+
+; *** Registry errors
+ErrorRegOpenKey=خطا در بازکردن کلید ریجستری:%n%1\%2
+ErrorRegCreateKey=خطا در ایجاد کلید ریجستری:%n%1\%2
+ErrorRegWriteKey=خطا در نوشتن در کلید ریجستری:%n%1\%2
+
+; *** INI errors
+ErrorIniEntry=خطا در ایجاد ورودی INI در فایل "%1".
+
+; *** File copying errors
+FileAbortRetryIgnoreSkipNotRecommended=&پرش از این فایل (پیشنهاد نمی‌شود)
+FileAbortRetryIgnoreIgnoreNotRecommended=&نادیده گرفتن خطا و ادامه (پیشنهاد نمی‌شود)
+SourceIsCorrupted=فایل منبع آسیب دیده است
+SourceDoesntExist=فایل منبع "%1" وجود ندارد
+SourceVerificationFailed=اعتبار سنجی فایل منبع ناموفق بود: %1
+VerificationSignatureDoesntExist=فایل امضاء "%1" وجود ندارد
+VerificationSignatureInvalid=فایل امضاء "%1" نامعتبر است
+VerificationKeyNotFound=فایل امضاء "%1" از کلیدی ناشناخته استفاده می‌کند
+VerificationFileNameIncorrect=نام فایل اشتباه است
+VerificationFileTagIncorrect=تگ فایل اشتباه است
+VerificationFileSizeIncorrect=اندازه فایل اشتباه است
+VerificationFileHashIncorrect=هش فایل اشتباه است
+ExistingFileReadOnly2=فایل موجود بدلیل فقط-خواندنی بودن قابل جایگزینی نیست.
+ExistingFileReadOnlyRetry=&حذف خصوصیت فقط-خواندنی و تلاش مجدد
+ExistingFileReadOnlyKeepExisting=&نگه داشتن فایل موجود
+ErrorReadingExistingDest=در هنگام تلاش برای خواندن فایل موجود خطایی رخ داده است:
+FileExistsSelectAction=انتخاب عمل
+FileExists2=فایل از قبل وجود دارد.
+FileExistsOverwriteExisting=&بازنویسی فایل موجود
+FileExistsKeepExisting=&نگه‌داشتن فایل موجود
+FileExistsOverwriteOrKeepAll=&این کار را برای تداخل های بعد انجام بده
+ExistingFileNewerSelectAction=انتخاب عمل
+ExistingFileNewer2=فایل موجود از فایلی که نصب کننده در تلاش برای نصب آن است جدیدتر است.
+ExistingFileNewerOverwriteExisting=&بازنویسی فایل موجود
+ExistingFileNewerKeepExisting=&نگه داشتن فایل موجود (پیشنهاد می‌شود)
+ExistingFileNewerOverwriteOrKeepAll=&این کار را برای تداخل های بعدی انجام بده
+ErrorChangingAttr=در هنگام تلاش برای تغییر خصوصیت فایل موجود خطایی رخ داده است:
+ErrorCreatingTemp=در هنگام تلاش برای ایجاد یک فایل در پوشه مقصد خطایی رخ داده است:
+ErrorReadingSource=در هنگام تلاش برای خواندن فایل مبداء خطایی رخ داده است:
+ErrorCopying=در هنگام تلاش برای کپی فایل خطایی رخ داده است:
+ErrorDownloading=در هنگام تلاش برای دانلود فایل خطایی رخ داده است:
+ErrorExtracting=در هنگام تلاش برای استخراج فایل فشرده خطایی رخ داده است:
+ErrorReplacingExistingFile=در هنگام تلاش برای جایگزینی فایل موجود خطایی رخ داده است:
+ErrorRestartReplace=RestartReplace ناموفق بود:
+ErrorRenamingTemp=در هنگام تلاش برای تغییر نام یک فایل در پوشه مقصد خطایی رخ داده است:
+ErrorRegisterServer=خطا در ریجستر DLL/OCX برای: %1
+ErrorRegSvr32Failed=RegSvr32 با کد خطای ناموفق بود %1
+ErrorRegisterTypeLib=قادر به ریجستر کتابخانه نوع نبود: %1
+
+; *** Uninstall display name markings
+; used for example as 'My Program (32-bit)'
+UninstallDisplayNameMark=%1 (%2)
+; used for example as 'My Program (32-bit, All users)'
+UninstallDisplayNameMarks=%1 (%2، %3)
+UninstallDisplayNameMark32Bit=32-بیت
+UninstallDisplayNameMark64Bit=64-بیت
+UninstallDisplayNameMarkAllUsers=تمامی کاربران
+UninstallDisplayNameMarkCurrentUser=کاربر فعلی
+
+; *** Post-installation errors
+ErrorOpeningReadme=در هنگام تلاش برای بازکردن فایل README خطایی رخ داده است.
+ErrorRestartingComputer=نصب کننده قادر به راه‌اندازی مجدد کامپیوتر نبود. لطفاً به صورت دستی ری‌استارت کنید.
+
+; *** Uninstaller messages
+UninstallNotFound=فایل "%1" وجود ندارد. حذف امکان پذیر نیست.
+UninstallOpenError=امکان باز کردن فایل"%1" وجود ندارد. حذف امکان پذیر نیست
+UninstallUnsupportedVer=فایل لاگ حذف کننده "%1" در فرمتی قرار دارد که توسط این نسخه از حذف کننده قابل شناسایی نیست. حذف امکان پذیر نیست
+UninstallUnknownEntry=با یک ورودی ناشناخته (%1) در فایل لاگ حذف مواجه شده است 
+ConfirmUninstall=آیا از حذف %1 و تمام اجزای آن اطمینان دارید؟
+UninstallOnlyOnWin64=این برنامه نصب شده تنها در ویندوز 64-بیت قابل حذف است.
+OnlyAdminCanUninstall=این برنامه نصب شده، تنها توسط یک کاربر با دسترسی مدیر قابل حذف است.
+UninstallStatusLabel=لطفاً تا زمان حذف %1 از کامپیوتر شما صبر کنید.
+UninstalledAll=%1 با موفقیت از روی کامپیوتر شما حذف شد.
+UninstalledMost=%1 حذف تکمیل شد.%n%nبرخی از اجزاء را نمی‌توان حذف کرد. این موارد به صورت جداگانه قابل حذف هستند.
+UninstalledAndNeedsRestart=برای تکمیل حذف %1 کامپیوتر شما باید مجدداً راه‌اندازی شود.%n%nآیا مایل هستید هم‌اکنون ری‌استارت شود؟
+UninstallDataCorrupted="%1" فایل ناقص است. حذف امکان پذیر نیست
+
+; *** Uninstallation phase messages
+ConfirmDeleteSharedFileTitle=حذف فایل اشتراکی؟
+ConfirmDeleteSharedFile2=سیستم نشان می‌دهد که فایل اشتراکی زیر دیگر توسط هیچ برنامه دیگری در حال استفاده نیست. آیا مایل هستید که حذف کننده این فایل اشتراکی را حذف کند؟?%n%nاگر برنامه‌هایی هنوز از این فایل استفاده می‌کنند، با حذف این فایل این برنامه‌ها ممکن است به درستی کار نکنند. اگر مطمئن نیستید، خیر را انتخاب کنید. نگه‌داشتن فایل بر روی سیستم شما هیچ آسیبی نمی‌رساند.
+SharedFileNameLabel=نام فایل:
+SharedFileLocationLabel=محل فایل:
+WizardUninstalling=وضعیت حذف
+StatusUninstalling=در حال حذف %1...
+
+; *** Shutdown block reasons
+ShutdownBlockReasonInstallingApp=در حال نصب %1.
+ShutdownBlockReasonUninstallingApp=در حال حذف %1.
+
+; The custom messages below aren't used by Setup itself, but if you make
+; use of them in your scripts, you'll want to translate them.
+
+[CustomMessages]
+
+NameAndVersion=%1 نسخه %2
+AdditionalIcons=میانبر های جانبی:
+CreateDesktopIcon=ایجاد &میانبر روی دسکتاپ
+CreateQuickLaunchIcon=ایجاد یک میانبر اجرای &سریع
+ProgramOnTheWeb=%1 بر روی وب
+UninstallProgram=حذف %1
+LaunchProgram=اجرای %1
+AssocFileExtension=&اختصاص دادن %1 با پسوند فایل %2 
+AssocingFileExtension=در حال اختصاص %1 با پسوند فایل %2...
+AutoStartProgramGroupDescription=شروع همراه با ویندوز:
+AutoStartProgram=شروع خودکار %1
+AddonHostProgramNotFound=%1 در پوشه انتخاب شده یافت نشد.%n%nآیا بهرحال مایل به ادامه هستید؟

--- a/windows/packaging/exe/make_config.yaml
+++ b/windows/packaging/exe/make_config.yaml
@@ -13,10 +13,11 @@ install_dir_name: Lantern
 script_template: inno_setup.iss
 #setup_icon_file: ..\windows\runner\resources\app_icon.ico
 # Installer languages (drives LOCALES in inno_setup.iss). en/ru use bundled
-# .isl files; fa uses the vendored isl/Farsi.isl that CI copies into Inno's
-# Languages dir. zh/ja are intentionally omitted — their unofficial .isl files
-# aren't provisioned, so leaving them out keeps them dormant (English) as today.
+# .isl files; zh/fa use the vendored isl/*.isl that CI copies into Inno's
+# Languages dir. ja is omitted — its unofficial .isl isn't provisioned, so it
+# stays dormant (English) as today; add it the same way if needed.
 locales:
   - en
+  - zh
   - ru
   - fa

--- a/windows/packaging/exe/make_config.yaml
+++ b/windows/packaging/exe/make_config.yaml
@@ -12,3 +12,11 @@ create_desktop_icon: true
 install_dir_name: Lantern
 script_template: inno_setup.iss
 #setup_icon_file: ..\windows\runner\resources\app_icon.ico
+# Installer languages (drives LOCALES in inno_setup.iss). en/ru use bundled
+# .isl files; fa uses the vendored isl/Farsi.isl that CI copies into Inno's
+# Languages dir. zh/ja are intentionally omitted — their unofficial .isl files
+# aren't provisioned, so leaving them out keeps them dormant (English) as today.
+locales:
+  - en
+  - ru
+  - fa


### PR DESCRIPTION
## Problem

The dominant Windows support cluster in the last week — concentrated in **China** — is users reporting the v9 installer succeeds but the app won't launch, failing with **`icu.dll 丢失` / "icu.dll missing"**. Several explicitly mention being on **Windows 7** and having previously run 8.3.7 fine.

## Root cause

- v9 is a Flutter app pinned to **Flutter 3.41.0** (`.github/flutter-version.yaml`).
- The bundled `flutter_windows.dll` dynamically links the **system combined `icu.dll`**, which Microsoft ships only on **Windows 10 version 1903 (build 18362)** and later. ([MS Learn — ICU](https://learn.microsoft.com/en-us/windows/win32/intl/international-components-for-unicode--icu-))
- The Inno Setup installer had **no `MinVersion`** and `ArchitecturesAllowed=x64compatible arm64`, so it installed cleanly on Win7/8.1 and pre-1903 Win10 — where the app then dies at launch because the OS has no `icu.dll`.
- The 8.3.7 → v9 transition (old desktop stack → Flutter) silently raised the effective minimum Windows version without any installer guard, which is why this surfaced as a wave of post-"upgrade" breakage.

Bundling an `icu.dll` would **not** rescue Win7 — Flutter 3.41's embedder needs other Win10-only APIs too, so you'd just hit the next missing symbol. The correct fix is a clean install-time version gate.

## Change

`windows/packaging/exe/inno_setup.iss`:

1. **`MinVersion=10.0.18362`** in `[Setup]` — Inno 6.1+ (what CI installs via choco) supports build-number gating. Pre-1903 systems are now refused **at install time** with a clear message instead of installing a binary that crashes.
2. **`[Messages]` override** of `WindowsVersionNotSupported` — states the requirement plainly (no download link, since `lantern.io/download` only serves the current build).

## Localized messages (Chinese, Russian, Farsi)

The installer was English-only in practice: `LOCALES` defaulted to `[en]` (no `locales:` key in `make_config.yaml`), and the pre-existing `zh`/`ja` template branches were **dormant** because nothing in CI provisions their unofficial `.isl` files. China is the highest-volume affected population for this gate, and Russia/Iran are core markets, so the message now displays in those languages:

- `make_config.yaml`: add `locales: [en, zh, ru, fa]`. `ja` is left out (stays dormant/English as today — add it the same way if needed).
- `inno_setup.iss`: `chinesesimplified` (pre-existing branch, now active) + new `russian` + `farsi` `[Languages]` entries and `WindowsVersionNotSupported` overrides. `ShowLanguageDialog=no` so Inno **auto-detects** from the system UI locale (zh-CN → Chinese, ru-RU → Russian, fa-IR → Farsi, else English) rather than showing a new picker dialog.
- **Russian** uses the bundled `compiler:Languages\Russian.isl`.
- **Chinese Simplified** and **Farsi** are *not* bundled Inno translations, so they're vendored under `windows/packaging/exe/isl/` (both Inno 6.5.0+, MIT — [kira-96](https://github.com/kira-96/Inno-Setup-Chinese-Simplified-Translation) for zh, [peymanr34](https://github.com/peymanr34/inno-setup-translations) for fa) and CI copies them into Inno's `Languages\` dir before packaging.
- `build-windows.yml`: pin Inno Setup to **6.5.0** (matches the vendored `.isl` versions exactly and makes the `Languages\` path deterministic) and install both `.isl` files before `fastforge package`.

## Scope decisions

- **Gates out pre-1903 Win10 (1507–1809) too**, not just Win7/8.1 — those builds also lack the combined `icu.dll`. Chose the simple gate over bundling `icu.dll` to rescue them (bundling risks ABI mismatch and shadowing the system DLL on 1903+).
- **Does not** address keeping a maintained legacy build for the affected Win7 population — that's a separate product/support decision.
- **`ja` left dormant.** Japanese would need its (also unofficial) `.isl` vendored + provisioned the same way — easy follow-up, but no signal it's needed.

## Test plan

- [ ] CI `build-windows` compiles the installer with Inno 6.5.0 — validates the `[Messages]`/`MinVersion` syntax **and** that the vendored `ChineseSimplified.isl` + `Farsi.isl` are accepted by the pinned compiler (can't run ISCC on macOS, so CI is the real check). Confirm choco has `innosetup --version=6.5.0`.
- [ ] Manual: run the installer on a Win7 or pre-1903 Win10 VM → expect a clear "requires Windows 10 1903+" dialog, no install.
- [ ] Manual: run on Win10 1903+ / Win11 → installs and launches as before.
- [ ] Manual: on **zh-CN**, **ru-RU**, and **fa-IR** pre-1903 VMs, confirm the gate message renders in Chinese / Russian / Farsi (Farsi RTL). Native-speaker review of the ru/fa strings welcome (zh uses the existing in-repo string).
