### PR TITLE
android: don't drop networks when NetworkInterface enum is empty (API 30)

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
@@ -2,9 +2,11 @@ package org.getlantern.lantern.service
 
 import android.annotation.SuppressLint
 import android.content.pm.PackageManager
+import android.net.LinkAddress
 import android.net.NetworkCapabilities
 import android.os.Build
 import android.os.Process
+import android.system.Os
 import android.system.OsConstants
 import androidx.annotation.RequiresApi
 import lantern.io.libbox.InterfaceUpdateListener
@@ -99,8 +101,13 @@ interface PlatformInterfaceWrapper : PlatformInterface {
             val networkCapabilities =
                 LanternApp.connectivity.getNetworkCapabilities(network) ?: continue
             val interfaceName = linkProperties.interfaceName ?: continue
-            val networkInterface =
-                networkInterfaces.find { it.name == interfaceName } ?: continue
+            // On some devices (notably Android 11 / API 30 and certain OEM ROMs)
+            // NetworkInterface.getNetworkInterfaces() returns empty, so the name
+            // match misses and we'd drop every network — leaving sing-box with
+            // "no available network interface" (FD #176099). When that happens,
+            // build the entry from ConnectivityManager + Os.if_nametoindex, which
+            // don't depend on the restricted interface-enumeration syscall.
+            val networkInterface = networkInterfaces.find { it.name == interfaceName }
             // Wrap all property access in a single try-catch so that if the
             // interface disappears mid-enumeration (e.g. tun0 during VPN restart)
             // we skip it instead of reporting a broken interface to sing-box.
@@ -115,22 +122,31 @@ interface PlatformInterfaceWrapper : PlatformInterface {
                     networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET) -> Libbox.InterfaceTypeEthernet
                     else -> Libbox.InterfaceTypeOther
                 }
-                boxInterface.index = networkInterface.index
-                boxInterface.mtu = networkInterface.mtu
-                boxInterface.addresses =
-                    StringArray(networkInterface.interfaceAddresses.mapTo(mutableListOf()) { it.toPrefix() }
-                        .iterator())
+                boxInterface.index = networkInterface?.index ?: Os.if_nametoindex(interfaceName)
+                boxInterface.mtu = networkInterface?.mtu
+                    ?: linkProperties.mtu.takeIf { it > 0 } ?: 1500
+                boxInterface.addresses = StringArray(
+                    (networkInterface?.interfaceAddresses?.map { it.toPrefix() }
+                        ?: linkProperties.linkAddresses.map { it.toPrefix() }).iterator()
+                )
                 var dumpFlags = 0
                 if (networkCapabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
                     dumpFlags = OsConstants.IFF_UP or OsConstants.IFF_RUNNING
                 }
