### PR TITLE
Fix Windows report issue and pro account routing

### DIFF
--- a/lantern-core/ffi/ffi.go
+++ b/lantern-core/ffi/ffi.go
@@ -341,7 +341,7 @@ func reportIssue(
 			logPath,
 			attachmentsJSON,
 		); err != nil {
-			return C.CString(fmt.Sprintf("error reporting issue: %v", err))
+			return SendError(fmt.Errorf("error reporting issue: %w", err))
 		}
 		return C.CString("ok")
 	})

--- a/lib/core/utils/pro_utils.dart
+++ b/lib/core/utils/pro_utils.dart
@@ -18,9 +18,17 @@ bool shouldShowProAccountSetupDialog({
 
 Future<void> openAccountOrProAccountSetup({
   required BuildContext context,
-  required UserResponseModel user,
+  required UserResponseModel? user,
   required bool userLoggedIn,
 }) async {
+  if (user == null) {
+    appLogger.warning(
+      'Unable to open account because user data is unavailable',
+    );
+    context.showSnackBarError('it_looks_like_something_went_wrong'.i18n);
+    return;
+  }
+
   final userData = user.legacyUserData;
   if (shouldShowProAccountSetupDialog(user: user, userLoggedIn: userLoggedIn)) {
     await showProAccountFlowDialog(

--- a/lib/core/utils/pro_utils.dart
+++ b/lib/core/utils/pro_utils.dart
@@ -1,5 +1,37 @@
 import 'package:flutter/material.dart';
 import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/extensions/user_data.dart';
+import 'package:lantern/core/models/user.dart';
+
+bool hasRegisteredProAccount(UserResponseModel? user) {
+  final userData = user?.legacyUserData;
+  return userData != null && userData.isPro && userData.unpassRegistered;
+}
+
+bool shouldShowProAccountSetupDialog({
+  required UserResponseModel user,
+  required bool userLoggedIn,
+}) {
+  final userData = user.legacyUserData;
+  return userData.isPro && !userLoggedIn && !userData.unpassRegistered;
+}
+
+Future<void> openAccountOrProAccountSetup({
+  required BuildContext context,
+  required UserResponseModel user,
+  required bool userLoggedIn,
+}) async {
+  final userData = user.legacyUserData;
+  if (shouldShowProAccountSetupDialog(user: user, userLoggedIn: userLoggedIn)) {
+    await showProAccountFlowDialog(
+      context: context,
+      hasEmail: userData.email.isNotEmpty,
+    );
+    return;
+  }
+
+  appRouter.push(Account());
+}
 
 Future<void> showProAccountFlowDialog({
   required BuildContext context,
@@ -22,9 +54,9 @@ Future<void> showProAccountFlowDialog({
           hasEmail
               ? 'set_account_password_message'.i18n
               : 'update_pro_account_message'.i18n,
-          style: Theme.of(context).textTheme.bodySmall!.copyWith(
-                color: context.textSecondary,
-              ),
+          style: Theme.of(
+            context,
+          ).textTheme.bodySmall!.copyWith(color: context.textSecondary),
         ),
       ],
     ),

--- a/lib/features/home/home.dart
+++ b/lib/features/home/home.dart
@@ -4,7 +4,6 @@ import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lantern/core/common/app_text_styles.dart';
-import 'package:lantern/core/extensions/user_data.dart';
 import 'package:lantern/core/models/feature_flags.dart';
 import 'package:lantern/core/utils/pro_utils.dart';
 import 'package:lantern/core/widgets/info_row.dart';
@@ -122,18 +121,15 @@ class _HomeState extends ConsumerState<Home> {
               onPressed: () async {
                 final localUser = ref.read(homeProvider).value;
                 final userSignedIn = ref.read(appSettingProvider).userLoggedIn;
-                final email = localUser!.legacyUserData.email;
-                final isPro = localUser.legacyUserData.isPro;
-                if (isPro && !userSignedIn) {
-                  // this means user has pro account but not signed in
-                  await showProAccountFlowDialog(
-                    context: context,
-                    hasEmail: email.isNotEmpty,
-                  );
+                if (localUser == null) {
+                  appRouter.push(const SignInEmail());
                   return;
                 }
-
-                appRouter.push(Account());
+                await openAccountOrProAccountSetup(
+                  context: context,
+                  user: localUser,
+                  userLoggedIn: userSignedIn,
+                );
               },
             )
           else if (!userLoggedIn)

--- a/lib/features/home/home.dart
+++ b/lib/features/home/home.dart
@@ -121,10 +121,6 @@ class _HomeState extends ConsumerState<Home> {
               onPressed: () async {
                 final localUser = ref.read(homeProvider).value;
                 final userSignedIn = ref.read(appSettingProvider).userLoggedIn;
-                if (localUser == null) {
-                  appRouter.push(const SignInEmail());
-                  return;
-                }
                 await openAccountOrProAccountSetup(
                   context: context,
                   user: localUser,

--- a/lib/features/setting/setting.dart
+++ b/lib/features/setting/setting.dart
@@ -293,11 +293,6 @@ class _SettingState extends ConsumerState<Setting>
 
       case _SettingType.account:
         final user = ref.read(homeProvider).value;
-        if (user == null) {
-          appRouter.push(const SignInEmail());
-          return;
-        }
-
         final userSignedIn = ref.read(appSettingProvider).userLoggedIn;
         await openAccountOrProAccountSetup(
           context: context,

--- a/lib/features/setting/setting.dart
+++ b/lib/features/setting/setting.dart
@@ -2,7 +2,6 @@ import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lantern/core/common/common.dart';
-import 'package:lantern/core/extensions/user_data.dart';
 import 'package:lantern/core/localization/localization_constants.dart';
 import 'package:lantern/core/updater/updater.dart';
 import 'package:lantern/core/utils/pro_utils.dart';
@@ -62,9 +61,7 @@ class _SettingState extends ConsumerState<Setting>
 
     final appSetting = ref.watch(appSettingProvider);
 
-    final hasProSession =
-        (user?.legacyUserData.isPro ?? false) &&
-        (user?.legacyUserData.unpassRegistered ?? false);
+    final hasProSession = hasRegisteredProAccount(user);
 
     final isAuthenticated = appSetting.userLoggedIn || hasProSession;
 
@@ -302,17 +299,11 @@ class _SettingState extends ConsumerState<Setting>
         }
 
         final userSignedIn = ref.read(appSettingProvider).userLoggedIn;
-        final email = user.legacyUserData.email;
-        final isPro = user.legacyUserData.isPro;
-        if (isPro && !userSignedIn) {
-          await showProAccountFlowDialog(
-            context: context,
-            hasEmail: email.isNotEmpty,
-          );
-          return;
-        }
-
-        appRouter.push(Account());
+        await openAccountOrProAccountSetup(
+          context: context,
+          user: user,
+          userLoggedIn: userSignedIn,
+        );
         break;
       case _SettingType.vpnSetting:
         appRouter.push(VPNSetting());

--- a/test/core/utils/pro_utils_test.dart
+++ b/test/core/utils/pro_utils_test.dart
@@ -33,7 +33,7 @@ void main() {
       expect(hasRegisteredProAccount(null), isFalse);
     });
 
-    test('does not show setup dialog for registered Pro accounts', () {
+    test('shows setup only for unregistered signed-out Pro accounts', () {
       expect(
         shouldShowProAccountSetupDialog(user: user(), userLoggedIn: false),
         isTrue,

--- a/test/core/utils/pro_utils_test.dart
+++ b/test/core/utils/pro_utils_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/models/user.dart';
+import 'package:lantern/core/utils/pro_utils.dart';
+
+void main() {
+  group('Pro account helpers', () {
+    UserResponseModel user({
+      String userLevel = 'pro',
+      bool unpassRegistered = false,
+    }) {
+      return UserResponseModel(
+        legacyID: 1,
+        legacyToken: 'token',
+        emailConfirmed: true,
+        success: true,
+        legacyUserData: UserDataModel(
+          email: 'person@example.com',
+          userLevel: userLevel,
+          unpassRegistered: unpassRegistered,
+        ),
+      );
+    }
+
+    test('detects locally registered Pro accounts', () {
+      expect(hasRegisteredProAccount(user(unpassRegistered: true)), isTrue);
+      expect(hasRegisteredProAccount(user()), isFalse);
+      expect(
+        hasRegisteredProAccount(
+          user(userLevel: 'free', unpassRegistered: true),
+        ),
+        isFalse,
+      );
+      expect(hasRegisteredProAccount(null), isFalse);
+    });
+
+    test('does not show setup dialog for registered Pro accounts', () {
+      expect(
+        shouldShowProAccountSetupDialog(user: user(), userLoggedIn: false),
+        isTrue,
+      );
+      expect(
+        shouldShowProAccountSetupDialog(
+          user: user(unpassRegistered: true),
+          userLoggedIn: false,
+        ),
+        isFalse,
+      );
+      expect(
+        shouldShowProAccountSetupDialog(user: user(), userLoggedIn: true),
+        isFalse,
+      );
+    });
+  });
+}


### PR DESCRIPTION
- Return structured FFI errors from desktop report submission so failed Freshdesk submissions are surfaced instead of shown as successfully submitted.
- Reuse the registered Pro account state when opening Account from Home/Settings, so users who already have a password are not incorrectly prompted to set one again.