### PR TITLE
add logging for memory.

### DIFF
--- a/ios/Tunnel/PacketTunnelProvider.swift
+++ b/ios/Tunnel/PacketTunnelProvider.swift
@@ -83,19 +83,21 @@ class PacketTunnelProvider: ExtensionProvider {
     // Returns 0 on platforms / processes without a limit (e.g. macOS host app).
     let availableBytes = os_proc_available_memory()
     let availableMB = Double(availableBytes) / mb
-    let message = String(
-      format:
-        "PacketTunnelProvider memory [pressure=%u] — footprint: %.2f MB, available: %.2f MB, resident: %.2f MB, peak: %.2f MB, dirty: %.2f MB, compressed: %.2f MB, virtual: %.2f MB",
-      currentMemoryPressure.rawValue, footprintMB, availableMB, residentMB, peakMB, dirtyMB, compressedMB, virtualMB
-    )
+    let pressureLabel: String
     switch currentMemoryPressure {
     case .critical:
-      appLogger.info("\(message)")
+      pressureLabel = "critical"
     case .warning:
-      appLogger.info("\(message)")
+      pressureLabel = "warning"
     default:
-      appLogger.info("\(message)")
+      pressureLabel = "normal"
     }
+    let message = String(
+      format:
+        "PacketTunnelProvider memory [pressure=%@] — footprint: %.2f MB, available: %.2f MB, resident: %.2f MB, peak: %.2f MB, dirty: %.2f MB, compressed: %.2f MB, virtual: %.2f MB",
+      pressureLabel, footprintMB, availableMB, residentMB, peakMB, dirtyMB, compressedMB, virtualMB
+    )
+    appLogger.info("\(message)")
   }
 
   public override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?)

--- a/ios/Tunnel/PacketTunnelProvider.swift
+++ b/ios/Tunnel/PacketTunnelProvider.swift
@@ -3,17 +3,99 @@
 //  LanternTunnel
 //
 
+import Darwin
 import NetworkExtension
 import System
 import os
 
 class PacketTunnelProvider: ExtensionProvider {
+  private var memoryLogTimer: DispatchSourceTimer?
+  private var memoryPressureSource: DispatchSourceMemoryPressure?
+  private var currentMemoryPressure: DispatchSource.MemoryPressureEvent = .normal
+
   override func startTunnel(options: [String: NSObject]?) async throws {
     try await super.startTunnel(options: options)
+    startMemoryLogger()
   }
 
   override func stopTunnel(with reason: NEProviderStopReason) async {
+    stopMemoryLogger()
     try? await super.stopTunnel(with: reason)
+  }
+
+  private func startMemoryLogger(interval: TimeInterval = 10) {
+    stopMemoryLogger()
+    startMemoryPressureMonitor()
+    let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+    timer.schedule(deadline: .now(), repeating: interval)
+    timer.setEventHandler { [weak self] in
+      self?.logMemoryUsage()
+    }
+    memoryLogTimer = timer
+    timer.resume()
+  }
+
+  private func stopMemoryLogger() {
+    memoryLogTimer?.cancel()
+    memoryLogTimer = nil
+    memoryPressureSource?.cancel()
+    memoryPressureSource = nil
+    currentMemoryPressure = .normal
+  }
+
+  // Subscribes to kernel memory-pressure notifications. The OS publishes one
+  // of three levels (normal / warning / critical) — we mirror the latest into
+  // currentMemoryPressure so each log line carries the system's own label.
+  private func startMemoryPressureMonitor() {
+    let source = DispatchSource.makeMemoryPressureSource(
+      eventMask: [.normal, .warning, .critical],
+      queue: .global(qos: .utility)
+    )
+    source.setEventHandler { [weak self, weak source] in
+      guard let self = self, let source = source else { return }
+      self.currentMemoryPressure = source.data
+    }
+    memoryPressureSource = source
+    source.resume()
+  }
+
+
+  private func logMemoryUsage() {
+    var info = task_vm_info_data_t()
+    var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
+    let kerr = withUnsafeMutablePointer(to: &info) {
+      $0.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+        task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+      }
+    }
+    guard kerr == KERN_SUCCESS else {
+      appLogger.error("PacketTunnelProvider failed to read memory info: \(kerr)")
+      return
+    }
+    let mb = 1024.0 * 1024.0
+    let footprintMB = Double(info.phys_footprint) / mb
+    let residentMB = Double(info.resident_size) / mb
+    let peakMB = Double(info.resident_size_peak) / mb
+    let virtualMB = Double(info.virtual_size) / mb
+    let dirtyMB = Double(info.internal) / mb
+    let compressedMB = Double(info.compressed) / mb
+    // os_proc_available_memory: bytes remaining before iOS jetsams this process.
+    // Returns 0 on platforms / processes without a limit (e.g. macOS host app).
+    let availableBytes = os_proc_available_memory()
+    let availableMB = Double(availableBytes) / mb
+    let message = String(
+      format:
+        "PacketTunnelProvider memory [pressure=%u] — footprint: %.2f MB, available: %.2f MB, resident: %.2f MB, peak: %.2f MB, dirty: %.2f MB, compressed: %.2f MB, virtual: %.2f MB",
+      currentMemoryPressure.rawValue, footprintMB, availableMB, residentMB, peakMB, dirtyMB, compressedMB, virtualMB
+    )
+    switch currentMemoryPressure {
+    case .critical:
+      appLogger.info("\(message)")
+    case .warning:
+      appLogger.info("\(message)")
+    default:
+      appLogger.info("\(message)")
+    }
   }
 
   public override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?)