-                if (networkInterface.isLoopback) {
-                    dumpFlags = dumpFlags or OsConstants.IFF_LOOPBACK
-                }
-                if (networkInterface.isPointToPoint) {
-                    dumpFlags = dumpFlags or OsConstants.IFF_POINTOPOINT
-                }
-                if (networkInterface.supportsMulticast()) {
+                if (networkInterface != null) {
+                    if (networkInterface.isLoopback) {
+                        dumpFlags = dumpFlags or OsConstants.IFF_LOOPBACK
+                    }
+                    if (networkInterface.isPointToPoint) {
+                        dumpFlags = dumpFlags or OsConstants.IFF_POINTOPOINT
+                    }
+                    if (networkInterface.supportsMulticast()) {
+                        dumpFlags = dumpFlags or OsConstants.IFF_MULTICAST
+                    }
+                } else {
+                    // No java.net.NetworkInterface to query loopback/p2p/multicast;
+                    // ConnectivityManager only reports real underlying networks (never
+                    // loopback), so assume a normal multicast-capable physical link.
                     dumpFlags = dumpFlags or OsConstants.IFF_MULTICAST
                 }
                 boxInterface.flags = dumpFlags
@@ -206,6 +222,15 @@ interface PlatformInterfaceWrapper : PlatformInterface {
             "${Inet6Address.getByAddress(address.address).hostAddress}/${networkPrefixLength}"
         } else {
             "${address.hostAddress}/${networkPrefixLength}"
+        }
+    }
+
+    // ConnectivityManager fallback when java.net.NetworkInterface is unavailable.
+    private fun LinkAddress.toPrefix(): String {
+        return if (address is Inet6Address) {
+            "${Inet6Address.getByAddress(address.address).hostAddress}/${prefixLength}"
+        } else {
+            "${address.hostAddress}/${prefixLength}"
         }
     }
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
@@ -94,7 +94,16 @@ interface PlatformInterfaceWrapper : PlatformInterface {
 
     override fun getInterfaces(): NetworkInterfaceIterator {
         val networks = LanternApp.connectivity.allNetworks
-        val networkInterfaces = NetworkInterface.getNetworkInterfaces().toList()
+        // Best-effort: getNetworkInterfaces() returns null when no interfaces are
+        // found and can throw (SocketException/SecurityException) on restricted
+        // devices. Fall back to an empty list so the ConnectivityManager +
+        // Os.if_nametoindex path below still runs instead of crashing here.
+        val networkInterfaces = try {
+            NetworkInterface.getNetworkInterfaces()?.toList() ?: emptyList()
+        } catch (e: Exception) {
+            AppLogger.e("PlatformInterface", "getNetworkInterfaces() failed; using ConnectivityManager only", e)
+            emptyList()
+        }
         val interfaces = mutableListOf<lantern.io.libbox.NetworkInterface>()
         for (network in networks) {
             val linkProperties = LanternApp.connectivity.getLinkProperties(network) ?: continue


### PR DESCRIPTION
## Why

On the v9 stack, `PlatformInterfaceWrapper.getInterfaces()` is what feeds sing-box its list of usable underlying networks. It enumerates `ConnectivityManager.allNetworks`, then for each one **requires a name match** against `java.net.NetworkInterface.getNetworkInterfaces()` — dropping (`?: continue`) any network with no match:

```kotlin
val networkInterfaces = NetworkInterface.getNetworkInterfaces().toList()   // restricted on some devices
...
val networkInterface = networkInterfaces.find { it.name == interfaceName } ?: continue   // drops the network
```

On **Android 11 / API 30** (and some OEM ROMs) that enumeration returns **empty**, so *every* network is dropped and `getInterfaces()` returns an empty list. That empty list flows straight through to sing-box:

```mermaid
sequenceDiagram
    autonumber
    participant CM as ConnectivityManager
    participant PIW as PlatformInterfaceWrapper<br/>getInterfaces() (Kotlin)
    participant LB as libbox<br/>service.go
    participant NM as route/network.go<br/>UpdateInterfaces()
    participant DP as default_parallel_interface.go

    PIW->>CM: allNetworks (has wlan0/rmnet) ✅
    Note over PIW: NetworkInterface.getNetworkInterfaces()<br/>returns [] on API 30 ⚠️
    rect rgba(255, 200, 200, 0.3)
        Note over PIW: name match misses for every network →<br/>?: continue drops them all 🐛
    end
    PIW-->>LB: GetInterfaces() = []
    LB-->>NM: Interfaces() = []
    NM-->>DP: selectInterfaces() = 0
    DP-->>DP: E.New("no available network interface")
    Note over DP: every direct/bypass outbound dial fails
```

The `direct` outbound is the egress for domain fronting, config fetch, and issue-report upload — so on affected devices those all fail even though the device has working connectivity (TUN traffic still flows). This is the dominant root cause in **FD #176099** (Lenovo K12 Pro, Android 11 — **1,081** `no available network interface` errors in a 25s capture).

### This is *not* a universal regression

Evidence from three Russia tickets on the same `9.1.x` Android build:

| Ticket | Device | Android | API | `no available network interface` |
|---|---|---|---|---|
| #176099 | Lenovo K12 Pro | 11 | **30** | **1,081** |
| #176066 | (generic) | 13 | 33 | 0 |
| #175607 | realme RMX3636 | 15 | 35 | 0 |

API 33/35 enumerate interfaces fine, which is why this hasn't surfaced broadly — most users and most testing are on Android 12–15. The Android-11 cohort (and likely specific OEM ROMs) is what gets hit.

## Fix

Make the `java.net.NetworkInterface` lookup **best-effort** instead of mandatory. When it succeeds (API 33/35 — the common case) the path is **unchanged**. When it misses, build the interface entry from sources that don't depend on the restricted enumeration syscall:

- **index** → `Os.if_nametoindex(interfaceName)` — resolves a single name via `SIOCGIFINDEX` ioctl, not the `getifaddrs`/NETLINK dump that Android 11 restricts.
- **addresses** → `linkProperties.linkAddresses` (ConnectivityManager).
- **mtu** → `linkProperties.mtu`, falling back to 1500.
- **flags** → `IFF_UP|IFF_RUNNING` from `NET_CAPABILITY_INTERNET` (already computed without the Java object) + `IFF_MULTICAST` (ConnectivityManager only reports real underlying networks, never loopback).

The change is purely additive — it can only *recover* networks that were previously dropped; it never alters a network the Java enumeration already resolved.

## Verification

- [ ] CI `build-android` compiles. (Local `make android-debug` run alongside this PR.)
- [ ] **No-regression check** — install on an API 33/35 device or emulator, connect, confirm interfaces still enumerate and fronting/config-fetch work (the unchanged path).
- [ ] **Repro/fix check (best-effort)** — on an Android 11 / API 30 emulator, confirm `getInterfaces()` returns non-empty. ⚠️ A stock AOSP API-30 image may *not* reproduce the empty-enum case (it appears tied to the Lenovo ROM), so this mainly confirms no regression on API 30. True confirmation needs the affected device class or forcing the Java enum empty.

The fix is safe to ship regardless of whether the emulator reproduces, because it strictly widens the set of interfaces returned.

Refs FD [#176099](https://lantern.freshdesk.com/a/tickets/176099) (primary), [#175607](https://lantern.freshdesk.com/a/tickets/175607).

---
**Updated after review** (myleshorton/Copilot): made the top-level `NetworkInterface.getNetworkInterfaces()` call itself best-effort (try/catch → `emptyList()`), since it can return null or throw `SocketException`/`SecurityException` on restricted devices — otherwise it could crash before the per-network fallback runs. Also merged `main` to pick up the `result.success` build fix (#8827) + the new `compile-check` gate (#8828). Locally re-verified the debug APK builds.
