### PR TITLE
update radiance to kindling fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260611152530-ccc35dc511ac
+	github.com/getlantern/radiance v0.0.0-20260611191533-ce4b0859dcff
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.42.0
@@ -171,7 +171,7 @@ require (
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
 	github.com/getlantern/domainfront v0.0.0-20260419161617-0bff0b2169f4 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840 // indirect
-	github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050 // indirect
+	github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a // indirect
 	github.com/getlantern/lantern-box v0.0.88 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect

--- a/go.sum
+++ b/go.sum
@@ -247,6 +247,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840 h1:/YhIurj1
 github.com/getlantern/keepcurrent v0.0.0-20260608000050-6b50f5857840/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050 h1:fIZoAaS6SCpH+QqlkAsYsIKI1jNJ1k12vGqY8lmAbso=
 github.com/getlantern/kindling v0.0.0-20260607234336-5372ea728050/go.mod h1:9EDX+ZFoMVcd8M14LeE7ULn/TRuV9g5GijNUDgJyw2A=
+github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a h1:w62TGPHwGqPDKq43pbwOkbvCofMY4Ldd5d17QBF9jnY=
+github.com/getlantern/kindling v0.0.0-20260611181428-9a360f63ad5a/go.mod h1:9EDX+ZFoMVcd8M14LeE7ULn/TRuV9g5GijNUDgJyw2A=
 github.com/getlantern/lantern-box v0.0.88 h1:A+K417P/+1IMaI0NyEsyJLDY7xlk/faKpAgRI+WXyB0=
 github.com/getlantern/lantern-box v0.0.88/go.mod h1:7/V3MIU6+5zt4Ybg06rRJI0Yi/WSfqUfp8wWnk5ofDs=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
@@ -263,6 +265,8 @@ github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmI
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
 github.com/getlantern/radiance v0.0.0-20260611152530-ccc35dc511ac h1:BVpoa3fxz7SO3E8n2LIgK4/3hLEBnUowVO3fHFy2ipI=
 github.com/getlantern/radiance v0.0.0-20260611152530-ccc35dc511ac/go.mod h1:Y2xpDMl7hV4/kIk70ck0FymuCtl2TiPGPaq/sfdt00g=
+github.com/getlantern/radiance v0.0.0-20260611191533-ce4b0859dcff h1:OdIHMxeymhht0pMqL/U5UkTkKk48m5syshJ/JYZBGrM=
+github.com/getlantern/radiance v0.0.0-20260611191533-ce4b0859dcff/go.mod h1:RFwgB4YGjdJe071NqMqz5q0gXRvyqfofyxfj/0Ag344=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
This pull request updates dependencies in the `go.mod` file to newer versions for `github.com/getlantern/radiance` and `github.com/getlantern/kindling`. These updates help keep the project up-to-date with the latest improvements and bug fixes from these libraries.

Dependency updates:

* Updated `github.com/getlantern/radiance` to version `v0.0.0-20260611191533-ce4b0859dcff` to incorporate the latest changes and fixes.
* Updated `github.com/getlantern/kindling` (indirect dependency) to version `v0.0.0-20260611181428-9a360f63ad5a` for improved compatibility and recent updates.