### PR TITLE
android: drop armeabi-v7a (32-bit) from the AAB — fix SIGSYS crash loop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,15 +107,14 @@ ANDROID_LIB_PATH := android/app/libs/$(LANTERN_LIB_NAME).aar
 ANDROID_DEBUG_BUILD := $(BUILD_DIR)/app/outputs/flutter-apk/app-debug.apk
 ANDROID_APK_RELEASE_BUILD := $(BUILD_DIR)/app/outputs/flutter-apk/app-release.apk
 ANDROID_AAB_RELEASE_BUILD := $(BUILD_DIR)/app/outputs/bundle/release/app-release.aab
-# Split APK vs AAB ABI targeting (2026-05-15):
+# ABI targeting: arm64-only for both APK and AAB (2026-05-28).
 #
-# The sideload APK (uploaded to the GitHub release / Slack release channel)
-# drops armeabi-v7a so the download is small enough for the Iranian audience
-# on constrained bandwidth. The AAB keeps both ABIs so Play Store users on
-# legacy 32-bit-only Android devices still receive updates — Play delivers
-# per-ABI splits, so this doesn't penalize arm64 Play users.
+# armeabi-v7a (32-bit) was dropped from the AAB too: Go >=1.23.2 trips
+# Android 8-10 seccomp on 32-bit, killing libgojni.so with SIGSYS at startup
+# (golang/go#70495 — ~54% of v9 crashes; those devices were crash-looping
+# anyway). Re-add android-arm here if/when that's fixed upstream.
 ANDROID_APK_TARGET_PLATFORMS := android-arm64
-ANDROID_AAB_TARGET_PLATFORMS := android-arm,android-arm64
+ANDROID_AAB_TARGET_PLATFORMS := android-arm64
 # Back-compat: keep ANDROID_TARGET_PLATFORMS as the fat union for any
 # external caller / debug target that still references it.
 ANDROID_TARGET_PLATFORMS := $(ANDROID_AAB_TARGET_PLATFORMS)
@@ -155,10 +154,9 @@ UNAME_S := $(shell uname -s)
 endif
 GOMOBILECACHE ?= $(HOME)/.cache/gomobile
 # gomobile bind produces the AAR consumed by both the APK and the AAB.
-# Keep both ABIs in the AAR; the APK packaging step strips armeabi-v7a via
-# the lantern.thinAbi Gradle property (see android-release below). The AAB
-# build leaves it in for Play's per-ABI delivery.
-GOMOBILE_ANDROID_TARGET ?= android/arm,android/arm64
+# arm64 only — armeabi-v7a (32-bit) is no longer shipped in any artifact
+# (golang/go#70495 SIGSYS on 32-bit Android 8-10).
+GOMOBILE_ANDROID_TARGET ?= android/arm64
 GOMOBILE_VERSION ?= latest
 GOMOBILE_REPOS = \
 	github.com/sagernet/sing-box/experimental/libbox \
@@ -518,18 +516,17 @@ android-debug: $(ANDROID_DEBUG_BUILD)
 $(ANDROID_DEBUG_BUILD): $(ANDROID_LIB_BUILD)
 	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --debug
 
-# --target-platform restricts Flutter's libapp.so / libflutter.so to arm64;
-# -Plantern.thinAbi=true tells android/app/build.gradle to drop armeabi-v7a
-# from abiFilters + add it to packagingOptions.jniLibs.excludes so the
-# arm32 libgojni.so in the AAR doesn't get packed. Sideload-APK target only.
+# --target-platform restricts Flutter's libapp.so / libflutter.so to arm64.
+# build.gradle's abiFilters is arm64-only for all artifacts now, so no
+# per-target ABI property is needed.
 .PHONY: android-apk-release
 android-apk-release:
-	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES) -Plantern.thinAbi=true
+	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES)
 	cp $(ANDROID_APK_RELEASE_BUILD) $(ANDROID_RELEASE_APK)
 
-# AAB keeps both ABIs so Play Store delivers per-ABI splits (arm64 users
-# get the small split; legacy arm32-only users still get updates). The
-# Play path doesn't need the size cut — only the sideload APK does.
+# AAB is arm64-only too (armeabi-v7a dropped — golang/go#70495 SIGSYS on
+# 32-bit). 32-bit-only devices no longer get Play updates; they were
+# crash-looping on Android 8-10 regardless.
 .PHONY: android-aab-release
 android-aab-release:
 	flutter build appbundle --target-platform $(ANDROID_AAB_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES)

--- a/Makefile
+++ b/Makefile
@@ -115,8 +115,8 @@ ANDROID_AAB_RELEASE_BUILD := $(BUILD_DIR)/app/outputs/bundle/release/app-release
 # anyway). Re-add android-arm here if/when that's fixed upstream.
 ANDROID_APK_TARGET_PLATFORMS := android-arm64
 ANDROID_AAB_TARGET_PLATFORMS := android-arm64
