### PR TITLE
[stealth 1/4] build profile + flag plumbing

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -12,6 +12,28 @@ on:
       installer_base_name:
         required: true
         type: string
+      android_identity_seed:
+        required: false
+        type: string
+      stealth_leakage_mode:
+        description: "Optional stealth leakage scan mode, for example stealth or stealth-novpn"
+        required: false
+        type: string
+        default: ""
+      obfuscate_go:
+        description: "Build Android Go/native libraries through garble"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GRADLE_PROPERTIES:
+        required: true
+      APP_ENV:
+        required: true
+      KEYSTORE:
+        required: true
+      STEALTH_GARBLE_SEED:
+        required: false
 
 jobs:
   build-android:
@@ -128,13 +150,57 @@ jobs:
         env:
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
 
+      - name: Run stealth manifest filter tests
+        run: make stealth-manifest-filter-test
+
+      - name: Install garble
+        if: ${{ inputs.obfuscate_go }}
+        run: make install-garble
+
+      - name: Build Android obfuscated (APK + AAB)
+        if: ${{ inputs.obfuscate_go }}
+        run: make android-release-ci-obfuscated
+        env:
+          BUILD_TYPE: ${{ inputs.build_type }}
+          VERSION: ${{ inputs.version }}
+          INSTALLER_NAME: ${{ inputs.installer_base_name }}
+          ANDROID_IDENTITY_SEED: ${{ inputs.android_identity_seed }}
+          GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
+          STEALTH_GARBLE_SEED: ${{ secrets.STEALTH_GARBLE_SEED }}
+
       - name: Build Android (APK + AAB)
+        if: ${{ !inputs.obfuscate_go }}
         run: make android-release-ci
         env:
           BUILD_TYPE: ${{ inputs.build_type }}
           VERSION: ${{ inputs.version }}
           INSTALLER_NAME: ${{ inputs.installer_base_name }}
+          ANDROID_IDENTITY_SEED: ${{ inputs.android_identity_seed }}
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
+
+      - name: Stealth leakage check
+        id: stealth_leakage_check
+        if: ${{ inputs.stealth_leakage_mode != '' }}
+        shell: bash
+        run: |
+          set -o pipefail
+          : > stealth-leakage-report.txt
+          make stealth-leakage-check 2>&1 | tee stealth-leakage-report.txt
+        env:
+          STEALTH_LEAKAGE_MODE: ${{ inputs.stealth_leakage_mode }}
+          STEALTH_LEAKAGE_MISSING_OK: "0"
+          STEALTH_LEAKAGE_PATHS: >-
+            ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.apk
+            ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}.aab
+
+      - name: Upload stealth leakage report
+        if: ${{ always() && inputs.stealth_leakage_mode != '' && steps.stealth_leakage_check.outcome != 'skipped' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: stealth-leakage-report
+          path: stealth-leakage-report.txt
+          if-no-files-found: error
+          retention-days: 14
 
       - name: Upload Android APK
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,15 @@ on:
         required: false
         type: boolean
         default: false
+      stealth_leakage_mode:
+        description: "Run Android stealth leakage scanner for manual Android builds"
+        required: false
+        type: choice
+        options:
+          - none
+          - stealth
+          - stealth-novpn
+        default: none
 
 env:
   # Scheduled nightly store uploads run on these UTC weekdays. Configure via
@@ -81,6 +90,7 @@ jobs:
       is_test_run: ${{ steps.meta.outputs.is_test_run }}
       publish_mobile_stores: ${{ steps.meta.outputs.publish_mobile_stores }}
       smoke_enable_ip_check: ${{ steps.meta.outputs.smoke_enable_ip_check }}
+      stealth_leakage_mode: ${{ steps.meta.outputs.stealth_leakage_mode }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -257,6 +267,13 @@ jobs:
           fi
 
           SMOKE_ENABLE_IP_CHECK="false"
+          STEALTH_LEAKAGE_MODE=""
+          if [[ "$EVENT" == "workflow_dispatch" ]]; then
+            requested_stealth_leakage_mode="${{ github.event.inputs.stealth_leakage_mode }}"
+            if [[ "$requested_stealth_leakage_mode" != "none" ]]; then
+              STEALTH_LEAKAGE_MODE="$requested_stealth_leakage_mode"
+            fi
+          fi
 
           echo "Build Configuration:"
           echo "  Event:         $EVENT"
@@ -277,6 +294,7 @@ jobs:
           echo "is_test_run=$IS_TEST_RUN" >> $GITHUB_OUTPUT
           echo "publish_mobile_stores=$PUBLISH_MOBILE_STORES" >> $GITHUB_OUTPUT
           echo "smoke_enable_ip_check=$SMOKE_ENABLE_IP_CHECK" >> $GITHUB_OUTPUT
+          echo "stealth_leakage_mode=$STEALTH_LEAKAGE_MODE" >> $GITHUB_OUTPUT
 
       - name: Update pubspec.yaml version
         shell: bash
@@ -421,6 +439,7 @@ jobs:
       version: ${{ needs.set-metadata.outputs.version }}
       build_type: ${{ needs.set-metadata.outputs.build_type }}
       installer_base_name: ${{ needs.set-metadata.outputs.installer_base_name }}
+      stealth_leakage_mode: ${{ needs.set-metadata.outputs.stealth_leakage_mode }}
 
   release-create:
     needs: set-metadata

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,6 +105,7 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
+          REQUESTED_STEALTH_LEAKAGE_MODE: ${{ github.event.inputs.stealth_leakage_mode }}
         run: |
           EVENT="${{ github.event_name }}"
           REQUEST_MOBILE_STORE_PUBLISH="false"
@@ -269,10 +270,15 @@ jobs:
           SMOKE_ENABLE_IP_CHECK="false"
           STEALTH_LEAKAGE_MODE=""
           if [[ "$EVENT" == "workflow_dispatch" ]]; then
-            requested_stealth_leakage_mode="${{ github.event.inputs.stealth_leakage_mode }}"
-            if [[ "$requested_stealth_leakage_mode" != "none" ]]; then
-              STEALTH_LEAKAGE_MODE="$requested_stealth_leakage_mode"
-            fi
+            requested_stealth_leakage_mode="${REQUESTED_STEALTH_LEAKAGE_MODE:-none}"
+            case "$requested_stealth_leakage_mode" in
+              none|'') ;;
+              stealth|stealth-novpn) STEALTH_LEAKAGE_MODE="$requested_stealth_leakage_mode" ;;
+              *)
+                echo "Error: invalid stealth_leakage_mode '$requested_stealth_leakage_mode'" >&2
+                exit 1
+                ;;
+            esac
           fi
 
           echo "Build Configuration:"

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Miscellaneous
 *.class
+*.apk
+*.so
 *.log
 *.pyc
 *.swp

--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,11 @@ ifeq ($(strip $(APP_VERSION_PUBSPEC)),)
 $(error APP_VERSION_PUBSPEC is empty; export APP_VERSION (e.g. "9.0.25+459") or ensure pubspec.yaml contains a `version:` line)
 endif
 EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'
+STEALTH_GO_IMPORT_PATH := github.com/getlantern/lantern/lantern-core
+STEALTH_GO_LOG_LEVEL ?= warn
+STEALTH_GO_LDFLAGS := $(if $(filter stealth stealth-%,$(BUILD_TYPE)),-X '$(STEALTH_GO_IMPORT_PATH).StealthBuild=true' -X '$(STEALTH_GO_IMPORT_PATH).StealthLogLevel=$(STEALTH_GO_LOG_LEVEL)')
+GO_EXTRA_LDFLAGS := $(strip $(EXTRA_LDFLAGS) $(STEALTH_GO_LDFLAGS))
+LANTERND_EXTRA_LDFLAGS := $(EXTRA_LDFLAGS)
 
 DARWIN_APP_NAME := $(CAPITALIZED_APP).app
 DARWIN_LIB := $(LANTERN_LIB_NAME).dylib
@@ -105,6 +110,7 @@ LINUX_INSTALLER_RPM := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYP
 LINUX_INSTALLER_ARCH := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE))$(LINUX_PACKAGE_ARCH_SUFFIX).pkg.tar.zst
 LANTERND := lanternd
 LANTERND_SRC := $(RADIANCE_REPO)/cmd/lanternd
+LANTERND_SERVICE_LOG_LEVEL ?= $(if $(filter stealth stealth-%,$(BUILD_TYPE)),warn,trace)
 LANTERND_LINUX_AMD64 := $(BIN_DIR)/linux-amd64/$(LANTERND)
 LANTERND_LINUX_ARM64 := $(BIN_DIR)/linux-arm64/$(LANTERND)
 LINUX_BUNDLE_DIR_X64 := build/linux/x64/release/bundle
@@ -118,10 +124,12 @@ ifeq ($(OS),Windows_NT)
   MKDIR_P = $(PS) "New-Item -ItemType Directory -Force -Path '$(1)' | Out-Null"
   COPY_FILE = $(PS) "Copy-Item -Force -LiteralPath '$(1)' -Destination '$(2)'"
   RM_RF = $(PS) "Remove-Item -Recurse -Force -LiteralPath '$(1)'"
+  WRITE_TEXT_FILE = $(PS) "Set-Content -LiteralPath '$(2)' -Value '$(1)' -Encoding ASCII"
 else
   MKDIR_P = mkdir -p -- '$(1)'
   COPY_FILE = cp -f -- '$(1)' '$(2)'
   RM_RF = rm -rf -- '$(1)'
+  WRITE_TEXT_FILE = printf '%s\n' '$(1)' > '$(2)'
 endif
 
 LANTERND_WINDOWS_AMD64 := $(BIN_DIR)/windows-amd64/$(LANTERND).exe
@@ -157,8 +165,15 @@ ANDROID_AAB_TARGET_PLATFORMS := android-arm64
 ANDROID_TARGET_PLATFORMS := $(ANDROID_AAB_TARGET_PLATFORMS)
 ANDROID_RELEASE_APK := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE)).apk
 ANDROID_RELEASE_AAB := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE)).aab
+ANDROID_STEALTH_NOVPN_APK := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE))-stealth-novpn.apk
+ANDROID_STEALTH_NOVPN_AAB := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE))-stealth-novpn.aab
 ANDROID_MAPPING_SRC := build/app/outputs/mapping/release/mapping.txt
 ANDROID_SYMBOLS_SRC := build/app/outputs/native-debug-symbols/release/native-debug-symbols.zip
+PYTHON ?= python3
+STEALTH_LEAKAGE_MODE ?= stealth
+STEALTH_LEAKAGE_CONFIG ?= scripts/stealth/forbidden_tokens.json
+STEALTH_LEAKAGE_PATHS ?= $(ANDROID_RELEASE_APK) $(ANDROID_RELEASE_AAB) $(ANDROID_APK_RELEASE_BUILD) $(ANDROID_AAB_RELEASE_BUILD)
+STEALTH_LEAKAGE_MISSING_OK ?= 1
 ANDROID_NDK_VERSION          ?= 28.2.13676358
 ANDROID_CMAKE_VERSION        ?= 3.31.5
 ANDROID_BUILD_TOOLS_VERSION  ?= 35.0.0
@@ -169,6 +184,13 @@ ANDROID_DEBUG_FLUTTER_FLAGS  ?= --verbose
 ANDROID_PAGE_SIZE ?= 16384
 # Android 15+ Play requirement: arm64 native libs must be linked for 16 KB page-size compatibility.
 ANDROID_GOMOBILE_LDFLAGS ?= -s -w -checklinkname=0 -extldflags=-Wl,-z,max-page-size=$(ANDROID_PAGE_SIZE),-z,common-page-size=$(ANDROID_PAGE_SIZE)
+ANDROID_STEALTH_IDENTITY ?= $(if $(strip $(filter stealth stealth-%,$(BUILD_TYPE))$(STEALTH_MODE)$(STEALTH_PROFILE)),1,0)
+ANDROID_GENERATE_IDENTITY_PROFILE ?= $(ANDROID_STEALTH_IDENTITY)
+ANDROID_GENERATED_IDENTITY_PROFILE := $(BUILD_DIR)/stealth/android-identity.properties
+ANDROID_IDENTITY_PROFILE ?= $(if $(filter 1 true yes,$(ANDROID_GENERATE_IDENTITY_PROFILE)),$(ANDROID_GENERATED_IDENTITY_PROFILE),)
+ANDROID_IDENTITY_ENV = $(if $(strip $(ANDROID_IDENTITY_PROFILE)),ANDROID_IDENTITY_PROFILE="$(abspath $(ANDROID_IDENTITY_PROFILE))",)
+ANDROID_AUTH_SCHEME = $(strip $(if $(ANDROID_IDENTITY_PROFILE),$(shell sed -n 's/^appAuthScheme=//p' "$(ANDROID_IDENTITY_PROFILE)" 2>/dev/null | tail -n 1),))
+ANDROID_IDENTITY_DART_DEFINES = $(if $(STEALTH_ENABLED),,$(if $(ANDROID_AUTH_SCHEME),--dart-define=APP_AUTH_SCHEME=$(ANDROID_AUTH_SCHEME)))
 
 IOS_INSTALLER := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE)).ipa
 IOS_DIR := ios/
@@ -200,6 +222,30 @@ GOMOBILE_REPOS = \
 	github.com/sagernet/sing-box/experimental/libbox \
 	./lantern-core/mobile \
 	./lantern-core/utils
+# novpn now ships the FULL app over SOCKS (not the minimal proxy stub), so it
+# binds the same packages as the regular/vpn build: libbox (sing-box, required by
+# the real MainActivity's Libbox init + the SOCKS data path), mobile, utils.
+GOMOBILE_REPOS_STEALTH_NOVPN = \
+	github.com/sagernet/sing-box/experimental/libbox \
+	./lantern-core/mobile \
+	./lantern-core/utils
+
+GARBLE ?= garble
+GARBLE_VERSION ?= v0.16.0
+GARBLE_SEED ?= $(STEALTH_GARBLE_SEED)
+GARBLE_FLAGS ?= -literals
+STEALTH_GOGARBLE_PACKAGES := github.com/getlantern/lantern,github.com/getlantern/radiance,github.com/getlantern/common,github.com/getlantern/lantern-box,github.com/getlantern/kindling,github.com/getlantern/netx,github.com/getlantern/flashlight,github.com/getlantern/golog,github.com/getlantern/sing-box-minimal,github.com/getlantern/amp,github.com/getlantern/broflake,github.com/getlantern/samizdat,github.com/getlantern/domainfront,github.com/getlantern/semconv,github.com/getlantern/publicip,github.com/getlantern/dnstt,github.com/getlantern/keepcurrent,github.com/getlantern/algeneva,github.com/getlantern/lantern-water,github.com/getlantern/water,github.com/getlantern/wazero,github.com/getlantern/wireguard-go,github.com/getlantern/sing,github.com/getlantern/osversion,github.com/getlantern/timezone,github.com/getlantern/pluriconfig,github.com/getlantern/appdir,github.com/getlantern/context,github.com/getlantern/fronted,github.com/getlantern/lantern-server-provisioner,github.com/getlantern/ops
+GARBLE_GOGARBLE ?= $(if $(STEALTH_ENABLED),$(STEALTH_GOGARBLE_PACKAGES),github.com/getlantern/lantern)
+GARBLE_LDFLAGS ?= -w -s -buildid=
+
+ifeq ($(OS),Windows_NT)
+GARBLE_REAL_GO ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command '(Get-Command go -ErrorAction SilentlyContinue).Source')
+GARBLE_ENV = $(if $(GARBLE_GOGARBLE),set GOGARBLE=$(GARBLE_GOGARBLE)&& ,set GOGARBLE=&& )
+else
+GARBLE_REAL_GO ?= $(shell command -v go 2>/dev/null)
+GARBLE_ENV = $(if $(GARBLE_GOGARBLE),GOGARBLE="$(GARBLE_GOGARBLE)",env -u GOGARBLE)
+endif
+GARBLE_BUILD = $(GARBLE) $(GARBLE_FLAGS) -seed="$(GARBLE_SEED)" build
 
 SIGN_ID="Developer ID Application: Brave New Software Project, Inc (ACZRKC3LQ9)"
 
