### PR TITLE
refactor(servers): use SelectionHistory instead of URLTestResults

### DIFF
--- a/lib/core/models/available_servers.dart
+++ b/lib/core/models/available_servers.dart
@@ -20,12 +20,14 @@ class AvailableServers {
     return null;
   }
 
-  /// Lantern server with the lowest successful URL-test delay. Null when no
+  /// Lantern server with the lowest successful probe delay. Null when no
   /// Lantern server has a successful probe.
   Server? get fastestLanternServer {
     final ranked = lanternServers.where((s) => s.hasSuccessfulProbe).toList()
       ..sort(
-        (a, b) => a.urlTestResult!.delay.compareTo(b.urlTestResult!.delay),
+        (a, b) => a.selectionHistory!.lastSuccessDelayMs.compareTo(
+          b.selectionHistory!.lastSuccessDelayMs,
+        ),
       );
     return ranked.isEmpty ? null : ranked.first;
   }
@@ -39,7 +41,7 @@ class Server {
   final Map<String, dynamic>? endpoint;
   final GeoLocation location;
   final ServerCredential? credentials;
-  final UrlTestResult? urlTestResult;
+  final SelectionHistory? selectionHistory;
 
   Server({
     required this.tag,
@@ -49,7 +51,7 @@ class Server {
     this.endpoint,
     required this.location,
     this.credentials,
-    this.urlTestResult,
+    this.selectionHistory,
   });
 
   factory Server.fromJson(Map<String, dynamic> json) => Server(
@@ -64,16 +66,16 @@ class Server {
     credentials: json['credentials'] != null
         ? ServerCredential.fromJson(json['credentials'] as Map<String, dynamic>)
         : null,
-    urlTestResult: json["urlTestResult"] == null
+    selectionHistory: json["selection_history"] == null
         ? null
-        : UrlTestResult.fromJson(json["urlTestResult"]),
+        : SelectionHistory.fromJson(json["selection_history"]),
   );
 
   /// IP address extracted from outbound or endpoint options.
   String get serverIP =>
       outbound?['server'] as String? ?? endpoint?['server'] as String? ?? '';
 
-  bool get hasSuccessfulProbe => (urlTestResult?.delay ?? 0) > 0;
+  bool get hasSuccessfulProbe => (selectionHistory?.lastSuccessDelayMs ?? 0) > 0;
 
   /// Manual mode pins traffic to exactly this server. If Smart Location has no
   /// successful probe for it, warn before pinning so users can stay on auto.
@@ -123,17 +125,58 @@ class ServerCredential {
       );
 }
 
-class UrlTestResult {
-  int delay;
-  DateTime time;
+/// SelectionHistory mirrors radiance's per-server selection history. Probe
+/// outcomes feed [lastSuccessDelayMs]/[consecutiveFailures]; real user-traffic
+/// failures feed [userFailures], kept separate so a censor that passes the
+/// probe URL while dropping user traffic is still visible.
+class SelectionHistory {
+  /// Most recent successful probe RTT in milliseconds. 0 means no successful
+  /// probe yet, used as the sentinel by [Server.hasSuccessfulProbe].
+  final int lastSuccessDelayMs;
 
-  UrlTestResult({required this.delay, required this.time});
+  /// Timestamp of the most recent probe outcome, success or failure.
+  final DateTime? lastOutcomeAt;
 
-  factory UrlTestResult.fromJson(Map<String, dynamic> json) =>
-      UrlTestResult(delay: json["delay"], time: DateTime.parse(json["time"]));
+  /// Probe failures since the last probe success; resets on success.
+  final int consecutiveFailures;
+
+  /// Sliding window of user-traffic failure timestamps. Probe successes never
+  /// enter this window.
+  final List<DateTime> userFailures;
+
+  final DateTime? updatedAt;
+
+  SelectionHistory({
+    this.lastSuccessDelayMs = 0,
+    this.lastOutcomeAt,
+    this.consecutiveFailures = 0,
+    this.userFailures = const [],
+    this.updatedAt,
+  });
+
+  factory SelectionHistory.fromJson(Map<String, dynamic> json) =>
+      SelectionHistory(
+        lastSuccessDelayMs: json["last_success_delay_ms"] ?? 0,
+        lastOutcomeAt: json["last_outcome_at"] == null
+            ? null
+            : DateTime.parse(json["last_outcome_at"]),
+        consecutiveFailures: json["consecutive_failures"] ?? 0,
+        userFailures:
+            (json["user_failures"] as List<dynamic>?)
+                ?.map((e) => DateTime.parse(e as String))
+                .toList() ??
+            const [],
+        updatedAt: json["updated_at"] == null
+            ? null
+            : DateTime.parse(json["updated_at"]),
+      );
 
   Map<String, dynamic> toJson() => {
-    "delay": delay,
-    "time": time.toIso8601String(),
+    "last_success_delay_ms": lastSuccessDelayMs,
+    if (lastOutcomeAt != null) "last_outcome_at": lastOutcomeAt!.toIso8601String(),
+    "consecutive_failures": consecutiveFailures,
+    if (userFailures.isNotEmpty)
+      "user_failures": userFailures.map((e) => e.toIso8601String()).toList(),
+    if (updatedAt != null) "updated_at": updatedAt!.toIso8601String(),
   };
 }

--- a/lib/features/vpn/provider/available_servers_notifier.dart
+++ b/lib/features/vpn/provider/available_servers_notifier.dart
@@ -65,7 +65,7 @@ class AvailableServersNotifier extends _$AvailableServersNotifier {
     final city = fastest.location.city;
     appLogger.debug(
       'Pushing fastest server to Smart Location: '
-      'tag=${fastest.tag} delay=${fastest.urlTestResult?.delay}ms',
+      'tag=${fastest.tag} delay=${fastest.selectionHistory?.lastSuccessDelayMs}ms',
     );
     ref
         .read(serverLocationProvider.notifier)

--- a/test/core/models/available_servers_test.dart
+++ b/test/core/models/available_servers_test.dart
@@ -54,8 +54,11 @@ Server _server({required String tag, bool isLantern = true, int? delay}) {
       latitude: 40.7128,
       longitude: -74.006,
     ),
-    urlTestResult: delay == null
+    selectionHistory: delay == null
         ? null
-        : UrlTestResult(delay: delay, time: DateTime.utc(2026, 1, 1)),
+        : SelectionHistory(
+            lastSuccessDelayMs: delay,
+            updatedAt: DateTime.utc(2026, 1, 1),
+          ),
   );
 }


### PR DESCRIPTION
This pull request refactors the way server probe results and selection history are tracked and used throughout the codebase. The main change is replacing the `UrlTestResult` model with a more comprehensive `SelectionHistory` model, which captures more detailed probe and user-traffic failure information. All references and logic related to server probe results are updated accordingly.

Key changes include:

**Model and Data Structure Updates:**

* Replaced the `UrlTestResult` class with a new `SelectionHistory` class in `available_servers.dart`. `SelectionHistory` tracks the last successful probe delay, consecutive failures, user-traffic failures, and related timestamps for each server, providing a more complete history of server selection and health.
* Updated the `Server` model to use `selectionHistory` instead of `urlTestResult`. All JSON serialization/deserialization and related logic now work with the new `SelectionHistory` structure. [[1]](diffhunk://#diff-258c5d648d887fc4c3bc9d47851ae9ad8a4238bbec80ac21a03fab8863d7cbcbL42-R44) [[2]](diffhunk://#diff-258c5d648d887fc4c3bc9d47851ae9ad8a4238bbec80ac21a03fab8863d7cbcbL52-R54) [[3]](diffhunk://#diff-258c5d648d887fc4c3bc9d47851ae9ad8a4238bbec80ac21a03fab8863d7cbcbL67-R78)

**Business Logic Changes:**

* Updated the logic for determining the fastest Lantern server to use `selectionHistory.lastSuccessDelayMs` for sorting, instead of the previous `urlTestResult.delay`.
* Changed the `hasSuccessfulProbe` logic to check `selectionHistory.lastSuccessDelayMs` instead of `urlTestResult.delay`.

**Logging and Testing:**

* Updated debug logging to display the new probe delay field from `selectionHistory` when reporting the fastest server.
* Updated test helpers to construct `Server` instances with `SelectionHistory` instead of `UrlTestResult`.