-# Back-compat: keep ANDROID_TARGET_PLATFORMS as the fat union for any
-# external caller / debug target that still references it.
+# Back-compat alias for any external caller / debug target that references
+# ANDROID_TARGET_PLATFORMS. Now arm64-only, same as the APK/AAB targets.
 ANDROID_TARGET_PLATFORMS := $(ANDROID_AAB_TARGET_PLATFORMS)
 ANDROID_RELEASE_APK := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE)).apk
 ANDROID_RELEASE_AAB := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE)).aab

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -51,7 +51,7 @@ android {
     // (Makefile --target-platform), or installs crash with "Could not find
     // 'libflutter.so'".
 
-    // Use legacy packaging to helps reduce apk size
+    // Use legacy packaging to help reduce apk size
     packagingOptions {
         exclude "DebugProbesKt.bin"
         jniLibs {

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,16 +44,12 @@ android {
         jvmTarget = "17"
     }
 
-    // The sideload APK target (Makefile android-apk-release) passes
-    // -Plantern.thinAbi=true so this build emits only arm64. The AAB
-    // target leaves the property unset so Play Store users on legacy
-    // 32-bit ARM devices still receive updates via per-ABI splits.
-    //
-    // Constraint: the ABIs listed in abiFilters must match the ABIs
-    // Flutter actually built (Makefile's --target-platform flag).
-    // Listing an ABI here that Flutter didn't build crashes installs on
-    // that architecture with "Could not find 'libflutter.so'".
-    def thinAbi = project.findProperty("lantern.thinAbi") == "true"
+    // arm64-only for every artifact (APK + AAB). armeabi-v7a (32-bit) was
+    // dropped: Go >=1.23.2 trips Android 8-10 seccomp on 32-bit, killing
+    // libgojni.so with SIGSYS at startup (golang/go#70495 — ~54% of v9
+    // crashes). Constraint: abiFilters must match the ABIs Flutter built
+    // (Makefile --target-platform), or installs crash with "Could not find
+    // 'libflutter.so'".
 
     // Use legacy packaging to helps reduce apk size
     packagingOptions {
@@ -67,18 +63,15 @@ android {
             // libbarhopper_v3.so + 1.2 MB libc++_shared.so + 0.7 MB
             // libnative-imagetranscoder.so under lib/x86_64/ in
             // v9.1.9-beta. Explicit excludes here strip them at packaging
-            // time. When lantern.thinAbi is set the sideload APK also
-            // strips armeabi-v7a; the AAB build leaves it in.
+            // time. armeabi-v7a is stripped too — we ship arm64 only.
             def abiExcludes = [
                 "lib/x86/**",
                 "lib/x86_64/**",
                 "lib/armeabi/**",
+                "lib/armeabi-v7a/**",
                 "lib/mips/**",
                 "lib/mips64/**",
             ]
-            if (thinAbi) {
-                abiExcludes += "lib/armeabi-v7a/**"
-            }
             excludes += abiExcludes
         }
     }
@@ -91,11 +84,9 @@ android {
         versionName = flutter.versionName
 
         ndk {
-            // ABI set must match what Flutter built (Makefile's
-            // --target-platform). Sideload APK: arm64 only
-            // (-Plantern.thinAbi=true). AAB: arm64 + armeabi-v7a so Play
-            // Store users on legacy 32-bit hardware still get updates.
-            abiFilters = thinAbi ? ["arm64-v8a"] : ["arm64-v8a", "armeabi-v7a"]
+            // arm64 only (APK + AAB) — armeabi-v7a dropped, see the comment
+            // above defaultConfig (golang/go#70495 SIGSYS on 32-bit).
+            abiFilters = ["arm64-v8a"]
             debugSymbolLevel 'FULL'
         }
 


### PR DESCRIPTION
## Why

The **#1 crash on the v9 build** (`9.1.11`) is a **SIGSYS / SYS_SECCOMP kill in `libgojni.so` at startup** — **~54% of all v9 crashes**, 86 users/wk, API 26–29, **32-bit `lib/arm` only**. Root cause is an open upstream Go regression, [golang/go#70495](https://github.com/golang/go/issues/70495): Go ≥1.23.2's runtime issues a syscall that Android 8–10's seccomp-bpf denies on 32-bit ABIs. Our `libgojni.so` is built with `go 1.26.2` and the codebase requires it, so a toolchain downgrade (the only known upstream workaround) isn't viable.

Full analysis: getlantern/engineering#3562.

## What

Stop shipping 32-bit. The sideload **APK was already arm64-only**; this drops `armeabi-v7a` from the **AAB** too, and removes the now-redundant `lantern.thinAbi` split mechanism (arm64-only is now unconditional).

- **`android/app/build.gradle`** — `abiFilters = ["arm64-v8a"]` (was thin-conditional); strip `lib/armeabi-v7a/**` in `packagingOptions.jniLibs.excludes`; remove the `thinAbi` property + branches.
- **`Makefile`** — `ANDROID_AAB_TARGET_PLATFORMS` → `android-arm64` (was `android-arm,android-arm64`); `GOMOBILE_ANDROID_TARGET` → `android/arm64`; drop the dead `-Plantern.thinAbi=true` from `android-apk-release`.

End-to-end consistent: gomobile builds `android/arm64` → Flutter `--target-platform android-arm64` → `abiFilters ["arm64-v8a"]`.

## Impact / trade-off

- **Eliminates** the SIGSYS crash loop (it's 32-bit-only). arm64 Android 8–10 is unaffected (different seccomp allowlist).
- **32-bit-only devices stop receiving Play updates.** On API 26–29 they were crash-looping ~54% of the time anyway; on API 30+ they lose a working app. **Before merging, confirm the `armeabi-v7a` install share** in Play Console (Statistics → device → ABI) — if there's a meaningful API-30+ 32-bit population, weigh that against the crash relief.
- Re-add `android-arm` everywhere if golang/go#70495 is fixed upstream (noted in the Makefile comment).

## Test plan
- [ ] CI `build-android` produces an AAB with **only** `lib/arm64-v8a/` (verify: `unzip -l *.aab | grep lib/`).
- [ ] Pull `armeabi-v7a` install share from Play Console before rollout (see trade-off).
- [ ] Watch the v9 crash rate / issue `726f64d4` after the release reaches API 26–29 devices.