### PR TITLE
Refresh config ablity 

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -147,6 +147,7 @@ enum class Methods(val method: String) {
     GetEnvVars("getEnvVars"),
     RunURLTests("runURLTests"),
     SendConfigRequest("sendConfigRequest"),
+    ClearTunnelCache("clearTunnelCache"),
 }
 
 class MethodHandler : FlutterPlugin,
@@ -1302,6 +1303,12 @@ class MethodHandler : FlutterPlugin,
             Methods.SendConfigRequest.method -> {
                 scope.handleResult(result, "send_config_request") {
                     Mobile.sendConfigRequest()
+                }
+            }
+
+            Methods.ClearTunnelCache.method -> {
+                scope.handleResult(result, "clear_tunnel_cache") {
+                    Mobile.clearTunnelCache()
                 }
             }
 

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1634,3 +1634,10 @@ msgstr "Couldn't check for updates"
 
 msgid "check_connection_and_retry"
 msgstr "Check your connection and try again"
+
+msgid "refresh_configuration"
+msgstr "Refresh Configuration"
+
+msgid "configuration_refreshed"
+msgstr "Configuration refreshed"
+

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1638,6 +1638,21 @@ msgstr "Check your connection and try again"
 msgid "refresh_configuration"
 msgstr "Refresh Configuration"
 
-msgid "configuration_refreshed"
-msgstr "Configuration refreshed"
+msgid "configuration_cleared"
+msgstr "Configuration cleared"
+
+msgid "turn_off_vpn"
+msgstr "Turn off VPN"
+
+msgid "turn_on_vpn"
+msgstr "Turn on VPN"
+
+msgid "turn_off_vpn_message"
+msgstr "The VPN needs to be off before you can refresh your configuration. Turn it off, then try again."
+
+msgid "configuration_message"
+msgstr "Your old configuration has been cleared. Turn the VPN on to automatically download the latest."
+
+
+
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260608162135-44accff5187c
+	github.com/getlantern/radiance v0.0.0-20260610231922-e9bfcdd8c0f9
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.42.0

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmI
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
 github.com/getlantern/radiance v0.0.0-20260608162135-44accff5187c h1:jIFixWVQjUS8NNR0reGLLrTB+9JEXEp1RSmN+eilrzY=
 github.com/getlantern/radiance v0.0.0-20260608162135-44accff5187c/go.mod h1:Y2xpDMl7hV4/kIk70ck0FymuCtl2TiPGPaq/sfdt00g=
+github.com/getlantern/radiance v0.0.0-20260610231922-e9bfcdd8c0f9 h1:9G+lTzV6GzCZsyEMHx8hZZ6YgZWFXuUGoDm5eyxJD84=
+github.com/getlantern/radiance v0.0.0-20260610231922-e9bfcdd8c0f9/go.mod h1:Y2xpDMl7hV4/kIk70ck0FymuCtl2TiPGPaq/sfdt00g=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/ios/Runner/Handlers/MethodHandler.swift
+++ b/ios/Runner/Handlers/MethodHandler.swift
@@ -302,6 +302,9 @@ class MethodHandler {
       case "sendConfigRequest":
         self.sendConfigRequest(result: result)
 
+      case "clearTunnelCache":
+        self.clearTunnelCache(result: result)
+
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -1224,6 +1227,18 @@ class MethodHandler {
       MobileSendConfigRequest(&error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "SEND_CONFIG_REQUEST_ERROR")
+        return
+      }
+      await MainActor.run { result("ok") }
+    }
+  }
+
+  func clearTunnelCache(result: @escaping FlutterResult) {
+    Task {
+      var error: NSError?
+      MobileClearTunnelCache(&error)
+      if let error {
+        await self.handleFlutterError(error, result: result, code: "CLEAR_TUNNEL_CACHE_ERROR")
         return
       }
       await MainActor.run { result("ok") }

--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -73,6 +73,7 @@ type App interface {
 	GetEnvVars() map[string]string
 	RunOfflineURLTests() error
 	UpdateConfig() error
+	ClearTunnelCache() error
 	ReferralAttachment(referralCode string) (bool, error)
 	UpdateLocale(locale string) error
 	UpdateTelemetryConsent(consent bool) error
@@ -575,6 +576,10 @@ func (lc *LanternCore) RunOfflineURLTests() error {
 
 func (lc *LanternCore) UpdateConfig() error {
 	return lc.client.UpdateConfig(lc.ctx)
+}
+
+func (lc *LanternCore) ClearTunnelCache() error {
+	return lc.client.ClearTunnelCache(lc.ctx)
 }
 
 /////////////////

--- a/lantern-core/ffi/ffi.go
+++ b/lantern-core/ffi/ffi.go
@@ -1076,6 +1076,20 @@ func updateConfig() *C.char {
 	})
 }
 
+//export clearTunnelCache
+func clearTunnelCache() *C.char {
+	return runOnGoStack(func() *C.char {
+		c, errStr := requireCore()
+		if errStr != nil {
+			return errStr
+		}
+		if err := c.ClearTunnelCache(); err != nil {
+			return SendError(err)
+		}
+		return C.CString("ok")
+	})
+}
+
 func main() {
 
 }

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -850,6 +850,14 @@ func SendConfigRequest() error {
 	})
 }
 