@@ -211,6 +257,56 @@ get-command = $(shell which="$$(which $(1) 2> /dev/null)" && if [[ ! -z "$$which
 APPDMG    := $(call get-command,appdmg)
 
 DART_DEFINES := --dart-define=BUILD_TYPE=$(BUILD_TYPE) $(if $(VERSION),--dart-define=VERSION=$(VERSION),)
+STEALTH_NOVPN_BUILD_VARS := BUILD_TYPE=stealth-novpn STEALTH_MODE=stealth-novpn STEALTH_LEAKAGE_MODE=stealth-novpn
+STEALTH_VPN_BUILD_VARS   := BUILD_TYPE=stealth-vpn  STEALTH_MODE=stealth-vpn  STEALTH_LEAKAGE_MODE=stealth-vpn
+STEALTH_ICON_SEED ?=
+STEALTH_ICON_RES_DIR ?= android/app/build/generated/icons/res
+export STEALTH_ICON_SEED
+
+STEALTH_PROFILE_SCRIPT := scripts/stealth/generate_profile.py
+STEALTH_PROFILE_TOOL := $(PYTHON) $(STEALTH_PROFILE_SCRIPT)
+STEALTH_FLUTTER_BUILD_SCRIPT := scripts/stealth/run_flutter_build.py
+STEALTH_ANDROID_ARTIFACT_SANITIZER := scripts/stealth/sanitize_android_artifact.py
+STEALTH_ANDROID_ARTIFACT_SIGNING_FLAGS := $(if $(filter 1 true yes,$(STEALTH_ALLOW_DEBUG_KEYSTORE)),--allow-debug-keystore,)
+# De-branded copy of the REAL Android Kotlin + res, compiled in place of the
+# legacy foundation.bridge stub source set so stealth ships the real native bridge.
+STEALTH_DEBRAND_KOTLIN_SCRIPT := scripts/stealth/debrand_kotlin.py
+STEALTH_ANDROID_GEN_DIR := $(BUILD_DIR)/stealth/android
+STEALTH_ANDROID_KOTLIN_OUT := $(STEALTH_ANDROID_GEN_DIR)/kotlin
+STEALTH_ANDROID_RES_OUT := $(STEALTH_ANDROID_GEN_DIR)/res
+STEALTH_PROFILE ?=
+STEALTH_MODE ?=
+STEALTH_PACKAGE_NAME ?=
+STEALTH_APP_NAME ?=
+STEALTH_SESSION_NAME ?=
+STEALTH_OBFUSCATION_SEED ?=
+STEALTH_GO_OBFUSCATION_SEED ?= $(STEALTH_OBFUSCATION_SEED)
+STEALTH_DENYLIST_VERSION ?=
+STEALTH_PROFILE_OUT ?= $(BUILD_DIR)/stealth/profile.json
+STEALTH_DART_DEFINES_FILE ?= $(BUILD_DIR)/stealth/dart-defines.json
+STEALTH_ARTIFACT_METADATA ?= $(BUILD_DIR)/stealth/artifact-metadata.json
+STEALTH_GO_TAGS_FILE ?= $(BUILD_DIR)/stealth/go-tags-suffix.txt
+STEALTH_PROFILE_STAMP ?= $(BUILD_DIR)/stealth/profile.stamp
+STEALTH_PROFILE_INPUTS_FILE ?= $(BUILD_DIR)/stealth/profile.inputs
+STEALTH_ENABLED := $(strip $(STEALTH_MODE)$(STEALTH_PROFILE))
+STEALTH_DART_DEFINES := $(if $(STEALTH_ENABLED),--dart-define-from-file=$(STEALTH_DART_DEFINES_FILE),)
+STEALTH_GO_TAGS = $(if $(STEALTH_ENABLED),$(if $(wildcard $(STEALTH_GO_TAGS_FILE)),$(strip $(file <$(STEALTH_GO_TAGS_FILE))),$(error missing $(STEALTH_GO_TAGS_FILE); run make stealth-profile before building)),)
+STEALTH_PROFILE_ENV := $(if $(STEALTH_ENABLED),ORG_GRADLE_PROJECT_stealthProfile="$(abspath $(STEALTH_PROFILE_OUT))",)
+MAYBE_STEALTH_PROFILE := $(if $(STEALTH_ENABLED),$(STEALTH_PROFILE_STAMP),)
+STEALTH_IS_NOVPN = $(if $(findstring novpn,$(STEALTH_GO_TAGS)),1,)
+GOMOBILE_REPOS_EFFECTIVE = $(if $(STEALTH_IS_NOVPN),$(GOMOBILE_REPOS_STEALTH_NOVPN),$(GOMOBILE_REPOS))
+GOMOBILE_JAVAPKG = $(if $(STEALTH_ENABLED),foundation.engine,lantern.io)
+STEALTH_FLUTTER_PREFIX = $(if $(STEALTH_ENABLED),$(PYTHON) $(STEALTH_FLUTTER_BUILD_SCRIPT) --profile "$(STEALTH_PROFILE_OUT)" --,)
+# Stealth builds compile the REAL app entrypoint (lib/main.dart, Flutter's
+# default target). De-branding is a pre-compile transform (run_flutter_build.py)
+# plus the AppBuildInfo dart-define guards; the legacy lib/main_stealth.dart stub
+# is no longer used.
+STEALTH_FLUTTER_TARGET =
+# Dart symbol obfuscation removes brand *identifiers* (e.g. LanternService) from
+# the AOT-compiled libapp.so. Applied to stealth release builds only; requires
+# --split-debug-info. The symbol map stays local and is NOT shipped in the APK.
+STEALTH_FLUTTER_OBFUSCATE = $(if $(STEALTH_ENABLED),--obfuscate --split-debug-info=$(BUILD_DIR)/stealth/debug-symbols,)
+FLUTTER_DART_DEFINES = $(if $(STEALTH_ENABLED),$(if $(VERSION),--dart-define=VERSION=$(VERSION),),$(DART_DEFINES))
 
 INSTALLER_RESOURCES := installer-resources
 
@@ -220,6 +316,109 @@ guard-%:
 
 check-gomobile:
 	@command -v gomobile >/dev/null || (echo "gomobile not found. Run 'make install-android-deps'" && exit 1)
+
+.PHONY: stealth-android-sources
+stealth-android-sources:
+	$(PYTHON) $(STEALTH_DEBRAND_KOTLIN_SCRIPT) \
+	  --output $(STEALTH_ANDROID_KOTLIN_OUT) \
+	  --res-source android/app/src/main/res \
+	  --res-overlay android/app/src/stealth/res \
+	  --res-output $(STEALTH_ANDROID_RES_OUT)
+
+.PHONY: stealth-profile FORCE
+stealth-profile:
+	$(MAKE) -B "$(STEALTH_PROFILE_STAMP)"
+
+$(STEALTH_PROFILE_STAMP): FORCE $(STEALTH_PROFILE_SCRIPT)
+	$(call MKDIR_P,$(dir $(STEALTH_PROFILE_STAMP)))
+	@set -e; { \
+	  printf 'STEALTH_PROFILE_SCRIPT_SHA256='; \
+	  python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE_SCRIPT)"; \
+	  printf 'STEALTH_PROFILE=%s\n' "$(STEALTH_PROFILE)"; \
+	  printf 'STEALTH_PROFILE_SHA256='; \
+	  if [ -n "$(STEALTH_PROFILE)" ] && [ -f "$(STEALTH_PROFILE)" ]; then \
+	    python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE)"; \
+	  else \
+	    printf '\n'; \
+	  fi; \
+	  printf 'STEALTH_MODE=%s\n' "$(STEALTH_MODE)"; \
+	  printf 'STEALTH_PACKAGE_NAME=%s\n' "$(STEALTH_PACKAGE_NAME)"; \
+	  printf 'STEALTH_APP_NAME=%s\n' "$(STEALTH_APP_NAME)"; \
+	  printf 'STEALTH_SESSION_NAME=%s\n' "$(STEALTH_SESSION_NAME)"; \
+	  printf 'STEALTH_GO_OBFUSCATION_SEED_SHA256='; \
+	  if [ -n "$(STEALTH_GO_OBFUSCATION_SEED)" ]; then \
+	    python3 -c 'import hashlib, sys; print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())' "$(STEALTH_GO_OBFUSCATION_SEED)"; \
+	  else \
+	    printf '\n'; \
+	  fi; \
+	  printf 'STEALTH_DENYLIST_VERSION=%s\n' "$(STEALTH_DENYLIST_VERSION)"; \
+	} > "$(STEALTH_PROFILE_INPUTS_FILE).tmp"
+	@set -e; \
+	tmp_profile="$(STEALTH_PROFILE_OUT).tmp"; \
+	tmp_dart_defines="$(STEALTH_DART_DEFINES_FILE).tmp"; \
+	tmp_artifact_metadata="$(STEALTH_ARTIFACT_METADATA).tmp"; \
+	tmp_go_tags="$(STEALTH_GO_TAGS_FILE).tmp"; \
+	trap 'rm -f "$(STEALTH_PROFILE_INPUTS_FILE).tmp" "$$tmp_profile" "$$tmp_dart_defines" "$$tmp_artifact_metadata" "$$tmp_go_tags"' EXIT; \
+	if test -f "$(STEALTH_PROFILE_INPUTS_FILE)" && \
+		cmp -s "$(STEALTH_PROFILE_INPUTS_FILE).tmp" "$(STEALTH_PROFILE_INPUTS_FILE)" && \
+		test -s "$(STEALTH_PROFILE_OUT)" && \
+		test -s "$(STEALTH_DART_DEFINES_FILE)" && \
+		test -s "$(STEALTH_ARTIFACT_METADATA)" && \
+		test -s "$(STEALTH_GO_TAGS_FILE)"; then \
+	  touch "$@"; \
+	  rm -f "$(STEALTH_PROFILE_INPUTS_FILE).tmp"; \
+	else \
+	  $(STEALTH_PROFILE_TOOL) \
+		$(if $(STEALTH_PROFILE),--input "$(STEALTH_PROFILE)",) \
+		$(if $(STEALTH_MODE),--mode "$(STEALTH_MODE)",) \
+		$(if $(STEALTH_PACKAGE_NAME),--package-name "$(STEALTH_PACKAGE_NAME)",) \
+		$(if $(STEALTH_APP_NAME),--app-name "$(STEALTH_APP_NAME)",) \
+		$(if $(STEALTH_SESSION_NAME),--session-name "$(STEALTH_SESSION_NAME)",) \
+		$(if $(STEALTH_GO_OBFUSCATION_SEED),--go-obfuscation-seed "$(STEALTH_GO_OBFUSCATION_SEED)",) \
+		$(if $(STEALTH_DENYLIST_VERSION),--denylist-version "$(STEALTH_DENYLIST_VERSION)",) \
+		--output "$$tmp_profile" \
+		--dart-defines-output "$$tmp_dart_defines" \
+		--artifact-metadata-output "$$tmp_artifact_metadata"; \
+	  $(STEALTH_PROFILE_TOOL) --input "$$tmp_profile" --go-tags-suffix > "$$tmp_go_tags"; \
+	  mv "$(STEALTH_PROFILE_INPUTS_FILE).tmp" "$(STEALTH_PROFILE_INPUTS_FILE)"; \
+	  mv "$$tmp_profile" "$(STEALTH_PROFILE_OUT)"; \
+	  mv "$$tmp_dart_defines" "$(STEALTH_DART_DEFINES_FILE)"; \
+	  mv "$$tmp_artifact_metadata" "$(STEALTH_ARTIFACT_METADATA)"; \
+	  mv "$$tmp_go_tags" "$(STEALTH_GO_TAGS_FILE)"; \
+	  touch "$@"; \
+	fi
+
+.PHONY: check-garble require-garble-seed check-garble-seed check-garble-go
+check-garble:
+	@command -v $(GARBLE) >/dev/null 2>&1 || \
+		{ echo "garble not found. Run 'make install-garble' or set GARBLE=/path/to/garble."; exit 1; }
+	@command -v git >/dev/null 2>&1 || \
+		{ echo "git not found. garble requires git to patch the Go linker."; exit 1; }
+	@$(GARBLE) -h >/dev/null 2>&1 || \
+		{ echo "garble was found but could not run. Check GARBLE=$(GARBLE) and your Go toolchain."; exit 1; }
+
+require-garble-seed:
+	@if [ -z "$(GARBLE_SEED)" ]; then \
+		echo "GARBLE_SEED is required for obfuscated builds."; \
+		echo "Set GARBLE_SEED=<base64 profile seed> or STEALTH_GARBLE_SEED=<base64 profile seed>."; \
+		echo "Use GARBLE_SEED=random only for unreproducible local smoke builds."; \
+		exit 1; \
+	fi
+
+check-garble-seed: check-garble require-garble-seed
+	@$(GARBLE) -seed="$(GARBLE_SEED)" version >/dev/null 2>&1 || \
+		{ echo "GARBLE_SEED must be 'random' or a base64-encoded seed accepted by garble."; exit 1; }
+
+check-garble-go:
+	@if [ -z "$(GARBLE_REAL_GO)" ]; then \
+		echo "go not found. Install Go or set GARBLE_REAL_GO=/path/to/go for gomobile garble builds."; \
+		exit 1; \
+	fi
+
+.PHONY: stealth-android-icons
+stealth-android-icons: guard-STEALTH_ICON_SEED
+	python3 scripts/stealth/generate_android_icons.py \
+		--output-res-dir "$(STEALTH_ICON_RES_DIR)"
 
 
 .PHONY: require-appdmg
@@ -240,12 +439,21 @@ else
 endif
 
 .PHONY: desktop-lib
-desktop-lib:
+desktop-lib: $(MAYBE_STEALTH_PROFILE)
 	$(SETENV) go build -v -trimpath -buildmode=c-shared \
-		-tags="$(TAGS)" \
-		-ldflags="-w -s $(EXTRA_LDFLAGS)" \
+		-tags="$(TAGS)$(STEALTH_GO_TAGS)" \
+		-ldflags="-w -s $(GO_EXTRA_LDFLAGS)" \
 		-o $(LIB_NAME) ./$(FFI_DIR)
 	@echo "Built desktop library: $(LIB_NAME)"
+
+.PHONY: desktop-lib-obfuscated
+desktop-lib-obfuscated: check-garble-seed
+	$(call MKDIR_P,$(dir $(LIB_NAME)))
+	@$(SETENV) $(GARBLE_ENV) $(GARBLE_BUILD) -v -trimpath -buildmode=c-shared \
+		-tags="$(TAGS)" \
+		-ldflags="$(GARBLE_LDFLAGS) $(EXTRA_LDFLAGS)" \
+		-o $(LIB_NAME) ./$(FFI_DIR)
+	@echo "Built obfuscated desktop library: $(LIB_NAME)"
 
 # macOS build tools need to be installed when generating release builds,
 # but are not necessarily required for debug builds
@@ -260,14 +468,14 @@ install-macos-deps: install-gomobile
 .PHONY: macos
 macos: $(MACOS_FRAMEWORK_BUILD)
 
-$(MACOS_FRAMEWORK_BUILD): $(GO_SOURCES)
+$(MACOS_FRAMEWORK_BUILD): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	@echo "Building macOS Framework.."
 	rm -rf $(MACOS_FRAMEWORK_BUILD) && mkdir -p $(MACOS_FRAMEWORK_DIR)
 	GOTOOLCHAIN=$(GO_VERSION) GOOS=darwin gomobile bind -v \
-		-tags=$(TAGS),netgo  -trimpath \
+		-tags=$(TAGS),netgo$(STEALTH_GO_TAGS)  -trimpath \
 		-target=macos \
 		-o $(MACOS_FRAMEWORK_BUILD) \
-		-ldflags="-w -s -checklinkname=0 $(EXTRA_LDFLAGS)" \
+		-ldflags="-w -s -checklinkname=0 $(GO_EXTRA_LDFLAGS)" \
 		$(GOMOBILE_REPOS)
 	@echo "Built macOS Framework: $(MACOS_FRAMEWORK_BUILD)"
 	rm -rf $(MACOS_FRAMEWORK_DIR)/$(MACOS_FRAMEWORK)
@@ -280,14 +488,14 @@ macos-framework: $(MACOS_FRAMEWORK_BUILD)
 .PHONY: macos-debug
 macos-debug: $(DARWIN_DEBUG_BUILD)
 
-$(DARWIN_DEBUG_BUILD): $(DARWIN_LIB_BUILD)
+$(DARWIN_DEBUG_BUILD): $(DARWIN_LIB_BUILD) $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (debug) for macOS..."
-	flutter build macos --debug
+	flutter build macos --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: macos-unit-tests
-macos-unit-tests: $(MACOS_FRAMEWORK_BUILD)
+macos-unit-tests: $(MACOS_FRAMEWORK_BUILD) $(MAYBE_STEALTH_PROFILE)
 	@echo "Preparing macOS test project (building native assets)..."
-	flutter build macos --debug
+	flutter build macos --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 	@echo "Running macOS Runner unit tests..."
 	xcodebuild test \
 		-workspace macos/Runner.xcworkspace \
@@ -299,10 +507,10 @@ macos-unit-tests: $(MACOS_FRAMEWORK_BUILD)
 		CODE_SIGNING_REQUIRED=NO \
 		CODE_SIGN_IDENTITY=""
 
-$(DARWIN_RELEASE_BUILD):
+$(DARWIN_RELEASE_BUILD): $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for macOS..."
 	rm -vf $(MACOS_INSTALLER)
-	flutter build macos --release $(DART_DEFINES)
+	flutter build macos --release $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 build-macos-release: $(DARWIN_RELEASE_BUILD)
 
@@ -349,49 +557,79 @@ install-linux-deps:
 .PHONY: linux-arm64
 linux-arm64: $(LINUX_LIB_ARM64)
 
-$(LINUX_LIB_ARM64): $(GO_SOURCES)
+$(LINUX_LIB_ARM64): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	CC=$(LINUX_CC_ARM64) GOOS=linux GOARCH=arm64 LIB_NAME=$@ $(MAKE) desktop-lib
+
+.PHONY: linux-arm64-obfuscated
+linux-arm64-obfuscated: $(GO_SOURCES)
+	CC=$(LINUX_CC_ARM64) GOOS=linux GOARCH=arm64 LIB_NAME=$(LINUX_LIB_ARM64) $(MAKE) desktop-lib-obfuscated
 
 .PHONY: linux-amd64
 linux-amd64: $(LINUX_LIB_AMD64)
 
-$(LINUX_LIB_AMD64): $(GO_SOURCES)
+$(LINUX_LIB_AMD64): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	CC=$(LINUX_CC_AMD64) GOOS=linux GOARCH=amd64 LIB_NAME=$@ $(MAKE) desktop-lib
+
+.PHONY: linux-amd64-obfuscated
+linux-amd64-obfuscated: $(GO_SOURCES)
+	CC=$(LINUX_CC_AMD64) GOOS=linux GOARCH=amd64 LIB_NAME=$(LINUX_LIB_AMD64) $(MAKE) desktop-lib-obfuscated
 
 .PHONY: linux
 linux: linux-$(LINUX_TARGET_ARCH)
 	mkdir -p $(BIN_DIR)/linux
 	cp $(BIN_DIR)/linux-$(LINUX_TARGET_ARCH)/$(LINUX_LIB) $(LINUX_LIB_BUILD)
 
-.PHONY: lanternd-linux-amd64 lanternd-linux-arm64
+.PHONY: linux-obfuscated
+linux-obfuscated: linux-$(LINUX_TARGET_ARCH)-obfuscated
+	mkdir -p $(BIN_DIR)/linux
+	cp $(BIN_DIR)/linux-$(LINUX_TARGET_ARCH)/$(LINUX_LIB) $(LINUX_LIB_BUILD)
 
-lanternd-linux-amd64: $(GO_SOURCES)
+.PHONY: lanternd-linux-amd64 lanternd-linux-arm64 \
+        lanternd-linux-amd64-obfuscated lanternd-linux-arm64-obfuscated
+
+lanternd-linux-amd64: $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_LINUX_AMD64)))
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
-		-ldflags "-w -s $(EXTRA_LDFLAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
+		-ldflags "-w -s $(LANTERND_EXTRA_LDFLAGS)" \
 		-o $(LANTERND_LINUX_AMD64) $(LANTERND_SRC)
 	@echo "Built lanternd (linux-amd64): $(LANTERND_LINUX_AMD64)"
 
