### PR TITLE
Fixed reseller flow Issue

### DIFF
--- a/lib/features/auth/lantern_pro_license.dart
+++ b/lib/features/auth/lantern_pro_license.dart
@@ -126,8 +126,7 @@ class LanternProLicense extends HookConsumerWidget {
         await checkUserAccountStatus(ref, context);
         context.hideLoadingDialog();
 
-        /// User is already signed in
-        /// or User is OAuth
+        /// User is already signed in or using OAuth
         if (code.isEmpty) {
           appLogger.info(
             'No code provided, user is using OAuth (skip password)',

--- a/lib/features/auth/lantern_pro_license.dart
+++ b/lib/features/auth/lantern_pro_license.dart
@@ -12,11 +12,7 @@ class LanternProLicense extends HookConsumerWidget {
   final String email;
   final String code;
 
-  const LanternProLicense({
-    super.key,
-    required this.email,
-    required this.code,
-  });
+  const LanternProLicense({super.key, required this.email, required this.code});
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -82,9 +78,9 @@ class LanternProLicense extends HookConsumerWidget {
                 alignment: Alignment.centerRight,
                 child: Text(
                   '${normalizedLen.value}/25',
-                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                        color: context.textDisabled,
-                      ),
+                  style: Theme.of(
+                    context,
+                  ).textTheme.labelSmall?.copyWith(color: context.textDisabled),
                 ),
               ),
             ),
@@ -105,7 +101,10 @@ class LanternProLicense extends HookConsumerWidget {
   }
 
   Future<void> onActivatePro(
-      String resellerCode, WidgetRef ref, BuildContext context) async {
+    String resellerCode,
+    WidgetRef ref,
+    BuildContext context,
+  ) async {
     final maskedCode = resellerCode.length > 4
         ? '***${resellerCode.substring(resellerCode.length - 4)}'
         : '***';
@@ -127,9 +126,12 @@ class LanternProLicense extends HookConsumerWidget {
         await checkUserAccountStatus(ref, context);
         context.hideLoadingDialog();
 
+        /// User is already signed in
+        /// or User is OAuth
         if (code.isEmpty) {
-          appLogger
-              .info('No code provided, user is using OAuth (skip password)');
+          appLogger.info(
+            'No code provided, user is using OAuth (skip password)',
+          );
           AppDialog.showLanternProDialog(
             context: context,
             onPressed: () => appRouter.popUntilRoot(),
@@ -139,11 +141,13 @@ class LanternProLicense extends HookConsumerWidget {
         if (user!.legacyUserData.unpassRegistered) {
           appRouter.popUntilRoot();
         } else {
-          appRouter.push(CreatePassword(
-            email: email,
-            authFlow: AuthFlow.lanternProLicense,
-            code: code,
-          ));
+          appRouter.push(
+            CreatePassword(
+              email: email,
+              authFlow: AuthFlow.lanternProLicense,
+              code: code,
+            ),
+          );
         }
       },
     );

--- a/lib/features/plans/plans.dart
+++ b/lib/features/plans/plans.dart
@@ -8,8 +8,8 @@ import 'package:in_app_purchase/in_app_purchase.dart';
 import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/services/app_purchase.dart';
 import 'package:lantern/core/services/injection_container.dart';
-import 'package:lantern/core/utils/formatter.dart';
 import 'package:lantern/core/utils/country_code.dart';
+import 'package:lantern/core/utils/formatter.dart';
 import 'package:lantern/core/utils/screen_utils.dart';
 import 'package:lantern/core/widgets/app_rich_text.dart';
 import 'package:lantern/core/widgets/loading_indicator.dart';
@@ -217,6 +217,12 @@ class _PlansState extends ConsumerState<Plans>
               icon: AppImagePaths.keypad,
               label: 'lantern_pro_license'.i18n,
               onPressed: () {
+                final appSetting = ref.read(appSettingProvider);
+                final email = ref.read(userEmailProvider);
+                if (appSetting.userLoggedIn) {
+                  appRouter.push(LanternProLicense(email: email, code: ''));
+                  return;
+                }
                 appRouter.popAndPush(
                   AddEmail(authFlow: AuthFlow.lanternProLicense),
                 );

--- a/lib/features/plans/plans.dart
+++ b/lib/features/plans/plans.dart
@@ -217,9 +217,10 @@ class _PlansState extends ConsumerState<Plans>
               icon: AppImagePaths.keypad,
               label: 'lantern_pro_license'.i18n,
               onPressed: () {
+                context.pop();
                 final appSetting = ref.read(appSettingProvider);
                 final email = ref.read(userEmailProvider);
-                if (appSetting.userLoggedIn) {
+                if (appSetting.userLoggedIn && email.isNotEmpty) {
                   appRouter.push(LanternProLicense(email: email, code: ''));
                   return;
                 }


### PR DESCRIPTION
This pull request contains minor refactoring and code clean-up in the Lantern Pro License flow and the Plans screen. The most notable change is the improved navigation logic for users who are already logged in when accessing the Lantern Pro License screen. Additionally, there are several formatting and code style improvements.

**Navigation and user flow improvements:**

* Updated the navigation logic in the `_PlansState` class to immediately push the `LanternProLicense` screen with the user's email if the user is already logged in, otherwise prompt for email entry.

**Code style and formatting clean-up:**

* Reformatted the constructor of `LanternProLicense` for conciseness.
* Improved formatting in style assignment for the character counter in the license code input.
* Reformatted the `onActivatePro` method signature for readability.
* Improved logging and navigation logic comments and formatting for clarity in `LanternProLicense`. [[1]](diffhunk://#diff-8aa80ce8ee5b4d31938e916266ee7eba8b386a9dae9ed9b9e5b67fa78e7489c0R129-R134) [[2]](diffhunk://#diff-8aa80ce8ee5b4d31938e916266ee7eba8b386a9dae9ed9b9e5b67fa78e7489c0L142-R150)

**Import order consistency:**

* Reordered imports in `plans.dart` for better consistency and readability.