--- a/lantern-core/mobile/memory_logger.go
+++ b/lantern-core/mobile/memory_logger.go
@@ -1,0 +1,110 @@
+package mobile
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"runtime"
+	runtimeDebug "runtime/debug"
+	"sync"
+	"time"
+)
+
+// memoryLogInterval matches the iOS PacketTunnelProvider Swift memory logger
+// cadence so the Go-side and Swift-side log lines interleave at the same rate.
+const memoryLogInterval = 10 * time.Second
+
+const bytesPerMB = 1024.0 * 1024.0
+
+var (
+	memLogMu     sync.Mutex
+	memLogCancel context.CancelFunc
+)
+
+// startMemoryLogger begins periodic Go-runtime memory logging for the tunnel
+// (extension) process. It is the Go counterpart to the Swift memory logger in
+// PacketTunnelProvider: that one reports the whole extension process footprint
+// via Mach task_vm_info (phys_footprint), while this reports the Go runtime's
+// view from inside that same process. The Go heap is the largest mutable
+// contributor to phys_footprint, and iOS jetsams the entire Network Extension
+// when the footprint exceeds its tight memory cap — so correlating the two log
+// streams shows whether Go is what's pushing the process toward that limit.
+//
+// Started from StartIPCServer (tunnel start) and stopped from CloseIPCServer
+// (tunnel stop), mirroring the Swift logger's startTunnel/stopTunnel hooks.
+// Safe to call repeatedly: a start while already running is a no-op until the
+// matching stop.
+func startMemoryLogger() {
+	memLogMu.Lock()
+	defer memLogMu.Unlock()
+	if memLogCancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	memLogCancel = cancel
+	go func() {
+		ticker := time.NewTicker(memoryLogInterval)
+		defer ticker.Stop()
+		logMemStats() // log immediately, like the Swift timer's deadline: .now()
+		for {
+			select {
+			case <-ctx.Done():
+				slog.Debug("Stopping tunnel memory logger")
+				return
+			case <-ticker.C:
+				logMemStats()
+			}
+		}
+	}()
+}
+
+// stopMemoryLogger stops the goroutine started by startMemoryLogger. Safe to
+// call when the logger isn't running.
+func stopMemoryLogger() {
+	memLogMu.Lock()
+	defer memLogMu.Unlock()
+	if memLogCancel != nil {
+		memLogCancel()
+		memLogCancel = nil
+	}
+}
+
+// mbFromBytes converts a byte count to megabytes rounded to 2 decimals, matching
+// the "%.2f MB" formatting on the Swift side.
+func mbFromBytes(b uint64) float64 {
+	return math.Round(float64(b)/bytesPerMB*100) / 100
+}
+
+// logMemStats emits one Go-runtime memory snapshot. Field meanings:
+//   - heap_alloc: live heap objects (the working set Go can't release)
+//   - heap_inuse/heap_idle: bytes in in-use vs idle spans
+//   - heap_released: idle bytes already returned to the OS (lowers footprint)
+//   - stack_inuse: goroutine stacks
+//   - sys: total obtained from the OS (Go's contribution to process footprint)
+//   - next_gc: heap size that will trigger the next GC
+//   - mem_limit: the soft memory limit in effect (libbox.SetMemoryLimit sets
+//     this on mobile); 0 means no limit
+func logMemStats() {
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+
+	// SetMemoryLimit(-1) reads the current soft limit without changing it;
+	// math.MaxInt64 is the sentinel for "no limit".
+	var limitMB float64
+	if limit := runtimeDebug.SetMemoryLimit(-1); limit != math.MaxInt64 {
+		limitMB = math.Round(float64(limit)/bytesPerMB*100) / 100
+	}
+
+	slog.Info("[memory stats]",
+		"heap_alloc_mb", mbFromBytes(m.HeapAlloc),
+		"heap_inuse_mb", mbFromBytes(m.HeapInuse),
+		"heap_idle_mb", mbFromBytes(m.HeapIdle),
+		"heap_released_mb", mbFromBytes(m.HeapReleased),
+		"stack_inuse_mb", mbFromBytes(m.StackInuse),
+		"sys_mb", mbFromBytes(m.Sys),
+		"next_gc_mb", mbFromBytes(m.NextGC),
+		"mem_limit_mb", limitMB,
+		"num_gc", m.NumGC,
+		"num_goroutine", runtime.NumGoroutine(),
+	)
+}

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -305,7 +305,13 @@ func StartIPCServer(platform utils.PlatformInterface, opts *utils.Opts) error {
 		ipcBackend = be
 		ipcServer = ipc.NewServer(be, !common.IsMobile())
 		ipcClient = newLoopbackClient(be)
-		return struct{}{}, ipcServer.Start()
+		if err := ipcServer.Start(); err != nil {
+			return struct{}{}, err
+		}
+		// Start the Go-side memory logger for the tunnel process, mirroring the
+		// Swift PacketTunnelProvider logger. Stopped from CloseIPCServer.
+		startMemoryLogger()
+		return struct{}{}, nil
 	})
 	return err
 }
