### PR TITLE
Fix iOS purchase receipt loss after backend

### DIFF
--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'dart:convert';
 import 'dart:io';
 
 import 'package:in_app_purchase/in_app_purchase.dart';
@@ -774,13 +773,10 @@ class AppPurchase {
     _ackRetryTimers.remove(key)?.cancel();
   }
 
-  String _purchaseRetryKey(PurchaseDetails purchase) {
-    final transactionKey = _transactionPlanKey(purchase);
-    if (transactionKey != null) {
-      return transactionKey;
-    }
-    return _productPlanKey(purchase.productID);
-  }
+  // The transaction key when available, otherwise the product key — i.e. the
+  // most specific key `_planKeysForPurchase` would store this purchase under.
+  String _purchaseRetryKey(PurchaseDetails purchase) =>
+      _planKeysForPurchase(purchase).first;
 
   String _productPlanKey(String productID) =>
       '$_productPlanKeyPrefix$productID';
@@ -821,12 +817,7 @@ class AppPurchase {
     String productID,
     String planId,
   ) async {
-    if (planId.isEmpty) {
-      return;
-    }
-    final pending = await _loadPendingPurchasePlans();
-    pending[_productPlanKey(productID)] = planId;
-    await _savePendingPurchasePlans(pending);
+    await _rememberPendingPlan([_productPlanKey(productID)], planId);
     appLogger.info(
       '[AppPurchase] Stored pending purchase plan: productID=$productID planId=$planId',
     );
@@ -836,28 +827,26 @@ class AppPurchase {
     PurchaseDetails purchase,
     String planId,
   ) async {
-    if (planId.isEmpty) {
-      return;
-    }
-    final pending = await _loadPendingPurchasePlans();
-    for (final key in _planKeysForPurchase(purchase)) {
-      pending[key] = planId;
-    }
-    await _savePendingPurchasePlans(pending);
+    await _rememberPendingPlan(_planKeysForPurchase(purchase), planId);
     appLogger.info(
       '[AppPurchase] Stored pending purchase plan: '
       'productID=${purchase.productID} purchaseID=${purchase.purchaseID} planId=$planId',
     );
   }
 
-  Future<void> _forgetPendingPlan(PurchaseDetails purchase) async {
-    final pending = await _loadPendingPurchasePlans();
-    var changed = false;
-    for (final key in _planKeysForPurchase(purchase)) {
-      changed = pending.remove(key) != null || changed;
+  Future<void> _rememberPendingPlan(List<String> keys, String planId) async {
+    if (planId.isEmpty) {
+      return;
     }
-    if (changed) {
-      await _savePendingPurchasePlans(pending);
+    final pending = await _loadPendingPurchasePlans();
+    for (final key in keys) {
+      pending[key] = planId;
+    }
+    await _savePendingPurchasePlans(pending);
+  }
+
+  Future<void> _forgetPendingPlan(PurchaseDetails purchase) async {
+    if (await _forgetPendingPlanKeys(_planKeysForPurchase(purchase))) {
       appLogger.info(
         '[AppPurchase] Cleared pending purchase plan: '
         'productID=${purchase.productID} purchaseID=${purchase.purchaseID}',
@@ -866,46 +855,30 @@ class AppPurchase {
   }
 
   Future<void> _forgetPendingPlanForProduct(String productID) async {
-    final pending = await _loadPendingPurchasePlans();
-    if (pending.remove(_productPlanKey(productID)) != null) {
-      await _savePendingPurchasePlans(pending);
+    if (await _forgetPendingPlanKeys([_productPlanKey(productID)])) {
       appLogger.info(
         '[AppPurchase] Cleared pending purchase plan for productID=$productID',
       );
     }
   }
 
-  Future<Map<String, String>> _loadPendingPurchasePlans() async {
-    final storage = sl<LocalStorageService>();
-    final raw = storage.getString(_pendingPurchasePlansKey);
-    if (raw == null || raw.isEmpty) {
-      return {};
+  /// Removes [keys] from the pending plans map, persisting only when something
+  /// actually changed. Returns whether any entry was removed.
+  Future<bool> _forgetPendingPlanKeys(List<String> keys) async {
+    final pending = await _loadPendingPurchasePlans();
+    var changed = false;
+    for (final key in keys) {
+      changed = pending.remove(key) != null || changed;
     }
-    try {
-      final decoded = jsonDecode(raw);
-      if (decoded is Map) {
-        return decoded.map(
-          (key, value) => MapEntry(key.toString(), value.toString()),
-        );
-      }
-      appLogger.warning('Pending purchase plans had invalid shape; clearing');
-    } catch (e, st) {
-      appLogger.error(
-        'Failed to parse pending purchase plans; clearing',
-        e,
-        st,
-      );
+    if (changed) {
+      await _savePendingPurchasePlans(pending);
     }
-    await storage.remove(_pendingPurchasePlansKey);
-    return {};
+    return changed;
   }
 
-  Future<void> _savePendingPurchasePlans(Map<String, String> pending) async {
-    final storage = sl<LocalStorageService>();
-    if (pending.isEmpty) {
-      await storage.remove(_pendingPurchasePlansKey);
-      return;
-    }
-    await storage.setString(_pendingPurchasePlansKey, jsonEncode(pending));
-  }
+  Future<Map<String, String>> _loadPendingPurchasePlans() =>
+      sl<LocalStorageService>().getStringMap(_pendingPurchasePlansKey);
+
+  Future<void> _savePendingPurchasePlans(Map<String, String> pending) =>
+      sl<LocalStorageService>().setStringMap(_pendingPurchasePlansKey, pending);
 }

--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -817,32 +817,37 @@ class AppPurchase {
     String productID,
     String planId,
   ) async {
-    await _rememberPendingPlan([_productPlanKey(productID)], planId);
-    appLogger.info(
-      '[AppPurchase] Stored pending purchase plan: productID=$productID planId=$planId',
-    );
+    if (await _rememberPendingPlan([_productPlanKey(productID)], planId)) {
+      appLogger.info(
+        '[AppPurchase] Stored pending purchase plan: productID=$productID planId=$planId',
+      );
+    }
   }
 
   Future<void> _rememberPendingPlanForPurchase(
     PurchaseDetails purchase,
     String planId,
   ) async {
-    await _rememberPendingPlan(_planKeysForPurchase(purchase), planId);
-    appLogger.info(
-      '[AppPurchase] Stored pending purchase plan: '
-      'productID=${purchase.productID} purchaseID=${purchase.purchaseID} planId=$planId',
-    );
+    if (await _rememberPendingPlan(_planKeysForPurchase(purchase), planId)) {
+      appLogger.info(
+        '[AppPurchase] Stored pending purchase plan: '
+        'productID=${purchase.productID} purchaseID=${purchase.purchaseID} planId=$planId',
+      );
+    }
   }
 
-  Future<void> _rememberPendingPlan(List<String> keys, String planId) async {
+  /// Stores [planId] under each of [keys], persisting only when [planId] is
+  /// non-empty. Returns whether anything was written.
+  Future<bool> _rememberPendingPlan(List<String> keys, String planId) async {
     if (planId.isEmpty) {
-      return;
+      return false;
     }
     final pending = await _loadPendingPurchasePlans();
     for (final key in keys) {
       pending[key] = planId;
     }
     await _savePendingPurchasePlans(pending);
+    return true;
   }
 
   Future<void> _forgetPendingPlan(PurchaseDetails purchase) async {

--- a/lib/core/services/local_storage_service.dart
+++ b/lib/core/services/local_storage_service.dart
@@ -125,8 +125,8 @@ class LocalStorageService {
   }
 
   /// Reads a `Map<String, String>` persisted as a JSON object. Returns an
-  /// empty map when absent, and clears the key when its contents can't be
-  /// parsed into a map.
+  /// empty map when the key is absent or holds an empty string, and clears the
+  /// key when its (non-empty) contents can't be parsed into a map.
   Future<Map<String, String>> getStringMap(String key) async {
     final raw = getString(key);
     if (raw == null || raw.isEmpty) return {};

--- a/lib/core/services/local_storage_service.dart
+++ b/lib/core/services/local_storage_service.dart
@@ -124,6 +124,37 @@ class LocalStorageService {
     }
   }
 
+  /// Reads a `Map<String, String>` persisted as a JSON object. Returns an
+  /// empty map when absent, and clears the key when its contents can't be
+  /// parsed into a map.
+  Future<Map<String, String>> getStringMap(String key) async {
+    final raw = getString(key);
+    if (raw == null || raw.isEmpty) return {};
+    try {
+      final decoded = jsonDecode(raw);
+      if (decoded is Map) {
+        return decoded.map(
+          (k, v) => MapEntry(k.toString(), v.toString()),
+        );
+      }
+      appLogger.warning('Stored map at "$key" had invalid shape; clearing');
+    } catch (e, st) {
+      appLogger.error('Failed to parse stored map at "$key"; clearing', e, st);
+    }
+    await remove(key);
+    return {};
+  }
+
+  /// Persists a `Map<String, String>` as a JSON object, removing the key
+  /// entirely when the map is empty.
+  Future<void> setStringMap(String key, Map<String, String> value) async {
+    if (value.isEmpty) {
+      await remove(key);
+      return;
+    }
+    await setString(key, jsonEncode(value));
+  }
+
   bool containsKey(String key) => _prefs.containsKey(key);
 
   Future<void> remove(String key) async {


### PR DESCRIPTION
This pull request refactors and improves the handling of pending purchase plans in the in-app purchase service. The main changes include centralizing the logic for persisting and clearing pending plans, reducing code duplication, and introducing new utility methods in `LocalStorageService` for managing string maps. These updates make the code more robust and maintainable.

**Refactoring and Centralization of Pending Plan Logic:**

* Refactored the logic for remembering and forgetting pending purchase plans in `AppPurchase` by introducing the `_rememberPendingPlan` and `_forgetPendingPlanKeys` helper methods, reducing code duplication and improving clarity. (`lib/core/services/app_purchase.dart` [[1]](diffhunk://#diff-1ea657cb39bd3e831ce9f85db90d8fd9b025ca4bced34c51f64990d9a64cdd87L824-R820) [[2]](diffhunk://#diff-1ea657cb39bd3e831ce9f85db90d8fd9b025ca4bced34c51f64990d9a64cdd87R830-R849) [[3]](diffhunk://#diff-1ea657cb39bd3e831ce9f85db90d8fd9b025ca4bced34c51f64990d9a64cdd87L869-R883)
* Updated the retry key logic with a more concise `_purchaseRetryKey` method that always uses the most specific key. (`lib/core/services/app_purchase.dart` [lib/core/services/app_purchase.dartL777-R779](diffhunk://#diff-1ea657cb39bd3e831ce9f85db90d8fd9b025ca4bced34c51f64990d9a64cdd87L777-R779))

**Persistence Improvements:**

* Replaced manual JSON encoding/decoding for pending plans with new `getStringMap` and `setStringMap` methods in `LocalStorageService`, which handle parsing errors and key removal more gracefully. (`lib/core/services/app_purchase.dart` [[1]](diffhunk://#diff-1ea657cb39bd3e831ce9f85db90d8fd9b025ca4bced34c51f64990d9a64cdd87L869-R883) `lib/core/services/local_storage_service.dart` [[2]](diffhunk://#diff-a9c229e067e27b4714a4bc19707383dc246fc7eaaaa2e1f658058feca7ea1692R127-R157)

**Utility Additions in Local Storage:**

* Added `getStringMap` and `setStringMap` methods to `LocalStorageService` for easier and safer storage of string maps, with automatic error handling and cleanup of invalid data. (`lib/core/services/local_storage_service.dart` [lib/core/services/local_storage_service.dartR127-R157](diffhunk://#diff-a9c229e067e27b4714a4bc19707383dc246fc7eaaaa2e1f658058feca7ea1692R127-R157))

**Minor Cleanups:**

* Removed unused `dart:convert` import from `app_purchase.dart` as JSON handling is now encapsulated in `LocalStorageService`. (`lib/core/services/app_purchase.dart` [lib/core/services/app_purchase.dartL2](diffhunk://#diff-1ea657cb39bd3e831ce9f85db90d8fd9b025ca4bced34c51f64990d9a64cdd87L2))