### PR TITLE
ci: run Android compile check only on Kotlin changes

### DIFF
--- a/.github/workflows/android-compile-check.yml
+++ b/.github/workflows/android-compile-check.yml
@@ -1,24 +1,22 @@
 name: Android Compile Check
 
-# Gates PRs that touch Kotlin/Android (or the Go/deps that produce the gomobile
-# AAR the Kotlin compiles against) by building the debug APK — which compiles
-# all app Kotlin. The full signed release build (build-android.yml) is
-# workflow_call-only and never ran on PRs, so a Kotlin compile break (e.g. the
-# bare success() call in #8754) could merge to main undetected. This catches it.
+# Compiles all app Kotlin (by building the debug APK) on PRs that change Kotlin
+# source, to catch Kotlin compile breaks before they reach main. The full signed
+# release build (build-android.yml) is workflow_call-only and never runs on PRs,
+# so without this gate a Kotlin break (e.g. the bare success() call in #8754)
+# could merge undetected.
+#
+# Scope: triggers only on Kotlin (*.kt) changes. It intentionally does NOT run on
+# Go/gomobile-AAR or Flutter/dep changes — a Go change that breaks the
+# AAR<->Kotlin interface would surface in build-android.yml / release, not here.
 #
 # Debug build only: no keystore/APP_ENV secrets, no AAB, no artifact upload.
 
 on:
   pull_request:
     paths:
-      - "android/**"
-      - "lantern-core/**"
-      - "go.mod"
-      - "go.sum"
-      - "Makefile"
-      - "pubspec.yaml"
-      - "pubspec.lock"
-      - ".github/flutter-version.yaml"
+      - "**/*.kt"
+      # keep the self-trigger so edits to this workflow re-run it
       - ".github/workflows/android-compile-check.yml"
 
 concurrency:


### PR DESCRIPTION
## What

Narrows the **Android Compile Check** trigger to **Kotlin changes only**.

`pull_request.paths` goes from:
`android/**`, `lantern-core/**`, `go.mod`, `go.sum`, `Makefile`, `pubspec.yaml`, `pubspec.lock`, `.github/flutter-version.yaml`, + self
→ **`**/*.kt`** + the workflow self-trigger.

So the (slow, `macos-26`) debug-APK build runs only when Kotlin source actually changes — not on every Go / Flutter / dependency-bump PR (which is most of them).

## Trade-off (intentional)

This gate previously also ran on Go/dep changes to catch a **Go/gomobile-AAR change breaking the AAR↔Kotlin interface**. Scoping to `*.kt` means such a break is no longer caught *here* — it would surface in `build-android.yml` / the release build instead. Header comment updated to reflect this.

## Safety

`main` is **not branch-protected** (no required status checks; the only rulesets are Copilot review), so narrowing `paths:` can't leave a required check stuck "pending" on PRs that don't touch Kotlin.

## Notes
- Kept the workflow self-path so edits to this file still self-test.
- `*.kts` (Gradle Kotlin DSL) is intentionally **not** included — easy to add if you also want gradle-script changes to trigger the compile check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
