### PR TITLE
Do not give option to remove there own device

### DIFF
--- a/lib/core/widgets/user_devices.dart
+++ b/lib/core/widgets/user_devices.dart
@@ -20,7 +20,6 @@ class UserDevices extends HookConsumerWidget {
     }
     final userDevices = user.legacyUserData.devices.toList();
     final myDeviceId = user.legacyUserData.deviceID;
-
     return AppCard(
       padding: EdgeInsets.zero,
       child: ListView.separated(
@@ -31,7 +30,7 @@ class UserDevices extends HookConsumerWidget {
         separatorBuilder: (context, index) => const DividerSpace(),
         itemBuilder: (context, index) {
           final e = userDevices[index];
-          return _buildRow(e, ref, context, myDeviceId != e.name);
+          return _buildRow(e, ref, context, myDeviceId != e.deviceId);
         },
       ),
     );

--- a/lib/core/widgets/user_devices.dart
+++ b/lib/core/widgets/user_devices.dart
@@ -30,7 +30,8 @@ class UserDevices extends HookConsumerWidget {
         separatorBuilder: (context, index) => const DividerSpace(),
         itemBuilder: (context, index) {
           final e = userDevices[index];
-          return _buildRow(e, ref, context, myDeviceId != e.deviceId);
+          final removable = e.deviceId != myDeviceId;
+          return _buildRow(e, ref, context, removable);
         },
       ),
     );
@@ -40,12 +41,12 @@ class UserDevices extends HookConsumerWidget {
     DeviceModel e,
     WidgetRef ref,
     BuildContext context,
-    bool isMyDevice,
+    bool removable,
   ) {
     return AppTile(
       label: e.name.isEmpty ? e.deviceId : e.name,
       contentPadding: EdgeInsets.only(left: 16),
-      trailing: isMyDevice
+      trailing: removable
           ? AppTextButton(
               label: 'remove'.i18n,
               onPressed: () => _removeDevice(e, ref, context),

--- a/lib/features/auth/confirm_email.dart
+++ b/lib/features/auth/confirm_email.dart
@@ -136,7 +136,8 @@ class ConfirmEmail extends HookConsumerWidget {
       },
       (_) {
         context.hideLoadingDialog();
-        //refresh user data to pick up the new email
+
+        /// fetch user data to update email in the app
         ref.read(homeProvider.notifier).fetchUserData();
         AppDialog.dialog(
           context: context,

--- a/lib/features/auth/confirm_email.dart
+++ b/lib/features/auth/confirm_email.dart
@@ -137,7 +137,7 @@ class ConfirmEmail extends HookConsumerWidget {
       (_) {
         context.hideLoadingDialog();
         //refresh user data to pick up the new email
-        ref.read(homeProvider.notifier).refreshUser();
+        ref.read(homeProvider.notifier).fetchUserData();
         AppDialog.dialog(
           context: context,
           title: 'change_email'.i18n,


### PR DESCRIPTION
This pull request includes a few targeted fixes to improve device identification and data refresh logic in the user interface and authentication flow.

- **User Devices Widget Improvements**
  * Fixed the device comparison in `_buildRow` to use `deviceId` instead of `name`, ensuring that the current device is correctly identified in the `UserDevices` widget.

- **Authentication Flow Enhancement**
  * Updated the email confirmation logic to use `fetchUserData()` instead of the deprecated `refreshUser()` method, ensuring user data is properly refreshed after email confirmation.