-lanternd-linux-arm64: $(GO_SOURCES)
+lanternd-linux-arm64: $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_LINUX_ARM64)))
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
-		-ldflags "-w -s $(EXTRA_LDFLAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
+		-ldflags "-w -s $(LANTERND_EXTRA_LDFLAGS)" \
 		-o $(LANTERND_LINUX_ARM64) $(LANTERND_SRC)
 	@echo "Built lanternd (linux-arm64): $(LANTERND_LINUX_ARM64)"
 
+lanternd-linux-amd64-obfuscated: check-garble-seed $(GO_SOURCES)
+	$(call MKDIR_P,$(dir $(LANTERND_LINUX_AMD64)))
+	@$(GARBLE_ENV) GOOS=linux GOARCH=amd64 CGO_ENABLED=1 \
+		$(GARBLE_BUILD) -mod=mod -v -trimpath -tags "$(TAGS)" \
+		-ldflags "$(GARBLE_LDFLAGS) $(EXTRA_LDFLAGS)" \
+		-o $(LANTERND_LINUX_AMD64) $(LANTERND_SRC)
+	@echo "Built obfuscated lanternd (linux-amd64): $(LANTERND_LINUX_AMD64)"
+
+lanternd-linux-arm64-obfuscated: check-garble-seed $(GO_SOURCES)
+	$(call MKDIR_P,$(dir $(LANTERND_LINUX_ARM64)))
+	@$(GARBLE_ENV) GOOS=linux GOARCH=arm64 CGO_ENABLED=1 \
+		$(GARBLE_BUILD) -mod=mod -v -trimpath -tags "$(TAGS)" \
+		-ldflags "$(GARBLE_LDFLAGS) $(EXTRA_LDFLAGS)" \
+		-o $(LANTERND_LINUX_ARM64) $(LANTERND_SRC)
+	@echo "Built obfuscated lanternd (linux-arm64): $(LANTERND_LINUX_ARM64)"
+
 .PHONY: linux-debug
-linux-debug:
+linux-debug: $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (debug) for Linux..."
-	flutter build linux --debug
+	flutter build linux --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: linux-release linux-release-ci
 linux-release: clean linux-release-ci
 
-linux-release-ci: linux pubget gen
+linux-release-ci: linux pubget gen $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for Linux..."
-	flutter build linux --release $(DART_DEFINES)
+	flutter build linux --release $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 	$(MAKE) lanternd-linux-$(LINUX_TARGET_ARCH)
 
 	@if [ "$(LINUX_TARGET_ARCH)" = "arm64" ]; then \
@@ -406,6 +644,7 @@ linux-release-ci: linux pubget gen
 	echo "Using Linux bundle dir: $$BUNDLE_DIR"; \
 	cp "$(LINUX_LIB_BUILD)" "$$BUNDLE_DIR"; \
 	cp "$(BIN_DIR)/linux-$(LINUX_TARGET_ARCH)/$(LANTERND)" "$$BUNDLE_DIR"; \
+	printf '%s\n' "$(LANTERND_SERVICE_LOG_LEVEL)" > "$$BUNDLE_DIR/lanternd-log-level"; \
 	patchelf --set-rpath '$$ORIGIN/lib' "$$BUNDLE_DIR/lantern" || true; \
 	VERSION=$(APP_VERSION) GOARCH=$(LINUX_TARGET_ARCH) LINUX_BUNDLE_SRC="$$BUNDLE_DIR/" \
 		nfpm package -f $(LINUX_PKG_ROOT)/nfpm.yaml -p deb -t $(LINUX_INSTALLER_DEB); \
@@ -432,12 +671,12 @@ windows: windows-amd64
 
 windows-amd64: WINDOWS_GOOS := windows
 windows-amd64: WINDOWS_GOARCH := amd64
-windows-amd64:
+windows-amd64: $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(WINDOWS_LIB_AMD64)))
 	$(MAKE) desktop-lib GOOS=$(WINDOWS_GOOS) GOARCH=$(WINDOWS_GOARCH) LIB_NAME=$(WINDOWS_LIB_AMD64) CGO_LDFLAGS="$(WINDOWS_CGO_LDFLAGS)"
 windows-arm64: WINDOWS_GOOS := windows
 windows-arm64: WINDOWS_GOARCH := arm64
-windows-arm64:
+windows-arm64: $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(WINDOWS_LIB_ARM64)))
 	$(MAKE) desktop-lib GOOS=$(WINDOWS_GOOS) GOARCH=$(WINDOWS_GOARCH) LIB_NAME=$(WINDOWS_LIB_ARM64) CGO_LDFLAGS="$(WINDOWS_CGO_LDFLAGS)"
 
@@ -445,19 +684,19 @@ lanternd-windows-amd64: $(LANTERND_WINDOWS_AMD64)
 
 lanternd-windows-arm64: $(LANTERND_WINDOWS_ARM64)
 
-$(LANTERND_WINDOWS_AMD64):
+$(LANTERND_WINDOWS_AMD64): $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_WINDOWS_AMD64)))
 	GOOS=windows GOARCH=amd64 CGO_ENABLED=0 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
-		-ldflags "$(EXTRA_LDFLAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
+		-ldflags "$(LANTERND_EXTRA_LDFLAGS)" \
 		-o $(LANTERND_WINDOWS_AMD64) $(LANTERND_SRC)
 	@echo "Built lanternd (windows-amd64): $(LANTERND_WINDOWS_AMD64)"
 
-$(LANTERND_WINDOWS_ARM64):
+$(LANTERND_WINDOWS_ARM64): $(MAYBE_STEALTH_PROFILE)
 	$(call MKDIR_P,$(dir $(LANTERND_WINDOWS_ARM64)))
 	GOOS=windows GOARCH=arm64 CGO_ENABLED=0 \
-		go build -mod=mod -v -trimpath -tags "$(TAGS)" \
-		-ldflags "$(EXTRA_LDFLAGS)" \
+		go build -mod=mod -v -trimpath -tags "$(TAGS)$(STEALTH_GO_TAGS)" \
+		-ldflags "$(LANTERND_EXTRA_LDFLAGS)" \
 		-o $(LANTERND_WINDOWS_ARM64) $(LANTERND_SRC)
 	@echo "Built lanternd (windows-arm64): $(LANTERND_WINDOWS_ARM64)"
 
@@ -477,16 +716,17 @@ copy-lanternd-debug: $(LANTERND_WINDOWS_AMD64)
 prepare-windows-release: lanternd-windows-amd64 lanternd-windows-arm64
 	$(MAKE) copy-lanternd-release
 	$(MAKE) copy-lanternd-release-arm64
+	$(call WRITE_TEXT_FILE,$(LANTERND_SERVICE_LOG_LEVEL),$(WINDOWS_RELEASE_DIR)/lanternd-log-level)
 
 .PHONY: windows-debug
-windows-debug: windows
+windows-debug: windows $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (debug) for Windows..."
-	flutter build windows --debug
+	flutter build windows --debug $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: build-windows-release
-build-windows-release:
+build-windows-release: $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for Windows..."
-	flutter build windows --release --verbose
+	flutter build windows --release --verbose $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 .PHONY: windows-release
 windows-release: clean windows pubget gen build-windows-release prepare-windows-release
@@ -503,6 +743,10 @@ install-gomobile:
 	else \
 		echo "Skipping gomobile init (cached for $(GO_VERSION))"; \
 	fi
+
+.PHONY: install-garble
+install-garble:
+	GOTOOLCHAIN=$(GO_VERSION) go install -v mvdan.cc/garble@$(GARBLE_VERSION)
 
 # Android Build
 .PHONY: check-android-sdk
@@ -531,13 +775,35 @@ android-env: check-android-sdk
 .PHONY: install-android-deps
 install-android-deps: install-gomobile
 
+.PHONY: android-identity-profile
+android-identity-profile: $(MAYBE_STEALTH_PROFILE)
+	@if [ "$(ANDROID_GENERATE_IDENTITY_PROFILE)" = "1" ] || [ "$(ANDROID_GENERATE_IDENTITY_PROFILE)" = "true" ] || [ "$(ANDROID_GENERATE_IDENTITY_PROFILE)" = "yes" ]; then \
+	  if [ -z "$(ANDROID_IDENTITY_PROFILE)" ]; then \
+	    echo "ANDROID_IDENTITY_PROFILE is empty"; \
+	    exit 1; \
+	  fi; \
+		  if [ ! -f "$(ANDROID_IDENTITY_PROFILE)" ] || [ -n "$(ANDROID_IDENTITY_SEED)" ] || [ "$(ANDROID_FORCE_IDENTITY_PROFILE)" = "1" ] || [ "$(ANDROID_FORCE_IDENTITY_PROFILE)" = "true" ] || [ "$(ANDROID_FORCE_IDENTITY_PROFILE)" = "yes" ]; then \
+		    mkdir -p "$$(dirname "$(ANDROID_IDENTITY_PROFILE)")"; \
+		    python3 scripts/stealth/generate_android_identity.py \
+		      --output "$(ANDROID_IDENTITY_PROFILE)" \
+		      $(if $(STEALTH_ENABLED),--profile "$(STEALTH_PROFILE_OUT)",) \
+		      $(if $(ANDROID_IDENTITY_SEED),--seed "$(ANDROID_IDENTITY_SEED)",); \
+		  elif [ -n "$(STEALTH_ENABLED)" ]; then \
+		    python3 scripts/stealth/generate_android_identity.py \
+		      --output "$(ANDROID_IDENTITY_PROFILE)" \
+		      --profile "$(STEALTH_PROFILE_OUT)"; \
+		  else \
+		    echo "Using Android identity profile: $(ANDROID_IDENTITY_PROFILE)"; \
+		  fi; \
+	fi
+
 .PHONY: android
 android: check-android-sdk check-gomobile $(ANDROID_LIB_BUILD)
 
