### PR TITLE
ci(android): fix compile-check gate (placeholder app.env)

### DIFF
--- a/.github/workflows/android-compile-check.yml
+++ b/.github/workflows/android-compile-check.yml
@@ -124,6 +124,12 @@ jobs:
           make pubget
           make gen
 
+      # app.env is a declared pubspec asset, normally decoded from a secret by
+      # the release workflow. This compile-only gate doesn't run the app, so an
+      # empty placeholder is enough to satisfy asset bundling without the secret.
+      - name: Create placeholder app.env
+        run: touch app.env
+
       # Builds the gomobile AAR, then compiles the debug APK (all app Kotlin).
       # A Kotlin compile error fails this step — the whole point of the gate.
       - name: Build debug APK (compiles Kotlin)


### PR DESCRIPTION
## Why

The `android-compile-check` gate added in #8827 fails at **asset bundling**, not compilation:

```
No file or variants found for asset: app.env.
Target debug_android_application failed: Exception: Failed to bundle asset files.
```

`app.env` is a declared pubspec asset (`pubspec.yaml:166`) that only the **release** workflow decodes from a secret. In the failed run, `:app:compileDebugKotlin` passed and `kernel_snapshot_program` completed — the build only choked when bundling the missing asset, **after** Kotlin compiled. So the gate's red on #8827 was a false negative; the merged `result.success` fix is correct and main's Android build is unblocked.

## Fix

The gate is compile-only and never runs the app, so `touch app.env` before the build satisfies asset bundling without needing the secret.

This PR touches the workflow, so its own `compile-check` run validates the fix.

Follow-up to #8827.