+// ClearTunnelCache clears the daemon's persisted tunnel cache (fakeip store,
+// rule-sets, rdrc). Mirrors the FFI `clearTunnelCache` export.
+func ClearTunnelCache() error {
+	return withCore(func(c lanterncore.Core) error {
+		return c.ClearTunnelCache()
+	})
+}
+
 // LogSubscription holds the cancellation handle for a TailLogs stream. Call
 // Cancel to stop receiving log entries.
 type LogSubscription struct {

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -854,6 +854,7 @@ func SendConfigRequest() error {
 // rule-sets, rdrc). Mirrors the FFI `clearTunnelCache` export.
 func ClearTunnelCache() error {
 	return withCore(func(c lanterncore.Core) error {
+		slog.Info("Clearing tunnel cache")
 		return c.ClearTunnelCache()
 	})
 }

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -851,7 +851,7 @@ func SendConfigRequest() error {
 }
 
 // ClearTunnelCache clears the daemon's persisted tunnel cache (fakeip store,
-// rule-sets, rdrc). Mirrors the FFI `clearTunnelCache` export.
+// rule-sets, rdrc).
 func ClearTunnelCache() error {
 	return withCore(func(c lanterncore.Core) error {
 		slog.Info("Clearing tunnel cache")

--- a/lib/features/support/support.dart
+++ b/lib/features/support/support.dart
@@ -3,10 +3,12 @@ import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:intl/intl.dart';
 import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/services/injection_container.dart' show sl;
 import 'package:lantern/core/utils/route_utils.dart';
 import 'package:lantern/core/utils/screen_utils.dart';
 import 'package:lantern/features/setting/follow_us.dart' hide FollowUs;
 import 'package:lantern/features/support/app_version.dart';
+import 'package:lantern/lantern/lantern_service.dart';
 
 @RoutePage(name: 'Support')
 class Support extends StatelessWidget {
@@ -40,11 +42,20 @@ class Support extends StatelessWidget {
                     onPressed: () => safePush(context, ReportIssue()),
                   ),
                   const DividerSpace(
-                      padding: EdgeInsets.symmetric(horizontal: 16)),
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                  ),
                   AppTile(
                     icon: Icons.code_outlined,
                     label: 'diagnostic_logs'.i18n,
                     onPressed: () => safePush(context, Logs()),
+                  ),
+                  const DividerSpace(
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                  ),
+                  AppTile(
+                    icon: Icons.refresh,
+                    label: 'refresh_configuration'.i18n,
+                    onPressed: () => onRefreshConfiguration(context),
                   ),
                 ],
               ),
@@ -62,7 +73,8 @@ class Support extends StatelessWidget {
                         UrlUtils.tryLaunchExternalUrl(context, Uri.parse(u)),
                   ),
                   const DividerSpace(
-                      padding: EdgeInsets.symmetric(horizontal: 16)),
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                  ),
                   AppTile.link(
                     icon: Icons.info_outlined,
                     label: 'frequently_asked_questions'.i18n,
@@ -71,7 +83,8 @@ class Support extends StatelessWidget {
                         UrlUtils.tryLaunchExternalUrl(context, Uri.parse(u)),
                   ),
                   const DividerSpace(
-                      padding: EdgeInsets.symmetric(horizontal: 16)),
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                  ),
                   AppTile.link(
                     icon: Icons.privacy_tip_outlined,
                     label: 'privacy_policy'.i18n,
@@ -80,7 +93,8 @@ class Support extends StatelessWidget {
                         UrlUtils.tryLaunchExternalUrl(context, Uri.parse(u)),
                   ),
                   const DividerSpace(
-                      padding: EdgeInsets.symmetric(horizontal: 16)),
+                    padding: EdgeInsets.symmetric(horizontal: 16),
+                  ),
                   AppTile.link(
                     icon: Icons.description_outlined,
                     label: 'terms_of_service'.i18n,
@@ -132,15 +146,25 @@ class Support extends StatelessWidget {
     showAppBottomSheet(
       context: context,
       title: 'follow_us'.i18n,
-      scrollControlDisabledMaxHeightRatio:
-          context.isSmallDevice ? 0.39.h : 0.3.h,
+      scrollControlDisabledMaxHeightRatio: context.isSmallDevice
+          ? 0.39.h
+          : 0.3.h,
       builder: (context, scrollController) {
         return Flexible(
-          child: FollowUsListView(
-            scrollController: scrollController,
-          ),
+          child: FollowUsListView(scrollController: scrollController),
         );
       },
+    );
+  }
+
+  Future<void> onRefreshConfiguration(BuildContext context) async {
+    final result = await sl<LanternService>().clearTunnelCache();
+    if (!context.mounted) return;
+    result.match(
+      (failure) => context.showSnackBarError(
+        'it_looks_like_something_went_wrong'.i18n,
+      ),
+      (_) => context.showSnackBar('configuration_refreshed'.i18n),
     );
   }
 }

--- a/lib/features/support/support.dart
+++ b/lib/features/support/support.dart
@@ -163,8 +163,12 @@ class Support extends ConsumerWidget {
     BuildContext context,
     WidgetRef ref,
   ) async {
+    // Clearing the tunnel cache requires the tunnel to be fully stopped, so
+    // only proceed when the VPN is disconnected. Any other state (connected,
+    // connecting, disconnecting, missingPermission, error) is treated as an
+    // active/in-transition tunnel and is blocked.
     final vpnStatus = ref.read(vpnProvider);
-    if (vpnStatus == VPNStatus.connected) {
+    if (vpnStatus != VPNStatus.disconnected) {
       AppDialog.dialog(
         context: context,
         title: 'turn_off_vpn'.i18n,

--- a/lib/features/support/support.dart
+++ b/lib/features/support/support.dart
@@ -1,6 +1,7 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:intl/intl.dart';
 import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/services/injection_container.dart' show sl;
@@ -8,14 +9,15 @@ import 'package:lantern/core/utils/route_utils.dart';
 import 'package:lantern/core/utils/screen_utils.dart';
 import 'package:lantern/features/setting/follow_us.dart' hide FollowUs;
 import 'package:lantern/features/support/app_version.dart';
+import 'package:lantern/features/vpn/provider/vpn_notifier.dart';
 import 'package:lantern/lantern/lantern_service.dart';
 
 @RoutePage(name: 'Support')
-class Support extends StatelessWidget {
+class Support extends ConsumerWidget {
   const Support({super.key});
 
   @override
-  Widget build(BuildContext context) {
+  Widget build(BuildContext context, WidgetRef ref) {
     return BaseScreen(
       title: toBeginningOfSentenceCase('support'.i18n),
       body: SafeArea(
@@ -55,7 +57,7 @@ class Support extends StatelessWidget {
                   AppTile(
                     icon: Icons.refresh,
                     label: 'refresh_configuration'.i18n,
-                    onPressed: () => onRefreshConfiguration(context),
+                    onPressed: () => onRefreshConfiguration(context, ref),
                   ),
                 ],
               ),
@@ -157,14 +159,63 @@ class Support extends StatelessWidget {
     );
   }
 
-  Future<void> onRefreshConfiguration(BuildContext context) async {
+  Future<void> onRefreshConfiguration(
+    BuildContext context,
+    WidgetRef ref,
+  ) async {
+    final vpnStatus = ref.read(vpnProvider);
+    if (vpnStatus == VPNStatus.connected) {
+      AppDialog.dialog(
+        context: context,
+        title: 'turn_off_vpn'.i18n,
+        content: 'turn_off_vpn_message'.i18n,
+        action: 'got_it'.i18n,
+      );
+      return;
+    }
+
     final result = await sl<LanternService>().clearTunnelCache();
     if (!context.mounted) return;
     result.match(
-      (failure) => context.showSnackBarError(
-        'it_looks_like_something_went_wrong'.i18n,
-      ),
-      (_) => context.showSnackBar('configuration_refreshed'.i18n),
+      (failure) =>
+          context.showSnackBarError('it_looks_like_something_went_wrong'.i18n),
+      (_) {
+        final textTheme = TextTheme.of(context);
+        AppDialog.customDialog(
+          context: context,
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: <Widget>[
+              SizedBox(height: defaultSize),
+              AppImage(
+                path: AppImagePaths.greenCheck,
+                width: 48,
+                useThemeColor: false,
+              ),
+              SizedBox(height: defaultSize),
+              Text(
+                'configuration_cleared'.i18n,
+                style: textTheme.headlineMedium,
+              ),
+              SizedBox(height: defaultSize),
+              Text('configuration_message'.i18n, style: textTheme.bodyMedium),
+            ],
+          ),
+          action: [
+            AppTextButton(
+              label: 'close'.i18n,
+              textColor: context.textSecondary,
+              onPressed: () => Navigator.of(context).pop(),
+            ),
+            AppTextButton(
+              label: 'turn_on_vpn'.i18n,
+              onPressed: () {
+                appRouter.popUntilRoot();
+              },
+            ),
+          ],
+        );
+      },
     );
   }
 }

--- a/lib/features/support/support.dart
+++ b/lib/features/support/support.dart
@@ -167,8 +167,12 @@ class Support extends ConsumerWidget {
     // only proceed when the VPN is disconnected. Any other state (connected,
     // connecting, disconnecting, missingPermission, error) is treated as an
     // active/in-transition tunnel and is blocked.
+    appLogger.info('Attempting to refresh configuration');
     final vpnStatus = ref.read(vpnProvider);
     if (vpnStatus != VPNStatus.disconnected) {
+      appLogger.warning(
+        'VPN is not disconnected (current status: $vpnStatus). Aborting configuration refresh.',
+      );
       AppDialog.dialog(
         context: context,
         title: 'turn_off_vpn'.i18n,
@@ -178,13 +182,21 @@ class Support extends ConsumerWidget {
       return;
     }
 
+    appLogger.info(
+      'VPN is disconnected. Proceeding with configuration refresh.',
+    );
     final result = await sl<LanternService>().clearTunnelCache();
     if (!context.mounted) return;
     result.match(
-      (failure) =>
-          context.showSnackBarError('it_looks_like_something_went_wrong'.i18n),
+      (failure) {
+        context.showSnackBarError('it_looks_like_something_went_wrong'.i18n);
+        appLogger.error('Failed to refresh configuration: $failure');
+      },
+
       (_) {
+        appLogger.info('Configuration refresh successful. Notifying user.');
         final textTheme = TextTheme.of(context);
+
         AppDialog.customDialog(
           context: context,
           content: Column(

--- a/lib/lantern/lantern_core_service.dart
+++ b/lib/lantern/lantern_core_service.dart
@@ -331,4 +331,6 @@ abstract class LanternCoreService {
   Future<Either<Failure, Unit>> runURLTests();
 
   Future<Either<Failure, Unit>> sendConfigRequest();
+
+  Future<Either<Failure, Unit>> clearTunnelCache();
 }

--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -1799,7 +1799,12 @@ class LanternFFIService implements LanternCoreService {
   Future<Either<Failure, Unit>> runURLTests() async {
     try {
       final result = await runInBackground<String>(() async {
-        return _ffiService.runURLTests().toDartString();
+        final resultPtr = _ffiService.runURLTests();
+        try {
+          return resultPtr.toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
       checkAPIError(result);
       return right(unit);
@@ -1813,7 +1818,12 @@ class LanternFFIService implements LanternCoreService {
   Future<Either<Failure, Unit>> sendConfigRequest() async {
     try {
       final result = await runInBackground<String>(() async {
-        return _ffiService.updateConfig().toDartString();
+        final resultPtr = _ffiService.updateConfig();
+        try {
+          return resultPtr.toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
       checkAPIError(result);
       return right(unit);
@@ -1827,7 +1837,12 @@ class LanternFFIService implements LanternCoreService {
   Future<Either<Failure, Unit>> clearTunnelCache() async {
     try {
       final result = await runInBackground<String>(() async {
-        return _ffiService.clearTunnelCache().toDartString();
+        final resultPtr = _ffiService.clearTunnelCache();
+        try {
+          return resultPtr.toDartString();
+        } finally {
+          _ffiService.freeCString(resultPtr);
+        }
       });
       checkAPIError(result);
       return right(unit);

--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -1822,6 +1822,20 @@ class LanternFFIService implements LanternCoreService {
       return Left(e.toFailure());
     }
   }
+
+  @override
+  Future<Either<Failure, Unit>> clearTunnelCache() async {
+    try {
+      final result = await runInBackground<String>(() async {
+        return _ffiService.clearTunnelCache().toDartString();
+      });
+      checkAPIError(result);
+      return right(unit);
+    } catch (e, st) {
+      appLogger.error('clearTunnelCache error', e, st);
+      return Left(e.toFailure());
+    }
+  }
 }
 
 void checkAPIError(dynamic result) {

--- a/lib/lantern/lantern_generated_bindings.dart
+++ b/lib/lantern/lantern_generated_bindings.dart
@@ -6436,6 +6436,17 @@ class LanternBindings {
       );
   late final _updateConfig = _updateConfigPtr
       .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
+  ffi.Pointer<ffi.Char> clearTunnelCache() {
+    return _clearTunnelCache();
+  }
+
+  late final _clearTunnelCachePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+        'clearTunnelCache',
+      );
+  late final _clearTunnelCache = _clearTunnelCachePtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
 }
 
 typedef va_list = ffi.Pointer<ffi.Char>;

--- a/lib/lantern/lantern_platform_service.dart
+++ b/lib/lantern/lantern_platform_service.dart
@@ -1688,4 +1688,15 @@ class LanternPlatformService implements LanternCoreService {
       return Left(e.toFailure());
     }
   }
+
+  @override
+  Future<Either<Failure, Unit>> clearTunnelCache() async {
+    try {
+      await _methodChannel.invokeMethod('clearTunnelCache');
+      return right(unit);
+    } catch (e, st) {
+      appLogger.error('clearTunnelCache error', e, st);
+      return Left(e.toFailure());
+    }
+  }
 }

--- a/lib/lantern/lantern_service.dart
+++ b/lib/lantern/lantern_service.dart
@@ -928,4 +928,12 @@ class LanternService implements LanternCoreService {
     }
     return _platformService.sendConfigRequest();
   }
+
+  @override
+  Future<Either<Failure, Unit>> clearTunnelCache() {
+    if (PlatformUtils.isFFISupported) {
+      return _ffiService.clearTunnelCache();
+    }
+    return _platformService.clearTunnelCache();
+  }
 }


### PR DESCRIPTION
This pull request adds a new "Refresh Configuration" feature that allows users to clear the VPN tunnel cache from the support screen in the app. This involves updates across the Flutter UI, platform channels (Android/iOS), and core backend to support the new operation, as well as new user-facing dialogs and translations.

**Feature: Refresh Configuration (Clear Tunnel Cache)**

* Added a "Refresh Configuration" option to the support screen UI, including user dialogs for success and error cases, and checks to ensure the VPN is disconnected before clearing configuration. [[1]](diffhunk://#diff-f256f4c13f5ea04e2d7a7a1aed74b2ecafbe93a365752de922a7e42e98c089c2R4-R20) [[2]](diffhunk://#diff-f256f4c13f5ea04e2d7a7a1aed74b2ecafbe93a365752de922a7e42e98c089c2L43-R61) [[3]](diffhunk://#diff-f256f4c13f5ea04e2d7a7a1aed74b2ecafbe93a365752de922a7e42e98c089c2L135-R216)
* Added new localized strings for the refresh configuration feature and its dialogs.

**Platform Integration**

* Implemented the `clearTunnelCache` method in the platform channels for both Android and iOS, wiring up the call from Flutter to the native implementations. [[1]](diffhunk://#diff-ca0ac366740a1dbedd6e767c52677cbee8ff5bd4b5d13a7e9d5075dc387ec0bfR150) [[2]](diffhunk://#diff-ca0ac366740a1dbedd6e767c52677cbee8ff5bd4b5d13a7e9d5075dc387ec0bfR1309-R1314) [[3]](diffhunk://#diff-b8d375d46b22447c9a4f12a2c9cad7e3c05b7509d27e8ba120a3075a2e44437aR305-R307) [[4]](diffhunk://#diff-b8d375d46b22447c9a4f12a2c9cad7e3c05b7509d27e8ba120a3075a2e44437aR1236-R1247)

**Core and FFI Support**

* Added `ClearTunnelCache` methods to the core Go backend, FFI bindings, and mobile interface, enabling the actual clearing of the tunnel cache. [[1]](diffhunk://#diff-62f35878f2bc3e51174e5c90579a40e547ce99ff63b5001d2d60d5186f726a12R76) [[2]](diffhunk://#diff-62f35878f2bc3e51174e5c90579a40e547ce99ff63b5001d2d60d5186f726a12R581-R584) [[3]](diffhunk://#diff-6fc1c9f8196232981f804da864f6713d6f5f13773354052a4a8717b78f3b1051R1079-R1092) [[4]](diffhunk://#diff-29bc68e34649b32f3954f2c51b728288546c01dcd66496ba85a8b7fe22be5351R853-R860)
* Exposed the new method through the Dart FFI and platform service layers, and updated the main service interface to support it. [[1]](diffhunk://#diff-12b09c9d4421c06b821b2848f66667ab44424903b0c791ec367c6bced6c0cb10R334-R335) [[2]](diffhunk://#diff-227189b7c829f3be2df7c6d805aab749e10b0aa3c5b8354bf0f1d8077cfb90f8R1825-R1838) [[3]](diffhunk://#diff-88fa62a1bf69eac4449a79ad57f6aa60eaab6405a09ab5787b1935b850d61651R6439-R6449) [[4]](diffhunk://#diff-3aed161ed2c507aa1efbe07e6ef752bdbbe58510e8b23f53d6319852277e71b3R1691-R1701) [[5]](diffhunk://#diff-27a18f6b1ade6150dafdd1dfd6fca5dde04abdaf5df82fb2ea26d386df0f4d4bR931-R938)