### PR TITLE
Hide change email for OAuth

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -393,8 +393,11 @@ msgstr "Add your email to access your subscription on any device."
 msgid "confirm_email_code"
 msgstr "Confirmation Code"
 
-msgid "confirm_email_code_message"
-msgstr "Confirm that this email address belongs to you, enter the code sent to: "
+msgid "confirm_email_code_message_part_one"
+msgstr "We sent a code to "
+
+msgid "confirm_email_code_message_part_two"
+msgstr " Enter it below. If it's not in your inbox, check your spam folder."
 
 msgid "resend_email"
 msgstr "Resend Email"

--- a/lib/features/account/account.dart
+++ b/lib/features/account/account.dart
@@ -49,7 +49,7 @@ class Account extends HookConsumerWidget {
     final email = ref.watch(userEmailProvider);
     final isUserFree = !isExpired && !isPro;
     final theme = TextTheme.of(buildContext);
-    final isOAuthLogin = ref.read(isOAuthLoginProvider).value ?? false;
+    final isOAuthLogin = ref.watch(isOAuthLoginProvider).value ?? false;
     return SafeArea(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,

--- a/lib/features/account/account.dart
+++ b/lib/features/account/account.dart
@@ -12,6 +12,7 @@ import 'package:lantern/core/widgets/user_devices.dart';
 import 'package:lantern/features/account/provider/account_notifier.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
 import 'package:lantern/features/home/provider/home_notifier.dart';
+import 'package:lantern/features/home/provider/radiance_settings_providers.dart';
 import 'package:lantern/lantern/lantern_service.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
 
@@ -48,7 +49,7 @@ class Account extends HookConsumerWidget {
     final email = ref.watch(userEmailProvider);
     final isUserFree = !isExpired && !isPro;
     final theme = TextTheme.of(buildContext);
-
+    final isOAuthLogin = ref.read(isOAuthLoginProvider).value ?? false;
     return SafeArea(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -98,14 +99,16 @@ class Account extends HookConsumerWidget {
                       copyToClipboard(email);
                     }
                   : null,
-              trailing: AppTextButton(
-                label: 'change_email'.i18n,
-                onPressed: () {
-                  appRouter.push(
-                    SignInPassword(email: email, fromChangeEmail: true),
-                  );
-                },
-              ),
+              trailing: isOAuthLogin
+                  ? null
+                  : AppTextButton(
+                      label: 'change_email'.i18n,
+                      onPressed: () {
+                        appRouter.push(
+                          SignInPassword(email: email, fromChangeEmail: true),
+                        );
+                      },
+                    ),
             ),
           ),
           SizedBox(height: defaultSize),

--- a/lib/features/auth/confirm_email.dart
+++ b/lib/features/auth/confirm_email.dart
@@ -3,9 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/common/app_text_styles.dart';
 import 'package:lantern/core/common/common.dart' hide BackButton;
 import 'package:lantern/core/widgets/app_pin_field.dart';
-import 'package:lantern/core/widgets/app_rich_text.dart';
 import 'package:lantern/features/auth/provider/auth_notifier.dart';
 import 'package:lantern/features/home/provider/home_notifier.dart';
 
@@ -70,9 +70,24 @@ class ConfirmEmail extends HookConsumerWidget {
             SizedBox(height: defaultSize),
             Padding(
               padding: const EdgeInsets.symmetric(horizontal: 16),
-              child: AppRichText(
-                texts: 'confirm_email_code_message'.i18n,
-                boldTexts: email,
+              child: RichText(
+                text: TextSpan(
+                  style: textTheme.labelLarge!.copyWith(
+                    color: context.textSecondary,
+                  ),
+                  children: [
+                    TextSpan(text: 'confirm_email_code_message_part_one'.i18n),
+                    TextSpan(
+                      text: '$email.',
+                      style: AppTextStyles.labelLargeBold.copyWith(
+                        fontWeight: FontWeight.bold,
+                        color: context.textSecondary,
+                        decoration: TextDecoration.underline,
+                      ),
+                    ),
+                    TextSpan(text: 'confirm_email_code_message_part_two'.i18n),
+                  ],
+                ),
               ),
             ),
             SizedBox(height: 32),

--- a/lib/features/auth/sign_in_password.dart
+++ b/lib/features/auth/sign_in_password.dart
@@ -63,8 +63,10 @@ class _SignInPasswordState extends ConsumerState<SignInPassword> {
                   obscureText: obscureText.value,
                   suffixIcon: _buildSuffix(obscureText),
                   textInputAction: TextInputAction.done,
-                  onSubmitted: (_) =>
-                      signInWithPassword(passwordController.text.trim()),
+                  onSubmitted: (value) {
+                    if (passwordController.text.isEmpty) return;
+                    signInWithPassword(passwordController.text.trim());
+                  },
                   onChanged: (value) {},
                 ),
                 SizedBox(height: 8),
@@ -127,7 +129,6 @@ class _SignInPasswordState extends ConsumerState<SignInPassword> {
 
   Future<void> signInWithPassword(String password) async {
     hideKeyboard();
-    if (password.isEmpty) return;
     if (widget.fromChangeEmail) {
       /// If the user is changing email, we need to verify the password
       context.pushRoute(

--- a/lib/features/auth/sign_in_password.dart
+++ b/lib/features/auth/sign_in_password.dart
@@ -4,12 +4,11 @@ import 'package:flutter/services.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/models/user.dart';
 import 'package:lantern/core/widgets/email_tag.dart';
 import 'package:lantern/features/auth/provider/auth_notifier.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
-
 import 'package:lantern/features/home/provider/home_notifier.dart';
-import 'package:lantern/core/models/user.dart';
 
 @RoutePage(name: 'SignInPassword')
 class SignInPassword extends StatefulHookConsumerWidget {
@@ -128,6 +127,7 @@ class _SignInPasswordState extends ConsumerState<SignInPassword> {
 
   Future<void> signInWithPassword(String password) async {
     hideKeyboard();
+    if (password.isEmpty) return;
     if (widget.fromChangeEmail) {
       /// If the user is changing email, we need to verify the password
       context.pushRoute(


### PR DESCRIPTION
This pull request introduces improvements to the account and authentication flows, focusing on handling OAuth logins and enhancing user experience during sign-in. The main changes include conditionally hiding the "Change Email" button for OAuth users, preventing empty password submissions, and organizing imports for better code clarity.

**Account screen improvements:**

* Added import for `radiance_settings_providers` and introduced the `isOAuthLoginProvider` to determine if the user logged in via OAuth (`lib/features/account/account.dart`). [[1]](diffhunk://#diff-ffbb2c96df92b74556311e1ad68681cf85ff72aacf2ae5f1398e9ba1df044eaeR15) [[2]](diffhunk://#diff-ffbb2c96df92b74556311e1ad68681cf85ff72aacf2ae5f1398e9ba1df044eaeL51-R52)
* The "Change Email" button is now hidden for OAuth users by checking `isOAuthLogin`, ensuring users authenticated via OAuth cannot attempt to change their email through the app UI (`lib/features/account/account.dart`).

**Authentication flow enhancements:**

* Prevented sign-in attempts with empty passwords by adding a guard clause in `signInWithPassword`, improving user feedback and security (`lib/features/auth/sign_in_password.dart`).

**Code organization:**

* Cleaned up and reordered imports in `sign_in_password.dart` for clarity and consistency (`lib/features/auth/sign_in_password.dart`).