### PR TITLE
build(android): fix version stamping (versionName + versionCode)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,11 @@ FFI_DIR := $(LANTERN_CORE)/ffi
 ifeq ($(OS),Windows_NT)
 APP_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command '(Select-String -Path "pubspec.yaml" -Pattern "^version:\s*(.+)$$").Matches[0].Groups[1].Value.Trim()')
 else
+## Only derive when the caller hasn't already supplied APP_VERSION (env or
+## command line). This honors the documented precedence (environment > pubspec)
+## and avoids both the cost of running version.sh and a misleading fallback
+## warning when the value is overridden.
+ifndef APP_VERSION
 ifndef GITHUB_ACTIONS
 ## Capture into a temp so we only set APP_VERSION when version.sh actually
 ## produced output. A bare `APP_VERSION ?= $(shell …)` would *define*
@@ -43,9 +48,10 @@ ifndef GITHUB_ACTIONS
 ## the "is empty" $(error). On empty: warn and fall through to pubspec.
 LANTERN_DERIVED_VERSION := $(shell ./scripts/ci/version.sh generate nightly 2>/dev/null)
 ifneq ($(strip $(LANTERN_DERIVED_VERSION)),)
-APP_VERSION ?= $(LANTERN_DERIVED_VERSION)
+APP_VERSION := $(LANTERN_DERIVED_VERSION)
 else
 $(warning could not derive version from scripts/ci/version.sh; falling back to pubspec.yaml — the build version may be stale)
+endif
 endif
 endif
 APP_VERSION ?= $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,19 @@ FFI_DIR := $(LANTERN_CORE)/ffi
 ## `common.Version` ldflag and a 400 "missing app version" at /v1/config-new.
 ## Local builds fall back to reading pubspec.yaml directly, with a PowerShell
 ## branch so Windows devs without Git Bash / WSL still get a working build.
+##
+## Caveat: pubspec.yaml's `version:` is a hardcoded literal that lags the real
+## release line — it is only rewritten to the authoritative version in CI (by
+## release.yml, from scripts/ci/version.sh). A local build still resolves its Go
+## deps from go.mod (current code) but would stamp that stale literal, so
+## sideload/dev builds get mislabeled (e.g. 9.0.28) in telemetry and support
+## tickets. Outside CI, derive the version from git tags first; the pubspec
+## fallback below only applies if that yields nothing (e.g. a checkout with no
+## tags). In CI, GITHUB_ACTIONS is set, so we skip this and trust the rewritten
+## pubspec.
+ifndef GITHUB_ACTIONS
+APP_VERSION ?= $(shell ./scripts/ci/version.sh generate nightly 2>/dev/null)
+endif
 ifeq ($(OS),Windows_NT)
 APP_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command '(Select-String -Path "pubspec.yaml" -Pattern "^version:\s*(.+)$$").Matches[0].Groups[1].Value.Trim()')
 else
@@ -525,7 +538,7 @@ android-debug-ci: ANDROID_DEBUG_FLUTTER_FLAGS :=
 android-debug-ci: $(ANDROID_DEBUG_BUILD)
 
 $(ANDROID_DEBUG_BUILD): $(ANDROID_LIB_BUILD)
-	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) $(ANDROID_DEBUG_FLUTTER_FLAGS) --debug -Plantern.sideloadUpdates=true
+	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) $(ANDROID_DEBUG_FLUTTER_FLAGS) --build-name=$(APP_VERSION_PUBSPEC) --debug -Plantern.sideloadUpdates=true
 
 # --target-platform restricts Flutter's libapp.so / libflutter.so to arm64.
 # abiFilters is arm64-only for all artifacts now (no thinAbi flag needed).
@@ -533,7 +546,7 @@ $(ANDROID_DEBUG_BUILD): $(ANDROID_LIB_BUILD)
 # direct-download APK artifact; Play AAB builds intentionally omit it.
 .PHONY: android-apk-release
 android-apk-release:
-	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES) -Plantern.sideloadUpdates=true
+	flutter build apk --target-platform $(ANDROID_APK_TARGET_PLATFORMS) --verbose --build-name=$(APP_VERSION_PUBSPEC) --release $(DART_DEFINES) -Plantern.sideloadUpdates=true
 	cp $(ANDROID_APK_RELEASE_BUILD) $(ANDROID_RELEASE_APK)
 
 # AAB is arm64-only too (armeabi-v7a dropped — golang/go#70495 SIGSYS on
@@ -541,7 +554,7 @@ android-apk-release:
 # crash-looping on Android 8-10 regardless.
 .PHONY: android-aab-release
 android-aab-release:
