### PR TITLE
ci(windows): install Inno Setup via --allow-downgrade (fix nightly)

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -120,9 +120,13 @@ jobs:
 
       - name: Install Inno Setup 6
         shell: pwsh
-        # Pinned to 6.5.0 so the vendored Farsi.isl (6.5.0+) matches the
-        # compiler exactly and the Languages dir path is deterministic.
-        run: choco install -y innosetup --version=6.5.0
+        # The runner image preinstalls Inno Setup (currently 6.7.1). A bare
+        # --version=6.5.0 now fails ("a newer version is already installed; use
+        # --allow-downgrade"), so pin to 6.7.1 with --allow-downgrade: the install
+        # is deterministic and the Languages dir stays "Inno Setup 6". The vendored
+        # Farsi/ChineseSimplified .isl files are "6.5.0+" and message-key-identical
+        # to 6.7.1's Default.isl, so they remain valid as-is.
+        run: choco install -y innosetup --version=6.7.1 --allow-downgrade
 
       - name: Install unofficial Inno Setup translations
         shell: pwsh


### PR DESCRIPTION
## Why

The nightly **Build and Release** has been failing on the **Windows** job (every other platform passes). The failing step is **Install Inno Setup 6**:

```
$ choco install -y innosetup --version=6.5.0
A newer version of InnoSetup (v6.7.1) is already installed.
 Use --allow-downgrade or --force to attempt to install older versions.
Chocolatey installed 0/1 packages. 1 packages failed.
```

The GitHub Windows runner image now **preinstalls Inno Setup 6.7.1**, so the pinned `--version=6.5.0` (added so the vendored `.isl` translations matched the compiler) now collides with it — Chocolatey refuses to downgrade without a flag, and the job exits 1. Nothing in our code regressed; the runner image moved under us.

## Fix

```diff
-        run: choco install -y innosetup --version=6.5.0
+        run: choco install -y innosetup --version=6.7.1 --allow-downgrade
```

Pin to **6.7.1** with `--allow-downgrade`: deterministic, keeps the `Inno Setup 6` Languages dir path, and won't break on the next runner-image bump.

### No translation changes needed (verified)

The vendored `Farsi.isl`/`ChineseSimplified.isl` are "6.5.0+" — and Inno's `[Messages]` set is unchanged through 6.7.x. Diffing against **6.7.1's** `Default.isl`:

| File | Required keys | Present | Missing | Stale |
|---|---|---|---|---|
| Farsi.isl | 281 | 281 | 0 | 0 |
| ChineseSimplified.isl | 281 | 281 | 0 | 0 |

So they remain valid as-is.

## Verification

Dispatched a **Windows-only, signing-free** test build of `release.yml` on this branch ([run 26696843961](https://github.com/getlantern/lantern/actions/runs/26696843961)). All steps green:

- ✅ Install Inno Setup 6
- ✅ Install unofficial Inno Setup translations (Farsi + Chinese)
- ✅ Build Windows binaries
- ✅ Package installer (ISCC 6.7.1 compiles `.iss` + `.isl` — the step the choco failure previously masked)
- ✅ Windows installer smoke suite
- ✅ Upload Windows installer

So Inno 6.7.1 both installs and compiles the installer with the translations cleanly. This unblocks tonight's nightly.