@@ -314,6 +320,7 @@ func CloseIPCServer() error {
 	_, err := utils.RunOffCgoStack(func() (struct{}, error) {
 		ipcMu.Lock()
 		defer ipcMu.Unlock()
+		stopMemoryLogger()
 		if ipcBackend != nil {
 			ipcBackend.Close()
 			ipcBackend = nil


### PR DESCRIPTION
This pull request introduces comprehensive memory usage logging for the iOS tunnel extension, with coordinated logging from both the Swift (PacketTunnelProvider) and Go (lantern-core) sides. The main goal is to monitor and correlate the Go runtime's memory usage with the overall process footprint, aiding in diagnosing memory pressure and potential jetsam events. The most important changes are:

**iOS Swift-side memory logging:**

* Added a periodic memory logger to `PacketTunnelProvider.swift` that records detailed process memory statistics and tracks system memory pressure events, starting and stopping with the tunnel lifecycle.

**Go runtime memory logging:**

* Introduced `memory_logger.go` to periodically log Go runtime memory stats (heap, stack, GC, soft memory limit, etc.), synchronized with the Swift logger's cadence for easy correlation.
* Updated `StartIPCServer` to start the Go-side memory logger when the tunnel starts, and `CloseIPCServer` to stop it when the tunnel stops, ensuring logs are only collected during the tunnel's active period. [[1]](diffhunk://#diff-29bc68e34649b32f3954f2c51b728288546c01dcd66496ba85a8b7fe22be5351L308-R314) [[2]](diffhunk://#diff-29bc68e34649b32f3954f2c51b728288546c01dcd66496ba85a8b7fe22be5351R323)