-	flutter build appbundle --target-platform $(ANDROID_AAB_TARGET_PLATFORMS) --verbose --release $(DART_DEFINES)
+	flutter build appbundle --target-platform $(ANDROID_AAB_TARGET_PLATFORMS) --verbose --build-name=$(APP_VERSION_PUBSPEC) --release $(DART_DEFINES)
 	cp $(ANDROID_AAB_RELEASE_BUILD) $(ANDROID_RELEASE_AAB)
 	# Copy Play console artifacts
 	@if [ -f "$(ANDROID_MAPPING_SRC)" ]; then \

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,17 @@ ifeq ($(OS),Windows_NT)
 APP_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command '(Select-String -Path "pubspec.yaml" -Pattern "^version:\s*(.+)$$").Matches[0].Groups[1].Value.Trim()')
 else
 ifndef GITHUB_ACTIONS
-APP_VERSION ?= $(shell ./scripts/ci/version.sh generate nightly 2>/dev/null)
+## Capture into a temp so we only set APP_VERSION when version.sh actually
+## produced output. A bare `APP_VERSION ?= $(shell …)` would *define*
+## APP_VERSION as empty when version.sh fails (no tags, shallow clone, a sort
+## without -V, …), turning the pubspec fallback below into a no-op and tripping
+## the "is empty" $(error). On empty: warn and fall through to pubspec.
+LANTERN_DERIVED_VERSION := $(shell ./scripts/ci/version.sh generate nightly 2>/dev/null)
+ifneq ($(strip $(LANTERN_DERIVED_VERSION)),)
+APP_VERSION ?= $(LANTERN_DERIVED_VERSION)
+else
+$(warning could not derive version from scripts/ci/version.sh; falling back to pubspec.yaml — the build version may be stale)
+endif
 endif
 APP_VERSION ?= $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
 endif

--- a/Makefile
+++ b/Makefile
@@ -29,15 +29,23 @@ FFI_DIR := $(LANTERN_CORE)/ffi
 ## tickets. Outside CI, derive the version from git tags first; the pubspec
 ## fallback below only applies if that yields nothing (e.g. a checkout with no
 ## tags). In CI, GITHUB_ACTIONS is set, so we skip this and trust the rewritten
-## pubspec.
-ifndef GITHUB_ACTIONS
-APP_VERSION ?= $(shell ./scripts/ci/version.sh generate nightly 2>/dev/null)
-endif
+## pubspec. The version.sh derivation lives in the non-Windows branch only: it's
+## a bash script and `2>/dev/null` is a POSIX redirection, neither of which
+## behaves under cmd.exe, so Windows devs fall through to the PowerShell read.
 ifeq ($(OS),Windows_NT)
 APP_VERSION ?= $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command '(Select-String -Path "pubspec.yaml" -Pattern "^version:\s*(.+)$$").Matches[0].Groups[1].Value.Trim()')
 else
+ifndef GITHUB_ACTIONS
+APP_VERSION ?= $(shell ./scripts/ci/version.sh generate nightly 2>/dev/null)
+endif
 APP_VERSION ?= $(shell grep '^version:' pubspec.yaml | sed 's/version: //;s/ //g')
 endif
+## Freeze APP_VERSION after resolution. `?=` leaves it recursively expanded, so
+## every later $(APP_VERSION) reference would re-run the $(shell …) — and
+## version.sh embeds a timestamp, so the value could drift between recipe
+## invocations (e.g. the deb/rpm/arch packages built sequentially in
+## linux-release-ci). The `:=` self-assignment evaluates it exactly once, here.
+APP_VERSION := $(APP_VERSION)
 ## Strip the +buildnumber for the Go linker. Done with Make built-ins so no
 ## shell tools are required — this is the part that has to work in every
 ## environment `make` might invoke the linker in.

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -38,9 +38,21 @@ def generateSideloadManifest = tasks.register("generateSideloadManifest") {
     }
 }
 
