### PR TITLE
fix(android): unbreak build from #8754 + gate Kotlin compile on PRs

### DIFF
--- a/.github/workflows/android-compile-check.yml
+++ b/.github/workflows/android-compile-check.yml
@@ -1,0 +1,132 @@
+name: Android Compile Check
+
+# Gates PRs that touch Kotlin/Android (or the Go/deps that produce the gomobile
+# AAR the Kotlin compiles against) by building the debug APK — which compiles
+# all app Kotlin. The full signed release build (build-android.yml) is
+# workflow_call-only and never ran on PRs, so a Kotlin compile break (e.g. the
+# bare success() call in #8754) could merge to main undetected. This catches it.
+#
+# Debug build only: no keystore/APP_ENV secrets, no AAB, no artifact upload.
+
+on:
+  pull_request:
+    paths:
+      - "android/**"
+      - "lantern-core/**"
+      - "go.mod"
+      - "go.sum"
+      - "Makefile"
+      - "pubspec.yaml"
+      - "pubspec.lock"
+      - ".github/flutter-version.yaml"
+      - ".github/workflows/android-compile-check.yml"
+
+concurrency:
+  group: android-compile-check-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  compile-check:
+    permissions:
+      contents: "read"
+    runs-on: macos-26
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: "go.mod"
+          cache: true
+
+      - name: Cache Flutter dependencies
+        uses: actions/cache@v4
+        timeout-minutes: 5
+        continue-on-error: true
+        with:
+          path: |
+            ~/.pub-cache
+          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-flutter-
+
+      - name: Cache Gradle dependencies
+        uses: actions/cache@v4
+        timeout-minutes: 10
+        continue-on-error: true
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+            ~/.android/build-cache
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Set up Java 17 (Gradle cache)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: "gradle"
+
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+
+      - name: Install Android SDK components
+        shell: bash
+        run: |
+          set -euxo pipefail
+          sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" \
+            "platform-tools" \
+            "platforms;android-35" \
+            "build-tools;35.0.0" \
+            "ndk;27.0.12077973" \
+            "cmake;3.22.1"
+          yes | sdkmanager --sdk_root="${ANDROID_SDK_ROOT}" --licenses >/dev/null || true
+
+          echo "ANDROID_HOME=${ANDROID_SDK_ROOT}" >> "$GITHUB_ENV"
+          for var in ANDROID_NDK_HOME ANDROID_NDK_ROOT NDK_HOME; do
+            echo "${var}=${ANDROID_SDK_ROOT}/ndk/27.0.12077973" >> "$GITHUB_ENV"
+          done
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2.22.0
+        with:
+          channel: stable
+          flutter-version-file: .github/flutter-version.yaml
+          cache: true
+
+      - name: Set gomobile cache dir
+        shell: bash
+        run: |
+          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
+          mkdir -p "$HOME/.cache/gomobile"
+
+      - name: Cache gomobile
+        uses: actions/cache@v4
+        timeout-minutes: 10
+        continue-on-error: true
+        with:
+          path: ~/.cache/gomobile
+          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-gomobile-
+
+      - name: Install dependencies (gomobile)
+        run: make install-android-deps
+        env:
+          GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
+
+      - name: Flutter pub get + codegen
+        run: |
+          make pubget
+          make gen
+
+      # Builds the gomobile AAR, then compiles the debug APK (all app Kotlin).
+      # A Kotlin compile error fails this step — the whole point of the gate.
+      - name: Build debug APK (compiles Kotlin)
+        run: make android-debug
+        env:
+          GOMOBILECACHE: ${{ env.GOMOBILECACHE }}

--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -1104,7 +1104,7 @@ class MethodHandler : FlutterPlugin,
                         )
                         val status = AndroidSideloadInstaller.install(MainActivity.instance, update)
                         withContext(Dispatchers.Main) {
-                            success(status)
+                            result.success(status)
                         }
                     } catch (e: Exception) {
                         withContext(Dispatchers.Main) {


### PR DESCRIPTION
## Why

`main`'s Android app **does not compile**. #8754 (Android sideload auto-updates) added a bare `success(status)` call in `MethodHandler.onMethodCall`'s `InstallSideloadUpdate` branch:

```kotlin
scope.launch {
    try {
        val status = AndroidSideloadInstaller.install(MainActivity.instance, update)
        withContext(Dispatchers.Main) {
            success(status)        // ← e: Unresolved reference 'success'
        }
    } ...
}
```

`success(...)` is **not** a helper method — every other call site is inside a `result.runCatching { … }` block, where the implicit receiver `this` is the `MethodChannel.Result`, so `success(...)` resolves to **`MethodChannel.Result.success()`** (the Flutter API). Inside this `scope.launch { … withContext(Dispatchers.Main) { } }` block there is no `result` receiver, so it doesn't resolve and the Kotlin compile fails.

## Fix

One line — qualify it explicitly:

```diff
-                            success(status)
+                            result.success(status)
```

`result.error(...)` is already used in the same branch's `catch`, so `result` is in scope.

## Why it shipped broken — and the gate

`build-android.yml` is **`workflow_call`-only** (invoked by the release flow) and never runs on PRs or pushes. PR CI is only Go CI / CodeQL, neither of which compiles app Kotlin. So this merged undetected.

This PR adds **`android-compile-check.yml`**: on PRs touching `android/**`, `lantern-core/**`, `go.mod`/`go.sum`, `Makefile`, or `pubspec*` (i.e. anything that can break Kotlin compilation, directly or via the gomobile AAR), it builds the **debug** APK — which compiles all app Kotlin. Debug-only, so it needs no keystore/`APP_ENV` secrets and skips the AAB/signing/upload. This PR's own run of the gate (it touches both Kotlin and the workflow) doubles as its validation.

## Verification

Locally on this branch: fresh gomobile AAR + `make android-debug` → **`✓ Built build/app/outputs/flutter-apk/app-debug.apk`**. Installed on an Android 11 / API 30 emulator, connected the VPN successfully (no crash, traffic routed).

> Follow-up worth considering: `android-compile-check` runs on `macos-26` to match the known-good `build-android` environment; a Linux runner would be cheaper for a per-PR gate if the gomobile Android build is verified to work there.