-$(ANDROID_LIB_BUILD): $(GO_SOURCES)
+$(ANDROID_LIB_BUILD): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(MAKE) build-android
 
-build-android: check-android-sdk check-gomobile
+build-android: check-android-sdk check-gomobile $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Android libraries..."
 	rm -rf $(ANDROID_LIB_BUILD) $(ANDROID_LIBS_DIR)/$(ANDROID_LIB)
 	mkdir -p $(dir $(ANDROID_LIB_BUILD)) $(ANDROID_LIBS_DIR)
@@ -546,14 +812,75 @@ build-android: check-android-sdk check-gomobile
 	GOTOOLCHAIN=$(GO_VERSION) GOOS=android gomobile bind -v \
 		-androidapi=23 \
 		-target="$(GOMOBILE_ANDROID_TARGET)" \
-		-javapkg=lantern.io \
-		-tags=$(TAGS) -trimpath \
+		-javapkg=$(GOMOBILE_JAVAPKG) \
+		-tags=$(TAGS)$(STEALTH_GO_TAGS) -trimpath \
 		-o=$(ANDROID_LIB_BUILD) \
-		-ldflags="$(ANDROID_GOMOBILE_LDFLAGS) $(EXTRA_LDFLAGS)" \
-		$(GOMOBILE_REPOS)
+		-ldflags="$(ANDROID_GOMOBILE_LDFLAGS) $(GO_EXTRA_LDFLAGS)" \
+		$(GOMOBILE_REPOS_EFFECTIVE)
 
 	cp $(ANDROID_LIB_BUILD) $(ANDROID_LIBS_DIR)
 	@echo "Built Android library: $(ANDROID_LIBS_DIR)/$(ANDROID_LIB)"
+
+.PHONY: android-obfuscated
+android-obfuscated: build-android-obfuscated
+
+.PHONY: build-android-obfuscated
+build-android-obfuscated: check-android-sdk check-gomobile check-garble-seed check-garble-go $(MAYBE_STEALTH_PROFILE)
+	@echo "Building obfuscated Android libraries..."
+	rm -rf $(ANDROID_LIB_BUILD) $(ANDROID_LIBS_DIR)/$(ANDROID_LIB)
+	mkdir -p $(dir $(ANDROID_LIB_BUILD)) $(ANDROID_LIBS_DIR)
+
+	@PATH="$(CURDIR)/scripts/garble-go:$$PATH" \
+	GARBLE_REAL_GO="$(GARBLE_REAL_GO)" \
+	GARBLE_BIN="$(GARBLE)" \
+	GARBLE_SEED="$(GARBLE_SEED)" \
+	GARBLE_FLAGS="$(GARBLE_FLAGS)" \
+	GARBLE_GOGARBLE="$(GARBLE_GOGARBLE)" \
+	GOMOBILECACHE="$(GOMOBILECACHE)" \
+	GOTOOLCHAIN=$(GO_VERSION) GOOS=android gomobile bind -v \
+		-androidapi=23 \
+		-target="$(GOMOBILE_ANDROID_TARGET)" \
+		-javapkg=$(GOMOBILE_JAVAPKG) \
+		-tags=$(TAGS)$(STEALTH_GO_TAGS) -trimpath \
+		-o=$(ANDROID_LIB_BUILD) \
+		-ldflags="$(ANDROID_GOMOBILE_LDFLAGS) $(GARBLE_LDFLAGS) $(EXTRA_LDFLAGS)" \
+		$(GOMOBILE_REPOS_EFFECTIVE)
+
+	cp $(ANDROID_LIB_BUILD) $(ANDROID_LIBS_DIR)
+	@echo "Built obfuscated Android library: $(ANDROID_LIBS_DIR)/$(ANDROID_LIB)"
+	$(if $(STEALTH_ENABLED),$(MAKE) ANDROID_LIBS_DIR="$(ANDROID_LIBS_DIR)" ANDROID_LIB="$(ANDROID_LIB)" verify-stealth-jni,)
+
+# verify-stealth-jni: hard gate on JNI symbol namespace in the stealth AAR.
+# Extracts arm64-v8a/libgojni.so and asserts:
+#   - Java_lantern_io_* is ABSENT (GOMOBILE_JAVAPKG=foundation.engine applied)
+#   - Java_foundation_engine_* is PRESENT (gomobile binding succeeded)
+# Called automatically by build-android-obfuscated when STEALTH_ENABLED is set.
+# Can also be called standalone: make verify-stealth-jni
+.PHONY: verify-stealth-jni
+verify-stealth-jni:
+	@echo "=== verify-stealth-jni: checking JNI namespace in $(ANDROID_LIBS_DIR)/$(ANDROID_LIB) ==="
+	@tmpdir=$$(mktemp -d); \
+	trap 'rm -rf "$$tmpdir"' EXIT; \
+	aar="$(ANDROID_LIBS_DIR)/$(ANDROID_LIB)"; \
+	if [ ! -f "$$aar" ]; then \
+	  echo "FAIL: AAR not found at $$aar — build stealth AAR first"; \
+	  exit 1; \
+	fi; \
+	unzip -q "$$aar" "jni/arm64-v8a/libgojni.so" -d "$$tmpdir" 2>/dev/null || \
+	  { echo "FAIL: libgojni.so not found in $$aar (expected jni/arm64-v8a/libgojni.so)"; exit 1; }; \
+	so="$$tmpdir/jni/arm64-v8a/libgojni.so"; \
+	bad=$$(nm -D "$$so" 2>/dev/null | grep -c "Java_lantern_io" || true); \
+	if [ "$$bad" -gt 0 ]; then \
+	  echo "FAIL: $$bad Java_lantern_io_* symbol(s) found — GOMOBILE_JAVAPKG=foundation.engine not applied:"; \
+	  nm -D "$$so" | grep "Java_lantern_io"; \
+	  exit 1; \
+	fi; \
+	good=$$(nm -D "$$so" 2>/dev/null | grep -c "Java_foundation_engine" || true); \
+	if [ "$$good" -eq 0 ]; then \
+	  echo "FAIL: no Java_foundation_engine_* symbols found — gomobile javapkg binding is missing"; \
+	  exit 1; \
+	fi; \
+	echo "PASS: JNI namespace gate — Java_lantern_io=0, Java_foundation_engine=$$good"
 
 .PHONY: android-debug android-debug-ci
 android-debug: $(ANDROID_DEBUG_BUILD)
@@ -561,25 +888,35 @@ android-debug: $(ANDROID_DEBUG_BUILD)
 android-debug-ci: ANDROID_DEBUG_FLUTTER_FLAGS :=
 android-debug-ci: $(ANDROID_DEBUG_BUILD)
 
-$(ANDROID_DEBUG_BUILD): $(ANDROID_LIB_BUILD)
-	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) $(ANDROID_DEBUG_FLUTTER_FLAGS) --build-name=$(APP_VERSION_PUBSPEC) --debug -Plantern.sideloadUpdates=true
+$(ANDROID_DEBUG_BUILD): $(ANDROID_LIB_BUILD) $(MAYBE_STEALTH_PROFILE)
+	$(MAKE) android-identity-profile
+	$(STEALTH_PROFILE_ENV) $(ANDROID_IDENTITY_ENV) $(STEALTH_FLUTTER_PREFIX) flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) $(ANDROID_DEBUG_FLUTTER_FLAGS) --build-name=$(APP_VERSION_PUBSPEC) --debug $(STEALTH_FLUTTER_TARGET) $(FLUTTER_DART_DEFINES) $(STEALTH_DART_DEFINES) $(ANDROID_IDENTITY_DART_DEFINES) -Plantern.sideloadUpdates=true
 
 # --target-platform restricts Flutter's libapp.so / libflutter.so to arm64.
 # abiFilters is arm64-only for all artifacts now (no thinAbi flag needed).
 # -Plantern.sideloadUpdates=true adds REQUEST_INSTALL_PACKAGES only to the
 # direct-download APK artifact; Play AAB builds intentionally omit it.
 .PHONY: android-apk-release
-android-apk-release:
-	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --build-name=$(APP_VERSION_PUBSPEC) --release $(DART_DEFINES) -Plantern.sideloadUpdates=true
+android-apk-release: android-identity-profile $(MAYBE_STEALTH_PROFILE)
+	$(STEALTH_PROFILE_ENV) $(ANDROID_IDENTITY_ENV) $(STEALTH_FLUTTER_PREFIX) flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --build-name=$(APP_VERSION_PUBSPEC) --release $(STEALTH_FLUTTER_TARGET) $(STEALTH_FLUTTER_OBFUSCATE) $(FLUTTER_DART_DEFINES) $(STEALTH_DART_DEFINES) $(ANDROID_IDENTITY_DART_DEFINES) -Plantern.sideloadUpdates=true
+	$(if $(STEALTH_ENABLED),$(PYTHON) $(STEALTH_ANDROID_ARTIFACT_SANITIZER) --resign $(STEALTH_ANDROID_ARTIFACT_SIGNING_FLAGS) $(ANDROID_APK_RELEASE_BUILD),true)
 	cp $(ANDROID_APK_RELEASE_BUILD) $(ANDROID_RELEASE_APK)
 
 # AAB is arm64-only too (armeabi-v7a dropped — golang/go#70495 SIGSYS on
 # 32-bit). 32-bit-only devices no longer get Play updates; they were
 # crash-looping on Android 8-10 regardless.
 .PHONY: android-aab-release
-android-aab-release:
-	flutter build appbundle --target-platform $(ANDROID_AAB_TARGET_PLATFORMS) --verbose --build-name=$(APP_VERSION_PUBSPEC) --release $(DART_DEFINES)
+android-aab-release: android-identity-profile $(MAYBE_STEALTH_PROFILE)
+	$(STEALTH_PROFILE_ENV) $(ANDROID_IDENTITY_ENV) $(STEALTH_FLUTTER_PREFIX) flutter build appbundle --target-platform $(ANDROID_AAB_TARGET_PLATFORMS) --verbose --build-name=$(APP_VERSION_PUBSPEC) --release $(STEALTH_FLUTTER_TARGET) $(STEALTH_FLUTTER_OBFUSCATE) $(FLUTTER_DART_DEFINES) $(STEALTH_DART_DEFINES) $(ANDROID_IDENTITY_DART_DEFINES)
+	$(if $(STEALTH_ENABLED),$(PYTHON) $(STEALTH_ANDROID_ARTIFACT_SANITIZER) --resign $(STEALTH_ANDROID_ARTIFACT_SIGNING_FLAGS) $(ANDROID_AAB_RELEASE_BUILD),true)
 	cp $(ANDROID_AAB_RELEASE_BUILD) $(ANDROID_RELEASE_AAB)
+	$(MAKE) android-copy-play-artifacts
+
+.PHONY: android-copy-play-artifacts
+android-copy-play-artifacts:
+ifneq ($(strip $(STEALTH_ENABLED)),)
+	@echo "Skipping Play mapping and native symbols copy for stealth build"
+else
 	# Copy Play console artifacts
 	@if [ -f "$(ANDROID_MAPPING_SRC)" ]; then \
 	  cp "$(ANDROID_MAPPING_SRC)" mapping.txt; \
@@ -590,13 +927,59 @@ android-aab-release:
 	elif [ -d "build/app/intermediates/merged_native_libs/release/out/lib" ]; then \
 	  (cd build/app/intermediates/merged_native_libs/release/out && zip -r ../../../../../../debug-symbols.zip lib >/dev/null); \
 	fi
+endif
+
+.PHONY: android-stealth-novpn-apk-release
+android-stealth-novpn-apk-release:
+	$(MAKE) $(STEALTH_NOVPN_BUILD_VARS) stealth-android-sources android pubget gen android-apk-release
+
+.PHONY: android-stealth-novpn-aab-release
+android-stealth-novpn-aab-release:
+	$(MAKE) $(STEALTH_NOVPN_BUILD_VARS) stealth-android-sources android pubget gen android-aab-release
+
+.PHONY: android-stealth-novpn-release
+android-stealth-novpn-release:
+	$(MAKE) $(STEALTH_NOVPN_BUILD_VARS) stealth-android-sources android-release-ci
+
+.PHONY: android-stealth-vpn-apk-release
+android-stealth-vpn-apk-release:
+	$(MAKE) $(STEALTH_VPN_BUILD_VARS) stealth-android-sources android pubget gen android-apk-release
+
+.PHONY: android-stealth-vpn-aab-release
+android-stealth-vpn-aab-release:
+	$(MAKE) $(STEALTH_VPN_BUILD_VARS) stealth-android-sources android pubget gen android-aab-release
+
+.PHONY: android-stealth-vpn-release
+android-stealth-vpn-release:
+	$(MAKE) $(STEALTH_VPN_BUILD_VARS) stealth-android-sources android-release-ci
 
 
 .PHONY: android-release
-android-release: clean android pubget gen android-apk-release
+android-release: clean android pubget gen android-identity-profile android-apk-release
 
 .PHONY: android-release-ci
-android-release-ci: android pubget gen android-apk-release android-aab-release
+android-release-ci: android pubget gen android-identity-profile android-apk-release android-aab-release
+
+.PHONY: stealth-leakage-check stealth-novpn-leakage-check
+stealth-leakage-check:
+	$(PYTHON) scripts/stealth/check_leakage.py \
+		--config "$(STEALTH_LEAKAGE_CONFIG)" \
+		--mode "$(STEALTH_LEAKAGE_MODE)" \
+		$(if $(filter 1 true yes,$(STEALTH_LEAKAGE_MISSING_OK)),--missing-ok,) \
+		$(STEALTH_LEAKAGE_PATHS)
+
+stealth-novpn-leakage-check:
+	$(MAKE) stealth-leakage-check STEALTH_LEAKAGE_MODE=stealth-novpn
+
+.PHONY: android-release-obfuscated
+android-release-obfuscated: clean android-obfuscated pubget gen android-identity-profile android-apk-release
+
+.PHONY: android-release-ci-obfuscated
+android-release-ci-obfuscated: android-obfuscated pubget gen android-identity-profile android-apk-release android-aab-release
+
+.PHONY: stealth-manifest-filter-test
+stealth-manifest-filter-test:
+	$(PYTHON) -m unittest discover -s scripts/stealth -p '*_test.py'
 
 # iOS Build
 .PHONY: install-ios-deps
@@ -610,18 +993,18 @@ ios: $(IOS_FRAMEWORK_BUILD)
 .PHONY: ios
 ios: check-gomobile $(IOS_FRAMEWORK_BUILD)
 
-$(IOS_FRAMEWORK_BUILD): $(GO_SOURCES)
+$(IOS_FRAMEWORK_BUILD): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
 	$(MAKE) build-ios
 
-build-ios:
+build-ios: $(MAYBE_STEALTH_PROFILE)
 	@echo "Building iOS Framework.."
 	rm -rf $(IOS_FRAMEWORK_BUILD)
 	rm -rf $(IOS_FRAMEWORK_DIR) && mkdir -p $(IOS_FRAMEWORK_DIR)
 	GOOS=ios gomobile bind -v \