-def start = new Date(2015, 1, 1).getTime()
-def now = System.currentTimeMillis()
-def code = (int)((now - start) / 1000)
+// versionCode = whole seconds since a fixed epoch. The only hard constraints
+// are that it increases monotonically (Play/Android reject a lower code on
+// upgrade) and stays below 2^31. EPOCH_2009 keeps today's value (~5.5e8) just
+// above the previous sequence and leaves ~50 years of int headroom.
+//
+// This used to be `new Date(2015, 1, 1).getTime()`, but that's the deprecated
+// java.util.Date(year, month, day) constructor: `year` is years-since-1900 and
+// `month` is 0-indexed, so it actually meant Feb 1 of year 3915 — ~1900 years
+// in the future. `now - start` was a large negative that wrapped on the (int)
+// cast to a positive ~5.3e8, which happened to stay monotonic (so upgrades
+// worked) but was meaningless and fragile. Do NOT "fix" this to a true
+// 2015-01-01 origin: that yields ~3.6e8 today, LOWER than shipped codes, which
+// would break upgrades.
+def EPOCH_2009 = 1230768000L // 2009-01-01T00:00:00Z, in seconds
+def code = (int)((System.currentTimeMillis() / 1000L) - EPOCH_2009)
 
 android {
     namespace = "org.getlantern.lantern"


### PR DESCRIPTION
This PR fixes two related Android version-stamping bugs found while triaging a Sri Lanka ticket (#178331) whose logs claimed version `9.0.28` but embedded **June-11 kindling + sing-box 1.12.22** — a build that can't legitimately be `9.0.28`.

---

## Bug 1 — `versionName`: local/sideload builds report a stale hardcoded version

Local and sideload builds — `make android-apk-release` / `android-aab-release`, the APKs internal testers actually run — stamped their version from the **hardcoded `version:` literal in `pubspec.yaml`** (currently `9.0.28`), while `go.mod` resolves the real deps (kindling, radiance, sing-box) to their **current** versions at build time.

Result: builds with current 9.1.x-era code were labeled **`9.0.28`**, which:
- mislabels them in telemetry — SigNoz `service.version` (from the Go `common.Version` ldflag)
- mislabels them in support tickets — Freshdesk `cf_client_version` (from Flutter `package_info`)
- **conflates internal dev/nightly builds with real `9.0.28` production users**, corrupting version-based analysis (e.g. ticket triage).

### Root cause
The version is only corrected **in CI**: `release.yml` rewrites `pubspec.yaml` via `scripts/ci/version.sh` before building, then `build-android.yml` consumes it. Any build that skips that rewrite — every local/sideload build — trusts the stale literal. And it can only be the stale literal: `version.sh generate` increments from the highest tag (`v9.1.9-beta` → `9.1.10`) and `validate` refuses to go backwards, so a *successful* overwrite could never produce `9.0.28`. The value persists precisely because the overwrite **never runs** on these paths — the Makefile's Android targets had no version-derivation step.

### Fix
- **Outside CI**, default `APP_VERSION` from `version.sh generate nightly` (real line + short SHA + timestamp), falling back to the existing pubspec read only if that yields nothing (e.g. a checkout with no tags). Gated on `GITHUB_ACTIONS`, so CI keeps trusting the rewritten pubspec — **CI behavior is byte-for-byte unchanged**.
- Pass `--build-name=$(APP_VERSION_PUBSPEC)` to the three Android Flutter recipes (`android-debug`, `android-apk-release`, `android-aab-release`).

This makes **both** version channels consistent for local builds — Flutter `versionName` (→ Freshdesk `cf_client_version`) and the Go `common.Version` ldflag (→ SigNoz `service.version` and the `X-Lantern-App-Version` header to `/v1/config-new`) — and makes sideload builds **self-identifying** via the embedded commit SHA.

### Verification (`make -n`)
| Scenario | Resolved `--build-name` / `common.Version` |
|---|---|
| Local build | `9.1.10-3e943e2-20260615T…Z` |
| CI (`GITHUB_ACTIONS=true`) | falls back to pubspec (rewritten to authoritative version in real CI) — unchanged |
| Single `make android-release-ci` | one shared timestamp across APK + AAB (no drift) |
| GNU Make 3.81 parse | ✓ |

---

## Bug 2 — `versionCode`: computed from a misused `Date` constructor

`android/app/build.gradle` computed `versionCode` as:
```groovy
def start = new Date(2015, 1, 1).getTime()
def code  = (int)((System.currentTimeMillis() - start) / 1000)
```
`new Date(2015, 1, 1)` is the deprecated `java.util.Date(year, month, day)` constructor: `year` is **years-since-1900** (→ `3915`) and `month` is **0-indexed** (→ February). So `start` is **Feb 1, year 3915** — ~1,900 years in the future. `now - start` is a large negative that **wraps on the `(int)` cast** to a positive ~`5.3e8`. It stayed monotonic by luck (constant `start` → still ticks +1/sec), so versionCode kept increasing and upgrades worked — but the value is meaningless and relies on signed-int overflow.

### Fix
Compute whole seconds since a fixed epoch, no deprecated `Date`:
```groovy
def EPOCH_2009 = 1230768000L // 2009-01-01T00:00:00Z
def code = (int)((System.currentTimeMillis() / 1000L) - EPOCH_2009)
```

**Critical constraint:** `versionCode` must never decrease (Play/Android reject lower codes on upgrade). A "correct" 2015-01-01 origin would yield ~`3.6e8` today — **lower** than already-shipped codes (~`5.3e8`) — and break upgrades. The `2009-01-01` origin keeps today's value at ~`5.5e8` (just above the shipped sequence) with ~50 years of `int` headroom.

| Origin | versionCode today | vs current ~530,206,755 |
|---|---|---|
| true 2015-01-01 | 361,465,200 | ❌ lower — breaks upgrades |
| **2009-01-01 (this PR)** | 550,767,600 | ✅ higher, ~50 yrs headroom |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
