### PR TITLE
bump radiance - suppress all IPv6 traffic

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260608162135-44accff5187c
+	github.com/getlantern/radiance v0.0.0-20260608193139-ac5b3283d921
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -261,8 +261,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260608162135-44accff5187c h1:jIFixWVQjUS8NNR0reGLLrTB+9JEXEp1RSmN+eilrzY=
-github.com/getlantern/radiance v0.0.0-20260608162135-44accff5187c/go.mod h1:Y2xpDMl7hV4/kIk70ck0FymuCtl2TiPGPaq/sfdt00g=
+github.com/getlantern/radiance v0.0.0-20260608193139-ac5b3283d921 h1:UhrbT52SFZZ+0DNO194cSoTy8VlEc/b/84ORtxluDhg=
+github.com/getlantern/radiance v0.0.0-20260608193139-ac5b3283d921/go.mod h1:Y2xpDMl7hV4/kIk70ck0FymuCtl2TiPGPaq/sfdt00g=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Bumps `github.com/getlantern/radiance` to the `suppress-ipv6` branch (getlantern/radiance#517), which suppresses IPv6 inside the tunnel so applications fall back to IPv4.

## Why

On global-IPv6 networks, AAAA traffic for dual-stack sites was routed onto a v6 path that stalled with no fallback — surfacing as an endless spinner (e.g. YouTube video that never plays) while connected.

## What the bump brings (radiance)

- **DNS**: only `A` queries route to the fake-IP server; `AAAA` is answered with NODATA (NOERROR + no records) so clients see no v6 address and use IPv4.
- **Routing**: all IPv6 destinations (`::/0`) are rejected with the default method (ICMP unreachable / RST → Happy Eyeballs fails over to IPv4 at once), as a backstop for v6 that escapes AAAA suppression. Gated on the TUN having captured a v6 address.

## Note

Points at a radiance **branch** commit, not `main`. Depends on getlantern/radiance#517 — once that merges, re-bump to the resulting `main` pseudo-version before merging this.