-		-tags=$(TAGS),with_low_memory, -trimpath \
+		-tags=$(TAGS),with_low_memory$(STEALTH_GO_TAGS) -trimpath \
 		-target=ios \
 		-o $(IOS_FRAMEWORK_BUILD) \
-		-ldflags="-w -s -checklinkname=0 $(EXTRA_LDFLAGS)" \
+		-ldflags="-w -s -checklinkname=0 $(GO_EXTRA_LDFLAGS)" \
 		$(GOMOBILE_REPOS)
 	@echo "Built iOS Framework: $(IOS_FRAMEWORK_BUILD)"
 	mv $(IOS_FRAMEWORK_BUILD) $(IOS_FRAMEWORK_DIR)
@@ -638,8 +1021,8 @@ format:
 	@echo "Formatting Swift code..."
 	$(MAKE) swift-format
 
-ios-release: clean pubget ios
-	flutter build ipa --release --export-options-plist ./ExportOptions.plist $(DART_DEFINES)
+ios-release: clean pubget ios $(MAYBE_STEALTH_PROFILE)
+	flutter build ipa --release --export-options-plist ./ExportOptions.plist $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 	@set -e; \
 	  IPA_DIR="$(CURDIR)/build/ios/ipa"; \
 	  IPA_SRC=$$(ls -t "$$IPA_DIR"/*.ipa 2>/dev/null | head -n 1); \

--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,10 @@ endif
 EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'
 STEALTH_GO_IMPORT_PATH := github.com/getlantern/lantern/lantern-core
 STEALTH_GO_LOG_LEVEL ?= warn
-STEALTH_GO_LDFLAGS := $(if $(filter stealth stealth-%,$(BUILD_TYPE)),-X '$(STEALTH_GO_IMPORT_PATH).StealthBuild=true' -X '$(STEALTH_GO_IMPORT_PATH).StealthLogLevel=$(STEALTH_GO_LOG_LEVEL)')
+# Stealth can be activated via a stealth BUILD_TYPE or via STEALTH_MODE/STEALTH_PROFILE
+# (which leave BUILD_TYPE=production), so gate stealth flags on all three signals.
+STEALTH_ACTIVE := $(strip $(filter stealth stealth-%,$(BUILD_TYPE))$(STEALTH_MODE)$(STEALTH_PROFILE))
+STEALTH_GO_LDFLAGS := $(if $(STEALTH_ACTIVE),-X '$(STEALTH_GO_IMPORT_PATH).StealthBuild=true' -X '$(STEALTH_GO_IMPORT_PATH).StealthLogLevel=$(STEALTH_GO_LOG_LEVEL)')
 GO_EXTRA_LDFLAGS := $(strip $(EXTRA_LDFLAGS) $(STEALTH_GO_LDFLAGS))
 LANTERND_EXTRA_LDFLAGS := $(EXTRA_LDFLAGS)
 
@@ -110,7 +113,7 @@ LINUX_INSTALLER_RPM := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYP
 LINUX_INSTALLER_ARCH := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE))$(LINUX_PACKAGE_ARCH_SUFFIX).pkg.tar.zst
 LANTERND := lanternd
 LANTERND_SRC := $(RADIANCE_REPO)/cmd/lanternd
-LANTERND_SERVICE_LOG_LEVEL ?= $(if $(filter stealth stealth-%,$(BUILD_TYPE)),warn,trace)
+LANTERND_SERVICE_LOG_LEVEL ?= $(if $(STEALTH_ACTIVE),warn,trace)
 LANTERND_LINUX_AMD64 := $(BIN_DIR)/linux-amd64/$(LANTERND)
 LANTERND_LINUX_ARM64 := $(BIN_DIR)/linux-arm64/$(LANTERND)
 LINUX_BUNDLE_DIR_X64 := build/linux/x64/release/bundle
@@ -333,11 +336,11 @@ $(STEALTH_PROFILE_STAMP): FORCE $(STEALTH_PROFILE_SCRIPT)
 	$(call MKDIR_P,$(dir $(STEALTH_PROFILE_STAMP)))
 	@set -e; { \
 	  printf 'STEALTH_PROFILE_SCRIPT_SHA256='; \
-	  python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE_SCRIPT)"; \
+	  $(PYTHON) -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE_SCRIPT)"; \
 	  printf 'STEALTH_PROFILE=%s\n' "$(STEALTH_PROFILE)"; \
 	  printf 'STEALTH_PROFILE_SHA256='; \
 	  if [ -n "$(STEALTH_PROFILE)" ] && [ -f "$(STEALTH_PROFILE)" ]; then \
-	    python3 -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE)"; \
+	    $(PYTHON) -c 'import hashlib, pathlib, sys; print(hashlib.sha256(pathlib.Path(sys.argv[1]).read_bytes()).hexdigest())' "$(STEALTH_PROFILE)"; \
 	  else \
 	    printf '\n'; \
 	  fi; \
@@ -347,7 +350,7 @@ $(STEALTH_PROFILE_STAMP): FORCE $(STEALTH_PROFILE_SCRIPT)
 	  printf 'STEALTH_SESSION_NAME=%s\n' "$(STEALTH_SESSION_NAME)"; \
 	  printf 'STEALTH_GO_OBFUSCATION_SEED_SHA256='; \
 	  if [ -n "$(STEALTH_GO_OBFUSCATION_SEED)" ]; then \
-	    python3 -c 'import hashlib, sys; print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())' "$(STEALTH_GO_OBFUSCATION_SEED)"; \
+	    $(PYTHON) -c 'import hashlib, sys; print(hashlib.sha256(sys.argv[1].encode("utf-8")).hexdigest())' "$(STEALTH_GO_OBFUSCATION_SEED)"; \
 	  else \
 	    printf '\n'; \
 	  fi; \
@@ -417,7 +420,7 @@ check-garble-go:
 
 .PHONY: stealth-android-icons
 stealth-android-icons: guard-STEALTH_ICON_SEED
-	python3 scripts/stealth/generate_android_icons.py \
+	$(PYTHON) scripts/stealth/generate_android_icons.py \
 		--output-res-dir "$(STEALTH_ICON_RES_DIR)"
 
 
@@ -784,12 +787,12 @@ android-identity-profile: $(MAYBE_STEALTH_PROFILE)
 	  fi; \
 		  if [ ! -f "$(ANDROID_IDENTITY_PROFILE)" ] || [ -n "$(ANDROID_IDENTITY_SEED)" ] || [ "$(ANDROID_FORCE_IDENTITY_PROFILE)" = "1" ] || [ "$(ANDROID_FORCE_IDENTITY_PROFILE)" = "true" ] || [ "$(ANDROID_FORCE_IDENTITY_PROFILE)" = "yes" ]; then \
 		    mkdir -p "$$(dirname "$(ANDROID_IDENTITY_PROFILE)")"; \
-		    python3 scripts/stealth/generate_android_identity.py \
+		    $(PYTHON) scripts/stealth/generate_android_identity.py \
 		      --output "$(ANDROID_IDENTITY_PROFILE)" \
 		      $(if $(STEALTH_ENABLED),--profile "$(STEALTH_PROFILE_OUT)",) \
 		      $(if $(ANDROID_IDENTITY_SEED),--seed "$(ANDROID_IDENTITY_SEED)",); \
 		  elif [ -n "$(STEALTH_ENABLED)" ]; then \
-		    python3 scripts/stealth/generate_android_identity.py \
+		    $(PYTHON) scripts/stealth/generate_android_identity.py \
 		      --output "$(ANDROID_IDENTITY_PROFILE)" \
 		      --profile "$(STEALTH_PROFILE_OUT)"; \
 		  else \

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -53,9 +53,238 @@ def generateSideloadManifest = tasks.register("generateSideloadManifest") {
 // would break upgrades.
 def EPOCH_2009 = 1230768000L // 2009-01-01T00:00:00Z, in seconds
 def code = (int)((System.currentTimeMillis() / 1000L) - EPOCH_2009)
+def stealthIconSeed = (findProperty("stealthIconSeed") ?: System.getenv("STEALTH_ICON_SEED"))?.toString()?.trim()
+def sha256Hex = { value ->
+    java.security.MessageDigest.getInstance("SHA-256")
+            .digest(value.getBytes("UTF-8"))
+            .collect { String.format("%02x", it & 0xff) }
+            .join()
+}
+def stealthIconSeedSha256 = stealthIconSeed ? sha256Hex(stealthIconSeed) : ""
+def generatedStealthIconResDir = layout.buildDirectory.dir("generated/icons/res")
+def generatedStealthIconMetadata = layout.buildDirectory.file("generated/icons/stealth-icon-metadata.json")
+def generatedStealthIconScript = file("${rootProject.projectDir.parentFile}/scripts/stealth/generate_android_icons.py")
+def launcherIconResource = stealthIconSeed ? "@mipmap/ic_launcher_alt" : "@mipmap/ic_launcher"
+def roundLauncherIconResource = stealthIconSeed ? "@mipmap/ic_launcher_alt_round" : "@mipmap/ic_launcher_round"
+
+def defaultStealthProfile = [
+        mode                        : "normal",
+        packageName                 : "org.getlantern.lantern",
+        appName                     : "Lantern",
+        sessionName                 : "LanternVpn",
+        denylistVersion             : 0,
+        directConnectionAppsEnabled : false,
+]
+
+def stealthModeAliases = [
+        vpn  : "stealth-vpn",
+        novpn: "stealth-novpn",
+]
+
+def normalizeStealthMode = { value ->
+    def mode = value.toString().trim()
+    return stealthModeAliases.get(mode, mode)
+}
+
+def buildConfigString = { value ->
+    def escaped = value.toString()
+            .replace("\\", "\\\\")
+            .replace("\n", "\\n")
+            .replace("\r", "\\r")
+            .replace("\t", "\\t")
+            .replace("\b", "\\b")
+            .replace("\f", "\\f")
+            .replace("\"", "\\\"")
+    return "\"${escaped}\""
+}
+
+def manifestPlaceholderString = { fieldName, value ->
+    def text = value.toString()
+    if (!text.trim()) {
+        throw new GradleException("Stealth profile ${fieldName} must not be empty")
+    }
+    for (int i = 0; i < text.length(); i++) {
+        def ch = text.charAt(i)
+        if (Character.isISOControl(ch) || ['"', "'", '&', '<', '>'].contains(String.valueOf(ch))) {
+            throw new GradleException(
+                    "Stealth profile ${fieldName} contains XML-reserved or control characters"
+            )
+        }
+    }
+    return text
+}
+
+def nonNegativeInteger = { fieldName, value ->
+    try {
+        def parsed = Integer.parseInt(value.toString())
+        if (parsed < 0) {
+            throw new NumberFormatException("negative")
+        }
+        return parsed
+    } catch (NumberFormatException ignored) {
+        throw new GradleException("Stealth profile ${fieldName} must be a non-negative integer")
+    }
+}
+
+def androidApplicationId = { fieldName, value ->
+    if (!(value instanceof CharSequence)) {
+        throw new GradleException("Stealth profile ${fieldName} must be a string")
+    }
+    def text = value.toString().trim()
+    if (!(text ==~ /[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+/)) {
+        throw new GradleException(
+                "Stealth profile ${fieldName} must be a valid Android applicationId"
+        )
+    }
+    return text
+}
+
+def resolveRepoRelativeFile = { path ->
+    def candidate = new File(path.toString())
+    if (candidate.isAbsolute()) {
+        return candidate
+    }
+    def fromRepoRoot = new File(rootProject.projectDir.parentFile, path.toString())
+    if (fromRepoRoot.exists()) {
+        return fromRepoRoot
+    }
+    return file(path.toString())
+}
+
+def loadStealthProfile = {
+    def profilePath = (findProperty("stealthProfile") ?: System.getenv("STEALTH_PROFILE"))?.toString()?.trim()
+    if (!profilePath) {
+        return defaultStealthProfile
+    }
+
+    def profileFile = resolveRepoRelativeFile(profilePath)
+    if (!profileFile.exists()) {
+        throw new GradleException("Stealth profile not found: ${profilePath}")
+    }
+
+    def parsed = new groovy.json.JsonSlurper().parse(profileFile)
+    if (!(parsed instanceof Map)) {
+        throw new GradleException("Stealth profile must be a JSON object: ${profileFile}")
+    }
+
+    def profile = defaultStealthProfile + parsed.findAll { it.value != null }
+    profile.mode = normalizeStealthMode(profile.mode)
+    if (!["stealth-vpn", "stealth-novpn"].contains(profile.mode)) {
+        throw new GradleException(
+                "Unsupported Stealth mode '${profile.mode}' in ${profileFile}; expected stealth-vpn, stealth-novpn, vpn, or novpn"
+        )
+    }
+    profile.appName = manifestPlaceholderString("appName", profile.appName)
+    profile.sessionName = manifestPlaceholderString("sessionName", profile.sessionName)
+    profile.denylistVersion = nonNegativeInteger("denylistVersion", profile.denylistVersion)
+    profile.packageName = androidApplicationId("packageName", profile.packageName)
+    // directConnectionAppsEnabled: profile JSON stores a boolean; default true for stealth modes.
+    def rawDca = profile.get("directConnectionAppsEnabled")
+    if (rawDca == null) {
+        profile.directConnectionAppsEnabled = ["stealth-vpn", "stealth-novpn"].contains(profile.mode)
+    } else if (rawDca instanceof Boolean) {
+        profile.directConnectionAppsEnabled = rawDca
+    } else {
+        throw new GradleException("Stealth profile directConnectionAppsEnabled must be a boolean")
+    }
+    return profile
+}
+
+def stealthProfile = loadStealthProfile()
+
+def rawStealthMode = stealthProfile.mode.toString()
+if (!rawStealthMode || rawStealthMode == "normal") {
+    rawStealthMode = (project.findProperty("STEALTH_MODE") ?: "").toString()
+}
+rawStealthMode = rawStealthMode.trim().toLowerCase(java.util.Locale.ROOT)
+def stealthModePrefix = "stealth-"
+def stealthMode = rawStealthMode.startsWith(stealthModePrefix)
+        ? rawStealthMode.substring(stealthModePrefix.length())
+        : rawStealthMode
+if (rawStealthMode.startsWith(stealthModePrefix) && !stealthMode) {
+    throw new GradleException("Unsupported STEALTH_MODE '${rawStealthMode}'. Expected stealth-vpn or stealth-novpn")
+}
+def explicitStealthNoVpn = project.findProperty("stealthNoVpn")?.toString()?.toBoolean() ?: false
+if (stealthMode == "vpn" && explicitStealthNoVpn) {
+    throw new GradleException("Conflicting stealth inputs: STEALTH_MODE=vpn cannot be combined with -PstealthNoVpn=true")
+}
+if (!stealthMode && explicitStealthNoVpn) {
+    stealthMode = "novpn"
+}
+def stealthModes = ["vpn", "novpn"]
+if (stealthMode && !stealthModes.contains(stealthMode)) {
+    throw new GradleException("Unsupported STEALTH_MODE '${stealthMode}'. Expected one of: ${stealthModes.join(', ')}")
+}
+def stealthNoVpn = explicitStealthNoVpn || stealthMode == "novpn"
+def stealthManifest = layout.buildDirectory.file("generated/stealth/${stealthMode}/AndroidManifest.xml").get().asFile
+def stealthManifestFilter = file("${rootProject.projectDir}/../scripts/stealth/android_manifest_filter.py")
+def stealthPython = (project.findProperty("stealthPython") ?: System.getenv("PYTHON") ?: "python3").toString()
+// Stealth compiles a de-branded COPY of the REAL Kotlin (generated by
+// scripts/stealth/debrand_kotlin.py into build/stealth/android/) so the app
+// ships its real native bridge, not the legacy foundation.bridge stub.
+def stealthGeneratedKotlinDir = new File(rootProject.projectDir.parentFile, "build/stealth/android/kotlin")
+def stealthGeneratedResDir = new File(rootProject.projectDir.parentFile, "build/stealth/android/res")
+// src/main/java holds Flutter's generated io.flutter.plugins.GeneratedPluginRegistrant
+// (brand-free) — required so plugins (path_provider, shared_preferences, ...) register;
+// without it storage init throws and the app hangs on a black screen.
+def stealthAndroidSourceDirs = [stealthGeneratedKotlinDir, 'src/main/java']
+
+def androidIdentityDefaults = [
+        applicationId: stealthProfile.packageName.toString(),
+        appLabel: stealthProfile.appName.toString(),
+        launcherLabel: stealthProfile.appName.toString(),
+        identityLabel: stealthProfile.appName.toString(),
+        identityProfileId: "standard",
+        identityMetadata: "{}",
+        vpnSessionName: stealthProfile.sessionName.toString(),
+        notificationChannelVpn: stealthMode ? "${stealthProfile.appName} Status" : "VPN",
+        notificationChannelDataUsage: "Data Usage",
+        notificationTitle: stealthProfile.appName.toString(),
+        notificationConnectedText: stealthMode ? "${stealthProfile.appName} is active" : "${stealthProfile.appName} VPN is running",
+        notificationStartingText: stealthMode ? "Starting ${stealthProfile.appName}..." : "Starting ${stealthProfile.appName} VPN...",
+        notificationDisconnectAction: "Disconnect",
+        quickTileActiveLabel: stealthMode ? "${stealthProfile.appName} on" : "VPN Connected",
+        quickTileInactiveLabel: stealthMode ? "${stealthProfile.appName} off" : "VPN Disconnected",
+        appIcon: stealthMode ? "@drawable/neutral_app_icon" : "@mipmap/ic_launcher",
+        appRoundIcon: stealthMode ? "@drawable/neutral_app_icon" : "@mipmap/ic_launcher_round",
+        notificationSmallIcon: stealthMode ? "@drawable/neutral_notification_icon" : "@drawable/lantern_notification_icon",
+        quickTileIcon: stealthMode ? "@drawable/neutral_notification_icon" : "@drawable/lantern_notification_icon",
+        appAuthScheme: stealthMode ? "mobileapp" : "lantern",
+]
+
+def androidIdentityProfilePath =
+        (project.findProperty("androidIdentityProfile") ?: System.getenv("ANDROID_IDENTITY_PROFILE"))?.toString()?.trim()
+def androidIdentity = new LinkedHashMap(androidIdentityDefaults)
+if (androidIdentityProfilePath) {
+    def profileFile = new File(androidIdentityProfilePath)
+    if (!profileFile.isAbsolute()) {
+        profileFile = new File(rootProject.projectDir.parentFile, androidIdentityProfilePath)
+    }
+    if (!profileFile.exists()) {
+        throw new GradleException("Android identity profile not found: ${profileFile}")
+    }
+    def props = new java.util.Properties()
+    profileFile.withReader("UTF-8") { props.load(it) }
+    props.each { key, value ->
+        def name = key.toString()
+        if (!androidIdentity.containsKey(name)) {
+            throw new GradleException("Unknown Android identity profile key '${name}' in ${profileFile}")
+        }
+        androidIdentity[name] = value.toString()
+    }
+}
+
+if (stealthIconSeed) {
+    androidIdentity.appIcon = launcherIconResource
+    androidIdentity.appRoundIcon = roundLauncherIconResource
+}
+
+if (!(androidIdentity.applicationId ==~ /^[A-Za-z][A-Za-z0-9_]*(\.[A-Za-z][A-Za-z0-9_]*)+$/)) {
+    throw new GradleException("Invalid Android applicationId in identity profile: ${androidIdentity.applicationId}")
+}
 
 android {
-    namespace = "org.getlantern.lantern"
+    namespace = stealthMode ? "foundation.bridge" : "org.getlantern.lantern"
     compileSdk = 36
     ndkVersion "28.2.13676358"
 
@@ -67,8 +296,17 @@ android {
             if (sideloadUpdates) {
                 manifest.srcFile sideloadManifestPath
             }
+            if (stealthMode) {
+                manifest.srcFile stealthManifest
+                java.srcDirs = stealthAndroidSourceDirs
+                kotlin.srcDirs = stealthAndroidSourceDirs
+                res.srcDirs = [stealthGeneratedResDir]
+            }
             jniLibs.srcDirs = ['libs']
             jniLibs.srcDirs += ['src/main/jniLibs']
+            if (stealthIconSeed) {
+                res.srcDirs += [generatedStealthIconResDir.get().asFile]
+            }
         }
     }
 
@@ -94,6 +332,10 @@ android {
     // crashes). Constraint: abiFilters must match the ABIs Flutter built
     // (Makefile --target-platform), or installs crash with "Could not find
     // 'libflutter.so'".
+
+    buildFeatures {
+        buildConfig true
+    }
 
     // Use legacy packaging to help reduce apk size
     packagingOptions {
@@ -121,12 +363,27 @@ android {
     }
 
     defaultConfig {
-        applicationId = "org.getlantern.lantern"
+        applicationId = androidIdentity.applicationId
         minSdkVersion = 24
         targetSdk = 36
         versionCode = code
         versionName = flutter.versionName
         buildConfigField "String", "SIDELOAD_SIGNING_CERTIFICATE_SHA256", "\"${sideloadSigningCertificateSha256}\""
+        manifestPlaceholders = [
+                appName: androidIdentity.appLabel,
+                appLabel: androidIdentity.appLabel,
+                launcherLabel: androidIdentity.launcherLabel,
+                appIcon: androidIdentity.appIcon,
+                appRoundIcon: androidIdentity.appRoundIcon,
+                launcherIcon: androidIdentity.appIcon,
+                roundLauncherIcon: androidIdentity.appRoundIcon,
+                identityLabel: androidIdentity.identityLabel,
+                identityProfileId: androidIdentity.identityProfileId,
+                identityMetadata: androidIdentity.identityMetadata,
+                quickTileIcon: androidIdentity.quickTileIcon,
+                appAuthScheme: androidIdentity.appAuthScheme,
+        ]
+        resValue "string", "app_name", androidIdentity.appLabel
 
         ndk {
             // arm64 only (APK + AAB) — armeabi-v7a dropped, see the comment
@@ -141,9 +398,33 @@ android {
                 arguments "-DANDROID_ARM_NEON=TRUE", '-DANDROID_STL=c++_shared'
             }
         }
-        buildFeatures {
-            buildConfig true
-        }
+        buildConfigField "String", "ANDROID_IDENTITY_LABEL", buildConfigString(androidIdentity.identityLabel)
+        buildConfigField "String", "ANDROID_IDENTITY_PROFILE_ID", buildConfigString(androidIdentity.identityProfileId)
+        buildConfigField "String", "ANDROID_IDENTITY_METADATA", buildConfigString(androidIdentity.identityMetadata)
+        // The REAL app code reads these BuildConfig fields, so they must exist in
+        // BOTH stealth and regular builds (stealth now compiles the real handlers,
+        // not the legacy stub). Only STEALTH_ENABLED differs by build.
+        buildConfigField "boolean", "STEALTH_ENABLED", stealthMode ? "true" : "false"
+        buildConfigField "String", "STEALTH_MODE", buildConfigString(stealthProfile.mode)
+        buildConfigField "String", "STEALTH_PACKAGE_NAME", buildConfigString(stealthProfile.packageName)
+        buildConfigField "String", "STEALTH_APP_NAME", buildConfigString(stealthProfile.appName)
+        buildConfigField "String", "STEALTH_SESSION_NAME", buildConfigString(stealthProfile.sessionName)
+        buildConfigField "int", "STEALTH_DENYLIST_VERSION", stealthProfile.denylistVersion.toString()
+        buildConfigField "String", "VPN_SESSION_NAME", buildConfigString(androidIdentity.vpnSessionName)
+        buildConfigField "String", "NOTIFICATION_CHANNEL_VPN", buildConfigString(androidIdentity.notificationChannelVpn)
+        buildConfigField "String", "NOTIFICATION_CHANNEL_DATA_USAGE", buildConfigString(androidIdentity.notificationChannelDataUsage)
+        buildConfigField "String", "NOTIFICATION_TITLE", buildConfigString(androidIdentity.notificationTitle)
+        buildConfigField "String", "NOTIFICATION_CONNECTED_TEXT", buildConfigString(androidIdentity.notificationConnectedText)
+        buildConfigField "String", "NOTIFICATION_STARTING_TEXT", buildConfigString(androidIdentity.notificationStartingText)
+        buildConfigField "String", "NOTIFICATION_DISCONNECT_ACTION", buildConfigString(androidIdentity.notificationDisconnectAction)
+        buildConfigField "String", "QUICK_TILE_ACTIVE_LABEL", buildConfigString(androidIdentity.quickTileActiveLabel)
+        buildConfigField "String", "QUICK_TILE_INACTIVE_LABEL", buildConfigString(androidIdentity.quickTileInactiveLabel)
+        buildConfigField "String", "NOTIFICATION_SMALL_ICON", buildConfigString(androidIdentity.notificationSmallIcon)
+        buildConfigField "boolean", "STEALTH_DIRECT_CONNECTION_APPS",
+                stealthProfile.directConnectionAppsEnabled.toString()
+        buildConfigField "boolean", "STEALTH_NO_VPN", stealthNoVpn.toString()
+        buildConfigField "String", "STEALTH_NO_VPN_PROXY_HOST", '"127.0.0.1"'
+        buildConfigField "int", "STEALTH_NO_VPN_PROXY_PORT", "14986"
     }
 
     signingConfigs {
@@ -177,6 +458,9 @@ android {
             }
             buildConfigField "boolean", "DEVELOPMENT_MODE", "false"
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            if (stealthNoVpn) {
+                proguardFiles 'proguard-stealth-novpn.pro'
+            }
         }
     }
 
@@ -187,6 +471,49 @@ if (sideloadUpdates) {
             .configureEach { dependsOn(generateSideloadManifest) }
 }
 
+if (stealthMode) {
+    afterEvaluate {
+        tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach { task ->
+            task.setSource(files(stealthAndroidSourceDirs))
+            task.exclude("org/getlantern/**")
+        }
+    }
+}
+
+if (stealthMode) {
+    tasks.register("generateStealthManifest", Exec) {
+        inputs.file(file("src/main/AndroidManifest.xml"))
+        inputs.file(stealthManifestFilter)
+        inputs.property("stealthMode", stealthMode)
+        outputs.file(stealthManifest)
+        commandLine(
+                stealthPython,
+                stealthManifestFilter.absolutePath,
+                "--mode", stealthMode,
+                "--input", "${projectDir}/src/main/AndroidManifest.xml",
+                "--output", stealthManifest.absolutePath,
+        )
+    }
+
+    tasks.matching { it.name == "preBuild" }.configureEach {
+        dependsOn(tasks.named("generateStealthManifest"))
+    }
+}
+
+tasks.register("generateStealthAndroidIcons", Exec) {
+    onlyIf { stealthIconSeed }
+    inputs.property("stealthIconSeedSha256", stealthIconSeedSha256)
+    inputs.file(generatedStealthIconScript)
+    outputs.dir(generatedStealthIconResDir)
+    outputs.file(generatedStealthIconMetadata)
+    environment "STEALTH_ICON_SEED", stealthIconSeed ?: ""
+    commandLine stealthPython,
+            generatedStealthIconScript.absolutePath,
+            "--output-res-dir", generatedStealthIconResDir.get().asFile.absolutePath
+}
+
+preBuild.dependsOn("generateStealthAndroidIcons")
+
 flutter {
     source = "../.."
 }
@@ -194,8 +521,10 @@ flutter {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation fileTree(dir: "libs", include: "liblantern.aar")
-    implementation 'androidx.core:core-ktx:1.15.0'
-    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.8.7'
-    implementation 'androidx.work:work-runtime-ktx:2.10.0'
+    if (!stealthMode) {
+        implementation 'androidx.core:core-ktx:1.15.0'
+        implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.8.7'
+        implementation 'androidx.work:work-runtime-ktx:2.10.0'
+    }
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -216,6 +216,9 @@ if (stealthMode && !stealthModes.contains(stealthMode)) {
     throw new GradleException("Unsupported STEALTH_MODE '${stealthMode}'. Expected one of: ${stealthModes.join(', ')}")
 }
 def stealthNoVpn = explicitStealthNoVpn || stealthMode == "novpn"
+// Emit the resolved mode (e.g. "stealth-vpn"), not stealthProfile.mode, which
+// stays "normal" when stealth is enabled via -PSTEALTH_MODE without a profile.
+def resolvedStealthMode = stealthMode ? "${stealthModePrefix}${stealthMode}" : "normal"
 def stealthManifest = layout.buildDirectory.file("generated/stealth/${stealthMode}/AndroidManifest.xml").get().asFile
 def stealthManifestFilter = file("${rootProject.projectDir}/../scripts/stealth/android_manifest_filter.py")
 def stealthPython = (project.findProperty("stealthPython") ?: System.getenv("PYTHON") ?: "python3").toString()
@@ -405,7 +408,7 @@ android {
         // BOTH stealth and regular builds (stealth now compiles the real handlers,
         // not the legacy stub). Only STEALTH_ENABLED differs by build.
         buildConfigField "boolean", "STEALTH_ENABLED", stealthMode ? "true" : "false"
-        buildConfigField "String", "STEALTH_MODE", buildConfigString(stealthProfile.mode)
+        buildConfigField "String", "STEALTH_MODE", buildConfigString(resolvedStealthMode)
         buildConfigField "String", "STEALTH_PACKAGE_NAME", buildConfigString(stealthProfile.packageName)
         buildConfigField "String", "STEALTH_APP_NAME", buildConfigString(stealthProfile.appName)
         buildConfigField "String", "STEALTH_SESSION_NAME", buildConfigString(stealthProfile.sessionName)

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -458,9 +458,6 @@ android {
             }
             buildConfigField "boolean", "DEVELOPMENT_MODE", "false"
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-            if (stealthNoVpn) {
-                proguardFiles 'proguard-stealth-novpn.pro'
-            }
         }
     }
 
@@ -521,10 +518,10 @@ flutter {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation fileTree(dir: "libs", include: "liblantern.aar")
-    if (!stealthMode) {
-        implementation 'androidx.core:core-ktx:1.15.0'
-        implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.8.7'
-        implementation 'androidx.work:work-runtime-ktx:2.10.0'
-    }
+    // Used by the real app code (VPN status, logs, background work) in both
+    // stealth and regular builds, so these are always included.
+    implementation 'androidx.core:core-ktx:1.15.0'
+    implementation 'androidx.lifecycle:lifecycle-livedata-ktx:2.8.7'
+    implementation 'androidx.work:work-runtime-ktx:2.10.0'
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.1.5'
 }

--- a/docs/stealth-build-profile.md
+++ b/docs/stealth-build-profile.md
@@ -1,0 +1,113 @@
+# Stealth Build Profile
+
+Stealth builds use the normal Lantern source tree. The build is switched by
+passing either a generated profile mode or a private profile JSON file into the
+existing Makefile targets.
+
+Normal builds are unchanged when neither `STEALTH_MODE` nor `STEALTH_PROFILE`
+is set.
+
+## Generate a Profile
+
+Generate a private profile under `build/stealth/`:
+
+```sh
+make stealth-profile STEALTH_MODE=stealth-vpn
+```
+
+Supported modes are:
+
+- `stealth-vpn`
+- `stealth-novpn`
+
+The generated profile includes:
+
+- `mode`
+- `packageName`
+- `appName`
+- `sessionName`
+- `goObfuscationSeed`
+- `denylistVersion`
+
+Override generated values with Make variables:
+
+```sh
+make stealth-profile \
+  STEALTH_MODE=stealth-vpn \
+  STEALTH_PACKAGE_NAME=org.example.client.s123 \
+  STEALTH_APP_NAME=Client \
+  STEALTH_SESSION_NAME=ClientVpn \
+  STEALTH_GO_OBFUSCATION_SEED=0123456789abcdef \
+  STEALTH_DENYLIST_VERSION=1
+```
+
+Use an existing private profile:
+
+```sh
+make stealth-profile STEALTH_PROFILE=/secure/profiles/client.json
+```
+
+## Build With a Profile
+
+Android build targets generate or normalize the profile before invoking Flutter:
+
+```sh
+make android-release STEALTH_MODE=stealth-vpn
+make android-release STEALTH_PROFILE=/secure/profiles/client.json
+```
+
+The Makefile writes:
+
+- `build/stealth/profile.json`: private normalized profile for support/debugging
+- `build/stealth/profile.inputs`: private Make cache key for profile inputs
+- `build/stealth/dart-defines.json`: Flutter `--dart-define-from-file` input
+- `build/stealth/artifact-metadata.json`: private CI artifact metadata
+- `build/stealth/go-tags-suffix.txt`: Go build tag suffix consumed by Make
+
+Treat the entire `build/stealth/` directory as private and do not publish these
+files in public release artifacts. They contain profile values that identify a
+build stream. Dart defines, metadata, and the Make cache key omit the raw Go
+obfuscation seed; metadata and the cache key include seed hashes for change
+detection and support correlation.
+
+## Android Plumbing
+
+`android/app/build.gradle` reads the normalized profile from a
+`-PstealthProfile=/path/to/profile` Gradle property, or from
+`ORG_GRADLE_PROJECT_stealthProfile` when invoked through Flutter/Make. The
+legacy `STEALTH_PROFILE` environment variable remains a fallback for manual
+non-daemon Gradle invocations.
+
+Gradle profile loading only affects Android manifest and `BuildConfig` values.
+It does not populate Dart constants by itself. Use the Make targets, or pass
+the generated `build/stealth/dart-defines.json` explicitly with
+`flutter build --dart-define-from-file=build/stealth/dart-defines.json`, so
+`AppBuildInfo` and `AppSecrets` see the same profile values as Gradle.
+
+The profile sets:
+
+- Android `applicationId`
+- Android manifest app label
+- `BuildConfig.STEALTH_*` constants
+
+For stealth builds the Android namespace becomes `foundation.bridge` (normal
+builds keep `org.getlantern.lantern`); see the `namespace` assignment in
+`android/app/build.gradle`. No separate source tree is needed.
+
+## Dart and Go Plumbing
+
+Flutter receives profile values through `--dart-define-from-file`, exposed in
+`AppBuildInfo.stealth*` constants. Go builds receive a tag suffix from
+`generate_profile.py` (`go_tags_suffix`):
+
+- `stealth` (all stealth builds)
+- `novpn` (added only for `stealth-novpn` mode)
+
+## Package Name Migration Tradeoff
+
+Generated stealth profiles use a per-profile Android package name by default.
+Android treats each package name as a different app, so a build with a new
+`packageName` does not update an existing install and does not share that app's
+data directory. Release and support workflows need to keep the private profile
+for each distributed build so they can identify which package name, app label,
+session name, denylist version, and Go obfuscation seed were used.

--- a/docs/stealth-build-profile.md
+++ b/docs/stealth-build-profile.md
@@ -9,10 +9,15 @@ is set.
 
 ## Generate a Profile
 
-Generate a private profile under `build/stealth/`:
+Generate a private profile under `build/stealth/`. Stealth modes require
+non-branded app and session names (the generator rejects empty or
+Lantern-branded values):
 
 ```sh
-make stealth-profile STEALTH_MODE=stealth-vpn
+make stealth-profile \
+  STEALTH_MODE=stealth-vpn \
+  STEALTH_APP_NAME=Client \
+  STEALTH_SESSION_NAME=ClientVpn
 ```
 
 Supported modes are:
@@ -52,7 +57,10 @@ make stealth-profile STEALTH_PROFILE=/secure/profiles/client.json
 Android build targets generate or normalize the profile before invoking Flutter:
 
 ```sh
-make android-release STEALTH_MODE=stealth-vpn
+make android-release \
+  STEALTH_MODE=stealth-vpn \
+  STEALTH_APP_NAME=Client \
+  STEALTH_SESSION_NAME=ClientVpn
 make android-release STEALTH_PROFILE=/secure/profiles/client.json
 ```
 

--- a/docs/stealth-feature-gates.md
+++ b/docs/stealth-feature-gates.md
@@ -1,0 +1,47 @@
+# Stealth feature gates
+
+Stealth artifacts disable high-identification product surfaces at compile time
+with Dart environment defines. Normal builds remain unchanged.
+
+## Build flags
+
+Use either profile-style mode names or an explicit boolean flag:
+
+```sh
+flutter build apk --dart-define=STEALTH_MODE=stealth-vpn
+flutter build apk --dart-define=STEALTH_MODE=stealth-novpn
+flutter build apk --dart-define=STEALTH_MODE=true
+flutter build apk --dart-define=STEALTH_BUILD=true
+flutter build apk --dart-define=STEALTH_NO_VPN=true
+```
+
+`STEALTH_MODE=true` is kept as a compatibility alias for generic stealth
+artifacts; profile-specific builds should prefer `stealth-vpn` or
+`stealth-novpn`.
+
+The app derives these gates from the stealth flag:
+
+- `enableOAuth`
+- `enableAppLinks`
+- `enableSocialLinks`
+- `enableAutoUpdate`
+
+`STEALTH_NO_VPN=true` is the explicit no-VPN compatibility flag. It enables the
+same feature gates as `STEALTH_BUILD=true` and is treated as stealth mode even
+when `STEALTH_MODE` is not supplied.
+
+## Disabled surfaces
+
+Stealth builds hide or short-circuit:
+
+- OAuth login buttons, callbacks, and SSO account deletion verification.
+- Runtime app-link handling in Flutter.
+- Follow-us, forum, alternate download, referral/social, and project-link
+  surfaces.
+- Desktop auto-update initialization, manual update checks, and appcast URL
+  resolution.
+
+Native manifest and entitlement removal is handled by the stealth manifest
+filtering build step. Artifact leakage checks should still scan final APK/IPA
+and desktop bundles for OAuth provider names, app-link hosts/schemes, billing
+entry points, social URLs, and appcast/update URLs.

--- a/lib/core/common/app_build_info.dart
+++ b/lib/core/common/app_build_info.dart
@@ -17,6 +17,77 @@ class AppBuildInfo {
     defaultValue: false,
   );
 
+  static const String stealthMode = String.fromEnvironment(
+    'STEALTH_MODE',
+    defaultValue: 'normal',
+  );
+
+  static const bool stealthNoVpn = bool.fromEnvironment(
+    'STEALTH_NO_VPN',
+    defaultValue: false,
+  );
+
+  static const String stealthPackageName = String.fromEnvironment(
+    'STEALTH_PACKAGE_NAME',
+    defaultValue: 'org.getlantern.lantern',
+  );
+
+  static const String stealthAppName = String.fromEnvironment(
+    'STEALTH_APP_NAME',
+    defaultValue: 'Lantern',
+  );
+
+  static const String stealthSessionName = String.fromEnvironment(
+    'STEALTH_SESSION_NAME',
+    defaultValue: 'LanternVpn',
+  );
+
+  static const int stealthDenylistVersion = int.fromEnvironment(
+    'STEALTH_DENYLIST_VERSION',
+    defaultValue: 0,
+  );
+
+  static bool get isStealthBuild =>
+      stealthBuild ||
+      stealthNoVpn ||
+      stealthMode.startsWith('stealth-') ||
+      stealthMode == 'true';
+
+  static const bool stealthBuild = bool.fromEnvironment(
+    'STEALTH_BUILD',
+    defaultValue: false,
+  );
+
+  /// Removes high-identification UI and runtime flows from stealth artifacts.
+  static const bool suppressIdentifyingFeatures =
+      stealthBuild ||
+      stealthNoVpn ||
+      stealthMode == 'stealth-vpn' ||
+      stealthMode == 'stealth-novpn' ||
+      stealthMode == 'true';
+
+  static const bool enableOAuth = !suppressIdentifyingFeatures;
+
+  static const bool enableAppLinks = !suppressIdentifyingFeatures;
+
+  static const bool enableSocialLinks = !suppressIdentifyingFeatures;
+
+  static const bool enableAutoUpdate = !suppressIdentifyingFeatures;
+
+  static const String appAuthScheme = String.fromEnvironment(
+    'APP_AUTH_SCHEME',
+    defaultValue: 'lantern',
+  );
+
+  static bool isAppAuthUri(Uri uri) {
+    return uri.scheme == appAuthScheme;
+  }
+
+  static const bool stealthDirectConnectionApps = bool.fromEnvironment(
+    'STEALTH_DIRECT_CONNECTION_APPS',
+    defaultValue: false,
+  );
+
   /// Developer mode is exposed in debug and nightly builds only.
   static bool get isDevModeEnabled => kDebugMode || buildType == 'nightly';
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1104,10 +1104,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -1661,26 +1661,26 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
+      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
       url: "https://pub.dev"
     source: hosted
-    version: "1.30.0"
+    version: "1.31.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
+      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.16"
+    version: "0.6.17"
   timezone:
     dependency: "direct main"
     description:

--- a/scripts/stealth/generate_profile.py
+++ b/scripts/stealth/generate_profile.py
@@ -46,6 +46,9 @@ ARTIFACT_METADATA_KEYS = (
 )
 PACKAGE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$")
 XML_ATTRIBUTE_RESERVED = set("\"'&<>")
+# De-branding privacy rule: stealth identity names must not leak Lantern
+# branding into shipped artifacts (manifest labels, notification text, ...).
+BRANDED_TOKEN_RE = re.compile(r"lantern", re.IGNORECASE)
 
 
 class ProfileError(ValueError):
@@ -129,6 +132,12 @@ def validate_manifest_placeholder_text(field: str, value: str) -> str:
     return value
 
 
+def validate_non_branded_text(field: str, value: str) -> str:
+    if BRANDED_TOKEN_RE.search(value):
+        raise ProfileError(f"{field} must not contain Lantern-branded text")
+    return value
+
+
 def normalize_mode(value: Any) -> str:
     mode = str(value or "").strip()
     return MODE_ALIASES.get(mode, mode)
@@ -149,9 +158,11 @@ def validate_profile(profile: dict[str, Any]) -> dict[str, Any]:
 
     app_name = str(profile.get("appName", "")).strip()
     validate_manifest_placeholder_text("appName", app_name)
+    validate_non_branded_text("appName", app_name)
 
     session_name = str(profile.get("sessionName", "")).strip()
     validate_manifest_placeholder_text("sessionName", session_name)
+    validate_non_branded_text("sessionName", session_name)
 
     go_obfuscation_seed = str(
         profile.get("goObfuscationSeed") or profile.get("obfuscationSeed", "")

--- a/scripts/stealth/generate_profile.py
+++ b/scripts/stealth/generate_profile.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+"""Generate and validate Stealth Lantern build profiles."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import secrets
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+SCHEMA_VERSION = 1
+MAX_ANDROID_INT = 2_147_483_647
+VALID_MODES = ("stealth-vpn", "stealth-novpn")
+MODE_ALIASES = {
+    "vpn": "stealth-vpn",
+    "novpn": "stealth-novpn",
+}
+DEFAULTS = {
+    "denylistVersion": 0,
+    "directConnectionAppsEnabled": False,
+}
+DART_DEFINE_KEYS = {
+    "mode": "STEALTH_MODE",
+    "packageName": "STEALTH_PACKAGE_NAME",
+    "appName": "STEALTH_APP_NAME",
+    "sessionName": "STEALTH_SESSION_NAME",
+    "denylistVersion": "STEALTH_DENYLIST_VERSION",
+    "directConnectionAppsEnabled": "STEALTH_DIRECT_CONNECTION_APPS",
+}
+ARTIFACT_METADATA_KEYS = (
+    "appName",
+    "denylistVersion",
+    "directConnectionAppsEnabled",
+    "generatedAt",
+    "mode",
+    "packageName",
+    "profileId",
+    "schemaVersion",
+    "sessionName",
+)
+PACKAGE_RE = re.compile(r"^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$")
+XML_ATTRIBUTE_RESERVED = set("\"'&<>")
+
+
+class ProfileError(ValueError):
+    pass
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            value = json.load(handle)
+    except OSError as exc:
+        raise ProfileError(f"failed to read profile input {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ProfileError(f"invalid JSON in {path}: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ProfileError(f"profile input {path} must be a JSON object")
+    return value
+
+
+def write_json(path: Path, value: dict[str, Any]) -> None:
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(value, handle, indent=2, sort_keys=True)
+            handle.write("\n")
+    except OSError as exc:
+        raise ProfileError(f"failed to write JSON output {path}: {exc}") from exc
+
+
+def new_profile_id() -> str:
+    return f"stl_{secrets.token_hex(6)}"
+
+
+def default_package_name(profile_id: str) -> str:
+    suffix = profile_id[4:] if profile_id.startswith("stl_") else profile_id
+    return f"com.s{suffix}.app"
+
+
+def coerce_denylist_version(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ProfileError("denylistVersion must be a non-negative integer")
+    if isinstance(value, int):
+        version = value
+    elif isinstance(value, str) and re.fullmatch(r"\d+", value.strip()):
+        version = int(value.strip())
+    else:
+        raise ProfileError("denylistVersion must be a non-negative integer")
+    if version < 0:
+        raise ProfileError("denylistVersion must be a non-negative integer")
+    if version > MAX_ANDROID_INT:
+        raise ProfileError("denylistVersion must fit in a 32-bit signed integer")
+    return version
+
+
+def coerce_schema_version(value: Any) -> int:
+    if isinstance(value, bool):
+        raise ProfileError("schemaVersion must be an integer")
+    if isinstance(value, int):
+        version = value
+    elif isinstance(value, str) and re.fullmatch(r"\d+", value.strip()):
+        version = int(value.strip())
+    else:
+        raise ProfileError("schemaVersion must be an integer")
+    if version != SCHEMA_VERSION:
+        raise ProfileError(
+            f"unsupported schemaVersion {version}; expected {SCHEMA_VERSION}"
+        )
+    return version
+
+
+def validate_manifest_placeholder_text(field: str, value: str) -> str:
+    if not value:
+        raise ProfileError(f"{field} is required")
+    if any(
+        char in XML_ATTRIBUTE_RESERVED or ord(char) < 32 or 0x7F <= ord(char) <= 0x9F
+        for char in value
+    ):
+        raise ProfileError(
+            f"{field} must not contain XML-reserved or control characters"
+        )
+    return value
+
+
+def normalize_mode(value: Any) -> str:
+    mode = str(value or "").strip()
+    return MODE_ALIASES.get(mode, mode)
+
+
+def validate_profile(profile: dict[str, Any]) -> dict[str, Any]:
+    schema_version = coerce_schema_version(profile.get("schemaVersion", SCHEMA_VERSION))
+
+    mode = normalize_mode(profile.get("mode", ""))
+    if mode not in VALID_MODES:
+        raise ProfileError(f"mode must be one of: {', '.join(VALID_MODES)}")
+
+    package_name = str(profile.get("packageName", "")).strip()
+    if not PACKAGE_RE.fullmatch(package_name):
+        raise ProfileError(
+            "packageName must be a valid Android application ID with at least two segments"
+        )
+
+    app_name = str(profile.get("appName", "")).strip()
+    validate_manifest_placeholder_text("appName", app_name)
+
+    session_name = str(profile.get("sessionName", "")).strip()
+    validate_manifest_placeholder_text("sessionName", session_name)
+
+    go_obfuscation_seed = str(
+        profile.get("goObfuscationSeed") or profile.get("obfuscationSeed", "")
+    ).strip()
+    if not go_obfuscation_seed:
+        raise ProfileError("goObfuscationSeed is required")
+
+    # directConnectionAppsEnabled: on by default for all stealth modes (security
+    # gate — the RKS denylist must be active unless explicitly disabled).
+    raw_dca = profile.get("directConnectionAppsEnabled")
+    if raw_dca is None:
+        direct_connection_apps_enabled = mode in VALID_MODES
+    elif isinstance(raw_dca, bool):
+        direct_connection_apps_enabled = raw_dca
+    else:
+        raise ProfileError("directConnectionAppsEnabled must be a boolean")
+
+    normalized = dict(profile)
+    normalized["mode"] = mode
+    normalized["packageName"] = package_name
+    normalized["appName"] = app_name
+    normalized["sessionName"] = session_name
+    normalized.pop("nativeLibraryName", None)
+    normalized.pop("obfuscationSeed", None)
+    normalized["goObfuscationSeed"] = go_obfuscation_seed
+    normalized["denylistVersion"] = coerce_denylist_version(
+        profile.get("denylistVersion", DEFAULTS["denylistVersion"])
+    )
+    normalized["directConnectionAppsEnabled"] = direct_connection_apps_enabled
+    normalized["schemaVersion"] = schema_version
+    return normalized
+
+
+def build_profile(args: argparse.Namespace) -> dict[str, Any]:
+    loaded = {}
+    if args.input:
+        loaded = load_json(args.input)
+    elif args.output and args.output.exists():
+        loaded = load_json(args.output)
+
+    profile_id = str(loaded.get("profileId") or new_profile_id())
+    generated_at = str(
+        loaded.get("generatedAt")
+        or datetime.now(timezone.utc).replace(microsecond=0).isoformat()
+    )
+
+    mode = normalize_mode(args.mode or loaded.get("mode", ""))
+
+    app_name = args.app_name or loaded.get("appName") or ""
+    session_name = args.session_name or loaded.get("sessionName") or ""
+
+    if mode in VALID_MODES:
+        if not app_name:
+            raise ProfileError(
+                "--app-name is required for stealth builds and must not be a Lantern-branded value"
+            )
+        if not session_name:
+            raise ProfileError(
+                "--session-name is required for stealth builds and must not be a Lantern-branded value"
+            )
+
+    profile = {
+        "schemaVersion": loaded.get("schemaVersion", SCHEMA_VERSION),
+        "profileId": profile_id,
+        "generatedAt": generated_at,
+        "mode": mode or None,
+        "packageName": args.package_name
+        or loaded.get("packageName")
+        or default_package_name(profile_id),
+        "appName": app_name,
+        "sessionName": session_name,
+        "goObfuscationSeed": args.go_obfuscation_seed
+        or loaded.get("goObfuscationSeed")
+        or loaded.get("obfuscationSeed")
+        or secrets.token_hex(16),
+        "denylistVersion": (
+            args.denylist_version
+            if args.denylist_version is not None
+            else loaded.get("denylistVersion", DEFAULTS["denylistVersion"])
+        ),
+    }
+
+    for key, value in loaded.items():
+        profile.setdefault(key, value)
+
+    return validate_profile(profile)
+
+
+def dart_defines(profile: dict[str, Any]) -> dict[str, str]:
+    defines = {}
+    for key, define in DART_DEFINE_KEYS.items():
+        value = profile[key]
+        # Emit booleans as lowercase strings for dart-defines / BuildConfig
+        defines[define] = "true" if value is True else ("false" if value is False else str(value))
+    defines["STEALTH_NO_VPN"] = (
+        "true" if profile["mode"] == "stealth-novpn" else "false"
+    )
+    return defines
+
+
+def artifact_metadata(profile: dict[str, Any]) -> dict[str, Any]:
+    metadata = {key: profile[key] for key in ARTIFACT_METADATA_KEYS if key in profile}
+    metadata["goObfuscationSeedSha256"] = hashlib.sha256(
+        str(profile["goObfuscationSeed"]).encode("utf-8")
+    ).hexdigest()
+    return metadata
+
+
+def go_tags_suffix(profile: dict[str, Any]) -> str:
+    # `stealth` strips OAuth/brand exports in lantern-core. The no-VPN data path
+    # is selected in radiance by the `novpn` build tag (radiance gates its
+    # SOCKS-only inbounds/split-tunnel on `novpn` vs `!novpn`); the VPN build
+    # omits it so radiance compiles its default TUN tunnel.
+    tags = ["stealth"]
+    if str(profile["mode"]) == "stealth-novpn":
+        tags.append("novpn")
+    return "," + ",".join(tags)
+
+
+def load_go_tags_profile(args: argparse.Namespace) -> dict[str, Any]:
+    if not args.input:
+        raise ProfileError("--input is required when using --go-tags-suffix")
+    return validate_profile(load_json(args.input))
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, help="optional input profile JSON")
+    parser.add_argument("--output", type=Path, help="normalized profile output path")
+    parser.add_argument("--dart-defines-output", type=Path)
+    parser.add_argument("--artifact-metadata-output", type=Path)
+    parser.add_argument("--go-tags-suffix", action="store_true")
+    parser.add_argument("--mode", choices=VALID_MODES + tuple(MODE_ALIASES))
+    parser.add_argument("--package-name")
+    parser.add_argument("--app-name")
+    parser.add_argument("--session-name")
+    parser.add_argument("--go-obfuscation-seed")
+    parser.add_argument("--denylist-version", type=int)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv)
+    try:
+        profile = load_go_tags_profile(args) if args.go_tags_suffix else build_profile(args)
+        if args.go_tags_suffix:
+            print(go_tags_suffix(profile), end="")
+            return 0
+        if not args.output:
+            raise ProfileError("--output is required when generating a profile")
+        write_json(args.output, profile)
+        if args.dart_defines_output:
+            write_json(args.dart_defines_output, dart_defines(profile))
+        if args.artifact_metadata_output:
+            write_json(args.artifact_metadata_output, artifact_metadata(profile))
+        print(f"Wrote stealth profile: {args.output}")
+        return 0
+    except ProfileError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/scripts/stealth/generate_profile_test.py
+++ b/scripts/stealth/generate_profile_test.py
@@ -1,0 +1,257 @@
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import generate_profile
+
+
+class GenerateProfileTest(unittest.TestCase):
+    def test_generates_profile_outputs_and_redacts_seed_metadata(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            profile_path = root / "profile.json"
+            defines_path = root / "dart-defines.json"
+            metadata_path = root / "metadata.json"
+
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--app-name",
+                    "Beacon",
+                    "--session-name",
+                    "BeaconLink",
+                    "--go-obfuscation-seed",
+                    "seed-for-test",
+                    "--denylist-version",
+                    "7",
+                    "--output",
+                    str(profile_path),
+                    "--dart-defines-output",
+                    str(defines_path),
+                    "--artifact-metadata-output",
+                    str(metadata_path),
+                ]
+            )
+
+            self.assertEqual(exit_code, 0)
+
+            profile = json.loads(profile_path.read_text())
+            self.assertEqual(profile["mode"], "stealth-vpn")
+            self.assertEqual(profile["packageName"], "org.example.safe.s123")
+            self.assertEqual(profile["appName"], "Beacon")
+            self.assertEqual(profile["sessionName"], "BeaconLink")
+            self.assertNotIn("nativeLibraryName", profile)
+            self.assertEqual(profile["goObfuscationSeed"], "seed-for-test")
+            self.assertEqual(profile["denylistVersion"], 7)
+
+            defines = json.loads(defines_path.read_text())
+            self.assertEqual(defines["STEALTH_MODE"], "stealth-vpn")
+            self.assertEqual(defines["STEALTH_NO_VPN"], "false")
+            self.assertEqual(
+                defines["STEALTH_PACKAGE_NAME"], "org.example.safe.s123"
+            )
+            # directConnectionAppsEnabled defaults to True for stealth-vpn
+            self.assertEqual(defines["STEALTH_DIRECT_CONNECTION_APPS"], "true")
+            self.assertNotIn("STEALTH_NATIVE_LIBRARY_NAME", defines)
+            self.assertNotIn("STEALTH_GO_OBFUSCATION_SEED", defines)
+
+            metadata = json.loads(metadata_path.read_text())
+            self.assertNotIn("goObfuscationSeed", metadata)
+            self.assertNotIn("unexpectedPrivateField", metadata)
+            self.assertIn("goObfuscationSeedSha256", metadata)
+
+    def test_go_tags_suffix_from_profile(self):
+        profile = {
+            "mode": "stealth-novpn",
+            "packageName": "org.example.safe.s456",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+            "unexpectedPrivateField": "do-not-export",
+        }
+
+        normalized = generate_profile.validate_profile(profile)
+
+        self.assertEqual(normalized["mode"], "stealth-novpn")
+        defines = generate_profile.dart_defines(normalized)
+        self.assertEqual(defines["STEALTH_NO_VPN"], "true")
+        # directConnectionAppsEnabled defaults to True for stealth-novpn
+        self.assertEqual(defines["STEALTH_DIRECT_CONNECTION_APPS"], "true")
+        self.assertEqual(
+            generate_profile.go_tags_suffix(normalized),
+            ",stealth,novpn",
+        )
+        metadata = generate_profile.artifact_metadata(normalized)
+        self.assertNotIn("unexpectedPrivateField", metadata)
+        self.assertIn("directConnectionAppsEnabled", metadata)
+        self.assertTrue(metadata["directConnectionAppsEnabled"])
+
+    def test_accepts_mode_aliases(self):
+        profile = {
+            "mode": "novpn",
+            "packageName": "org.example.safe.s456",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        normalized = generate_profile.validate_profile(profile)
+
+        self.assertEqual(normalized["mode"], "stealth-novpn")
+
+    def test_go_tags_suffix_requires_input(self):
+        exit_code = generate_profile.main(["--go-tags-suffix"])
+
+        self.assertEqual(exit_code, 2)
+
+    def test_rejects_invalid_package_name(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "bad package",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_unsupported_schema_version(self):
+        profile = {
+            "schemaVersion": generate_profile.SCHEMA_VERSION + 1,
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_boolean_denylist_version(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": True,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_float_denylist_version(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 1.9,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_denylist_version_outside_android_int_range(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Beacon",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": generate_profile.MAX_ANDROID_INT + 1,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_write_json_wraps_os_errors(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(generate_profile.ProfileError):
+                generate_profile.write_json(Path(tmp), {})
+
+    def test_rejects_manifest_placeholder_xml_characters(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": 'Bad "Label"',
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_rejects_manifest_placeholder_iso_control_characters(self):
+        profile = {
+            "mode": "stealth-vpn",
+            "packageName": "org.example.safe.s123",
+            "appName": "Bad\x7fLabel",
+            "sessionName": "BeaconLink",
+            "goObfuscationSeed": "seed-for-test",
+            "denylistVersion": 0,
+        }
+
+        with self.assertRaises(generate_profile.ProfileError):
+            generate_profile.validate_profile(profile)
+
+    def test_default_package_name_is_neutral(self):
+        """default_package_name must not embed 'lantern' or 'stealth' tokens."""
+        pkg = generate_profile.default_package_name("stl_abcdef")
+        self.assertNotIn("lantern", pkg.lower())
+        self.assertNotIn("stealth", pkg.lower())
+        # Must still be a valid Android application ID
+        import re
+        self.assertRegex(pkg, r"^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)+$")
+
+    def test_stealth_build_requires_app_name(self):
+        """build_profile must fail-fast when --app-name is absent for stealth modes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--session-name",
+                    "BeaconLink",
+                    "--output",
+                    str(Path(tmp) / "profile.json"),
+                ]
+            )
+            self.assertNotEqual(exit_code, 0)
+
+    def test_stealth_build_requires_session_name(self):
+        """build_profile must fail-fast when --session-name is absent for stealth modes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--app-name",
+                    "Beacon",
+                    "--output",
+                    str(Path(tmp) / "profile.json"),
+                ]
+            )
+            self.assertNotEqual(exit_code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/stealth/generate_profile_test.py
+++ b/scripts/stealth/generate_profile_test.py
@@ -252,6 +252,44 @@ class GenerateProfileTest(unittest.TestCase):
             )
             self.assertNotEqual(exit_code, 0)
 
+    def test_stealth_build_rejects_branded_app_name(self):
+        """De-branding rule: a Lantern-branded --app-name must fail validation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--app-name",
+                    "Lantern",
+                    "--session-name",
+                    "BeaconLink",
+                    "--output",
+                    str(Path(tmp) / "profile.json"),
+                ]
+            )
+            self.assertNotEqual(exit_code, 0)
+
+    def test_stealth_build_rejects_branded_session_name(self):
+        """De-branding rule: a Lantern-branded --session-name must fail validation."""
+        with tempfile.TemporaryDirectory() as tmp:
+            exit_code = generate_profile.main(
+                [
+                    "--mode",
+                    "stealth-vpn",
+                    "--package-name",
+                    "org.example.safe.s123",
+                    "--app-name",
+                    "Beacon",
+                    "--session-name",
+                    "LanternVpn",
+                    "--output",
+                    str(Path(tmp) / "profile.json"),
+                ]
+            )
+            self.assertNotEqual(exit_code, 0)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Part of epic getlantern/engineering#3569 — **stacked PR 1/4**, targets `main`.

Build-profile generation + flag plumbing: a per-build stealth profile (mode, package/app/session name, obfuscation seed, denylist version) fed into Android Gradle, Flutter dart-defines, Go build tags, and CI metadata, plus the central `AppBuildInfo` flag surface. All stealth behavior is build-time gated — **normal builds are unchanged**.

Implements getlantern/engineering#3623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stealth build support with identity obfuscation, custom package names, and privacy-focused configurations.
  * Introduced build profile system for generating stealth app variants with customizable parameters.
  * Added code obfuscation capability for stealth builds.
  * Added stealth leakage detection and reporting in build workflows.

* **Documentation**
  * Added stealth build profile generation and configuration guide.
  * Added stealth feature gates documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->