### PR TITLE
Avoid StoreKit product lookups during iOS startup

### DIFF
--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -54,6 +54,9 @@ class AppPurchase {
   // emit an empty stream event the way Play Billing does).
   bool _restoreReceivedAny = false;
 
+  /// Starts listening for store purchase updates without fetching product
+  /// details. Product lookup stays user-initiated to keep StoreKit out of the
+  /// normal app launch path on iOS.
   void init() {
     if (!_canInitializeStorePurchases()) {
       return;
@@ -68,11 +71,21 @@ class AppPurchase {
       onDone: _updateStreamOnDone,
       onError: _updateStreamOnError,
     );
-    unawaited(
-      fetchSubscriptions().catchError((Object e, StackTrace st) {
-        appLogger.error('[AppPurchase] init: fetchSubscriptions failed', e, st);
-      }),
+  }
+
+  Future<void> resumePendingPurchasesIfNeeded() async {
+    if (!Platform.isIOS) {
+      return;
+    }
+    final pending = await _loadPendingPurchasePlans();
+    if (pending.isEmpty) {
+      appLogger.debug('[AppPurchase] No pending iOS purchases to resume');
+      return;
+    }
+    appLogger.info(
+      '[AppPurchase] Pending iOS purchase metadata found; starting purchase listener',
     );
+    await _ensurePurchaseStreamReady();
   }
 
   bool _canInitializeStorePurchases() {
@@ -100,31 +113,31 @@ class AppPurchase {
     return allowed;
   }
 
-  Future<bool> _initPlayBillingIfAllowed() async {
+  Future<bool> _ensurePurchaseStreamReady() async {
     appLogger.info(
-      '[AppPurchase] _initPlayBillingIfAllowed: '
+      '[AppPurchase] _ensurePurchaseStreamReady: '
       'country=${CountryCode.current}, isKnown=${CountryCode.isKnown}, '
       'subscribed=${_subscription != null}',
     );
     init();
     if (_subscription != null) {
-      appLogger.info('[AppPurchase] _initPlayBillingIfAllowed: ready');
+      appLogger.info('[AppPurchase] _ensurePurchaseStreamReady: ready');
       return true;
     }
     if (Platform.isAndroid && !CountryCode.isKnown) {
       appLogger.info(
-        '[AppPurchase] _initPlayBillingIfAllowed: country unknown, '
+        '[AppPurchase] _ensurePurchaseStreamReady: country unknown, '
         'waiting for country-code event…',
       );
       final known = await CountryCode.waitUntilKnown();
       appLogger.info(
-        '[AppPurchase] _initPlayBillingIfAllowed: waitUntilKnown returned '
+        '[AppPurchase] _ensurePurchaseStreamReady: waitUntilKnown returned '
         '$known (country=${CountryCode.current}); retrying init',
       );
       init();
     }
     final ready = _subscription != null;
-    appLogger.info('[AppPurchase] _initPlayBillingIfAllowed: ready=$ready');
+    appLogger.info('[AppPurchase] _ensurePurchaseStreamReady: ready=$ready');
     return ready;
   }
 
@@ -230,7 +243,7 @@ class AppPurchase {
     // Store the exact plan id user chose (ex: "1y-usd-10")
     _pendingPlanId = plan;
 
-    if (!await _initPlayBillingIfAllowed()) {
+    if (!await _ensurePurchaseStreamReady()) {
       _onError?.call(
         "Unable to load App Store products. Check your network and try again.",
       );
@@ -297,7 +310,7 @@ class AppPurchase {
     _restoreReceivedAny = false;
     _pendingPlanId = null;
 
-    if (!await _initPlayBillingIfAllowed()) {
+    if (!await _ensurePurchaseStreamReady()) {
       _isRestoreFlow = false;
       final onError = _onError;
       clearCallbacks();

--- a/lib/core/services/app_purchase.dart
+++ b/lib/core/services/app_purchase.dart
@@ -73,21 +73,6 @@ class AppPurchase {
     );
   }
 
-  Future<void> resumePendingPurchasesIfNeeded() async {
-    if (!Platform.isIOS) {
-      return;
-    }
-    final pending = await _loadPendingPurchasePlans();
-    if (pending.isEmpty) {
-      appLogger.debug('[AppPurchase] No pending iOS purchases to resume');
-      return;
-    }
-    appLogger.info(
-      '[AppPurchase] Pending iOS purchase metadata found; starting purchase listener',
-    );
-    await _ensurePurchaseStreamReady();
-  }
-
   bool _canInitializeStorePurchases() {
     if (PlatformUtils.isDesktop) {
       appLogger.debug('[AppPurchase] Skipping init: desktop platform');
@@ -202,7 +187,7 @@ class AppPurchase {
     }
 
     final error = StateError(
-      'Unable to load App Store products after $maxAttempts attempts',
+      'Unable to load in-app purchase products after $maxAttempts attempts',
     );
     //  Safely complete the completer with an error, if it is still pending.
     if (_productsLoadedCompleter != null &&
@@ -245,7 +230,7 @@ class AppPurchase {
 
     if (!await _ensurePurchaseStreamReady()) {
       _onError?.call(
-        "Unable to load App Store products. Check your network and try again.",
+        "Unable to access in-app purchases. Check your network and try again.",
       );
       return;
     }
@@ -254,7 +239,7 @@ class AppPurchase {
       await _waitForProducts();
     } catch (_) {
       _onError?.call(
-        "Unable to load App Store products. Check your network and try again.",
+        "Unable to load in-app purchase products. Check your network and try again.",
       );
       return;
     }
@@ -315,7 +300,7 @@ class AppPurchase {
       final onError = _onError;
       clearCallbacks();
       onError?.call(
-        "Unable to load App Store products. Check your network and try again.",
+        "Unable to access in-app purchases. Check your network and try again.",
       );
       return;
     }

--- a/lib/core/services/injection_container.dart
+++ b/lib/core/services/injection_container.dart
@@ -1,5 +1,3 @@
-import 'dart:async';
-
 import 'package:get_it/get_it.dart';
 import 'package:lantern/core/services/app_purchase.dart';
 import 'package:lantern/core/services/local_storage_service.dart';
@@ -49,18 +47,11 @@ Future<void> injectServices() async {
   appLogger.debug('Registering AppPurchase...');
   final appPurchase = AppPurchase();
   sl.registerSingleton<AppPurchase>(appPurchase);
-  unawaited(
-    appPurchase.resumePendingPurchasesIfNeeded().catchError((
-      Object e,
-      StackTrace st,
-    ) {
-      appLogger.error(
-        '[AppPurchase] Failed to resume pending purchases',
-        e,
-        st,
-      );
-    }),
-  );
+  if (PlatformUtils.isIOS) {
+    // StoreKit can deliver pending transaction updates at launch; init()
+    // only subscribes to the stream and does not fetch product details.
+    appPurchase.init();
+  }
   appLogger.debug('AppPurchase registered');
 
   sl.registerSingleton<LanternFFIService>(

--- a/lib/core/services/injection_container.dart
+++ b/lib/core/services/injection_container.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:get_it/get_it.dart';
 import 'package:lantern/core/services/app_purchase.dart';
 import 'package:lantern/core/services/local_storage_service.dart';
@@ -44,12 +46,21 @@ Future<void> injectServices() async {
   );
   sl.registerSingleton<LanternPlatformService>(LanternPlatformService());
 
-  appLogger.debug('Initializing AppPurchase...');
+  appLogger.debug('Registering AppPurchase...');
   final appPurchase = AppPurchase();
   sl.registerSingleton<AppPurchase>(appPurchase);
-  if (!PlatformUtils.isAndroid) {
-    appPurchase.init();
-  }
+  unawaited(
+    appPurchase.resumePendingPurchasesIfNeeded().catchError((
+      Object e,
+      StackTrace st,
+    ) {
+      appLogger.error(
+        '[AppPurchase] Failed to resume pending purchases',
+        e,
+        st,
+      );
+    }),
+  );
   appLogger.debug('AppPurchase registered');
 
   sl.registerSingleton<LanternFFIService>(


### PR DESCRIPTION
Keeps StoreKit product queries out of the normal iOS launch path while still initializing purchase, restore, and pending purchase recovery flows when they are actually needed