### PR TITLE
android: move VPN tunnel teardown off the main thread in onDestroy

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -70,6 +70,14 @@ class LanternVpnService :
         private val connectInFlight = AtomicBoolean(false)
 
         lateinit var instance: LanternVpnService
+
+        // Process-lifetime scope for teardown that must run off the main thread
+        // but outlive the service instance. Mobile.stopVPN() is a blocking JNI
+        // call; running it on the main thread in onDestroy ANRs during service
+        // teardown (getlantern/engineering#3563). serviceScope is cancelled in
+        // onDestroy's finally, so teardown can't live there — this scope is
+        // never cancelled.
+        private val teardownScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
     }
 
     private val notificationHelper = NotificationHelper()
@@ -162,42 +170,38 @@ class LanternVpnService :
     override fun onDestroy() {
         try {
             AppLogger.d(TAG, "destroying LanternVpnService")
+            // Lightweight, main-thread-safe cleanup. These don't depend on the
+            // Go tunnel being torn down first, so do them synchronously here.
             closeTunInterface()
-            // Clean up synchronously — cannot use serviceScope here because
-            // it is cancelled in the finally block below.
-            //
-            // Call Mobile.stopVPN() as long as radiance is up. The previous
-            // isVPNConnected() guard (status == Connected) was wrong — if the
-            // tunnel is in any non-Connected state (Restarting, Connecting,
-            // Disconnecting, Error), c.tunnel is still non-nil on the Go side
-            // and needs to be closed so the next process lifetime starts clean.
-            // Mobile.stopVPN() itself is a no-op when c.tunnel is nil.
-            val radianceConnected = Mobile.isRadianceConnected()
-            AppLogger.d(TAG, "onDestroy — radianceConnected=$radianceConnected")
-            if (!radianceConnected) {
-                AppLogger.d(TAG, "Skipping stopVPN — Radiance IPC not running")
-            } else {
-                runCatching { Mobile.stopVPN() }
-                    .onSuccess { AppLogger.d(TAG, "stopVPN completed during destroy") }
-                    .onFailure { e ->
-                        AppLogger.e(TAG, "Mobile.stopVPN() failed during destroy", e)
-                    }
-            }
-            runCatching {
-                runBlocking(Dispatchers.IO) { DefaultNetworkMonitor.stop() }
-            }.onFailure { e ->
-                AppLogger.e(
-                    TAG,
-                    "DefaultNetworkMonitor.stop() failed during destroy",
-                    e
-                )
-            }
             notificationHelper.stopVPNConnectedNotification(this)
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 QuickTileService.triggerUpdateTileState(this, false)
             }
             serviceCleanUp()
 
+            // Tear down the Go tunnel OFF the main thread. Mobile.stopVPN() is a
+            // blocking JNI call (tunnel/connection close) — running it on the
+            // main thread here ANRs during service teardown and contends with any
+            // in-flight performStopVPN (getlantern/engineering#3563). teardownScope
+            // is process-lifetime, so this survives the serviceScope.cancel()
+            // below and still completes, keeping the next process launch clean.
+            // Mobile.stopVPN() is a no-op when c.tunnel is already nil, so a
+            // double-call from the stop path is harmless. Closed unconditionally
+            // when radiance is up: any non-Connected state (Restarting,
+            // Connecting, Disconnecting, Error) still has a non-nil c.tunnel.
+            teardownScope.launch {
+                runCatching {
+                    if (Mobile.isRadianceConnected()) {
+                        Mobile.stopVPN()
+                        AppLogger.d(TAG, "stopVPN completed during destroy")
+                    } else {
+                        AppLogger.d(TAG, "Skipping stopVPN — Radiance IPC not running")
+                    }
+                }.onFailure { e -> AppLogger.e(TAG, "Mobile.stopVPN() failed during destroy", e) }
+
+                runCatching { DefaultNetworkMonitor.stop() }
+                    .onFailure { e -> AppLogger.e(TAG, "DefaultNetworkMonitor.stop() failed during destroy", e) }
+            }
         } finally {
             serviceScope.cancel()
             super.onDestroy()

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -170,16 +170,11 @@ class LanternVpnService :
     override fun onDestroy() {
         try {
             AppLogger.d(TAG, "destroying LanternVpnService")
-            // Lightweight, main-thread-safe cleanup. These don't depend on the
-            // Go tunnel being torn down first, so do them synchronously here.
+            // Only the TUN fd close stays synchronous on the main thread — it's
+            // cheap and the OS should release the interface promptly.
             closeTunInterface()
-            notificationHelper.stopVPNConnectedNotification(this)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                QuickTileService.triggerUpdateTileState(this, false)
-            }
-            serviceCleanUp()
 
-            // Tear down the Go tunnel OFF the main thread. Mobile.stopVPN() is a
+            // Everything else runs OFF the main thread. Mobile.stopVPN() is a
             // blocking JNI call (tunnel/connection close) — running it on the
             // main thread here ANRs during service teardown and contends with any
             // in-flight performStopVPN (getlantern/engineering#3563). teardownScope
@@ -189,6 +184,10 @@ class LanternVpnService :
             // double-call from the stop path is harmless. Closed unconditionally
             // when radiance is up: any non-Connected state (Restarting,
             // Connecting, Disconnecting, Error) still has a non-nil c.tunnel.
+            // The notification/tile/receiver cleanup runs AFTER stopVPN so the UI
+            // reflects the stopped state and the status receiver stays registered
+            // through teardown. serviceCleanUp() unregisters via the application
+            // context (not the service), so running it after super.onDestroy() is safe.
             teardownScope.launch {
                 runCatching {
                     if (Mobile.isRadianceConnected()) {
@@ -201,6 +200,12 @@ class LanternVpnService :
 
                 runCatching { DefaultNetworkMonitor.stop() }
                     .onFailure { e -> AppLogger.e(TAG, "DefaultNetworkMonitor.stop() failed during destroy", e) }
+
+                notificationHelper.stopVPNConnectedNotification(this@LanternVpnService)
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    QuickTileService.triggerUpdateTileState(this@LanternVpnService, false)
+                }
+                serviceCleanUp()
             }
         } finally {
             serviceScope.cancel()


### PR DESCRIPTION
## Why

`LanternVpnService.onDestroy()` is the top `onDestroy` ANR family on v9 (`9.1.11`) — getlantern/engineering#3563, ~24 users/wk across three Play Console buckets. It called **`Mobile.stopVPN()`** (a blocking gomobile JNI tunnel teardown) and **`runBlocking { DefaultNetworkMonitor.stop() }`** directly on the **main thread** during service teardown.

Main-thread stack:
```
"main" tid=1 — libgojni.so
  at Mobile.stopVPN (Mobile.java)
  at LanternVpnService.onDestroy (LanternVpnService.kt:180)
  at android.app.ActivityThread.handleStopService
```
Crash dumps also show a `DefaultDispatcher-worker` **simultaneously** in `Mobile.stopVPN()` via the async `performStopVPN → stopVPNTunnel` path — so the main-thread call was redundant *and* contended with the in-flight teardown on the Go-side lock.

The old code ran synchronously on purpose (comment: *"cannot use serviceScope here because it is cancelled in the finally block"*), trading a scope-cancellation race for a main-thread ANR.

## Fix

Introduce a **process-lifetime `teardownScope`** (`Dispatchers.IO + SupervisorJob()`, never cancelled) and run the teardown there. `onDestroy` no longer blocks the main thread; the teardown still completes after the service instance is gone, keeping the next launch clean.

Only `closeTunInterface()` stays synchronous on the main thread (cheap fd close). Per review, the notification cancel, tile update, and `serviceCleanUp()` run **inside** the coroutine **after** `Mobile.stopVPN()` — so the UI reflects the actually-stopped state and the VPN status receiver stays registered through teardown. `serviceCleanUp()` unregisters via the **application** context (`LanternApp.application`), not the service, so running it off-thread after `super.onDestroy()` is safe.

`Mobile.stopVPN()` is a no-op when `c.tunnel` is already nil, so the residual double-call with `performStopVPN` is harmless once it's off the main thread. (Coroutine cancellation can't interrupt an in-flight JNI call anyway, so the original `serviceScope`-cancel concern was about losing the continuation — a separate never-cancelled scope sidesteps it.)

## Scope / follow-ups

- This is the **minimal** ANR fix. Fully de-duplicating the teardown (skip in `onDestroy` when `performStopVPN` already ran) is left as a follow-up — it's entangled with `restartService`, which reuses `stopVPNTunnel`, so a naive "stopped" flag would break restart. Off-the-main-thread + idempotent `stopVPN` makes the double-call benign in the meantime.

## Test plan
- [ ] CI `build-android` compiles (couldn't run the gomobile+gradle build locally).
- [ ] Manual on a real device (API 31+): connect VPN, force-stop / swipe-kill / toggle off repeatedly — confirm no onDestroy ANR and the tunnel tears down cleanly; verify the next launch connects without a wedged `Restarting` state.
- [ ] Watch issue buckets `18a5ae63` / `864a4d41` / `5a6e32aa` after release.

closes getlantern/engineering#3563
