### PR TITLE
macOS fix for tunnel cache

### DIFF
--- a/lib/lantern/lantern_generated_bindings.dart
+++ b/lib/lantern/lantern_generated_bindings.dart
@@ -5488,10 +5488,10 @@ class LanternBindings {
       .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)>();
 
   ffi.Pointer<ffi.Char> loadInstalledAppIcon(
-    ffi.Pointer<ffi.Char> appPath,
-    ffi.Pointer<ffi.Char> iconPath,
+    ffi.Pointer<ffi.Char> appPathC,
+    ffi.Pointer<ffi.Char> iconPathC,
   ) {
-    return _loadInstalledAppIcon(appPath, iconPath);
+    return _loadInstalledAppIcon(appPathC, iconPathC);
   }
 
   late final _loadInstalledAppIconPtr =
@@ -6050,6 +6050,87 @@ class LanternBindings {
   late final _freeCString = _freeCStringPtr
       .asFunction<void Function(ffi.Pointer<ffi.Char>)>();
 
+  ffi.Pointer<ffi.Char> patchSettings(ffi.Pointer<ffi.Char> patchJSON) {
+    return _patchSettings(patchJSON);
+  }
+
+  late final _patchSettingsPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)
+        >
+      >('patchSettings');
+  late final _patchSettings = _patchSettingsPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)>();
+
+  ffi.Pointer<ffi.Char> getSettings() {
+    return _getSettings();
+  }
+
+  late final _getSettingsPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+        'getSettings',
+      );
+  late final _getSettings = _getSettingsPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
+  ffi.Pointer<ffi.Char> patchEnvVars(ffi.Pointer<ffi.Char> patchJSON) {
+    return _patchEnvVars(patchJSON);
+  }
+
+  late final _patchEnvVarsPtr =
+      _lookup<
+        ffi.NativeFunction<
+          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)
+        >
+      >('patchEnvVars');
+  late final _patchEnvVars = _patchEnvVarsPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)>();
+
+  ffi.Pointer<ffi.Char> getEnvVars() {
+    return _getEnvVars();
+  }
+
+  late final _getEnvVarsPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+        'getEnvVars',
+      );
+  late final _getEnvVars = _getEnvVarsPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
+  ffi.Pointer<ffi.Char> runURLTests() {
+    return _runURLTests();
+  }
+
+  late final _runURLTestsPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+        'runURLTests',
+      );
+  late final _runURLTests = _runURLTestsPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
+  ffi.Pointer<ffi.Char> updateConfig() {
+    return _updateConfig();
+  }
+
+  late final _updateConfigPtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+        'updateConfig',
+      );
+  late final _updateConfig = _updateConfigPtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
+  ffi.Pointer<ffi.Char> clearTunnelCache() {
+    return _clearTunnelCache();
+  }
+
+  late final _clearTunnelCachePtr =
+      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
+        'clearTunnelCache',
+      );
+  late final _clearTunnelCache = _clearTunnelCachePtr
+      .asFunction<ffi.Pointer<ffi.Char> Function()>();
+
   ffi.Pointer<ffi.Char> digitalOceanPrivateServer() {
     return _digitalOceanPrivateServer();
   }
@@ -6365,87 +6446,6 @@ class LanternBindings {
         'getEnabledApps',
       );
   late final _getEnabledApps = _getEnabledAppsPtr
-      .asFunction<ffi.Pointer<ffi.Char> Function()>();
-
-  ffi.Pointer<ffi.Char> patchSettings(ffi.Pointer<ffi.Char> patchJSON) {
-    return _patchSettings(patchJSON);
-  }
-
-  late final _patchSettingsPtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)
-        >
-      >('patchSettings');
-  late final _patchSettings = _patchSettingsPtr
-      .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)>();
-
-  ffi.Pointer<ffi.Char> getSettings() {
-    return _getSettings();
-  }
-
-  late final _getSettingsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
-        'getSettings',
-      );
-  late final _getSettings = _getSettingsPtr
-      .asFunction<ffi.Pointer<ffi.Char> Function()>();
-
-  ffi.Pointer<ffi.Char> patchEnvVars(ffi.Pointer<ffi.Char> patchJSON) {
-    return _patchEnvVars(patchJSON);
-  }
-
-  late final _patchEnvVarsPtr =
-      _lookup<
-        ffi.NativeFunction<
-          ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)
-        >
-      >('patchEnvVars');
-  late final _patchEnvVars = _patchEnvVarsPtr
-      .asFunction<ffi.Pointer<ffi.Char> Function(ffi.Pointer<ffi.Char>)>();
-
-  ffi.Pointer<ffi.Char> getEnvVars() {
-    return _getEnvVars();
-  }
-
-  late final _getEnvVarsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
-        'getEnvVars',
-      );
-  late final _getEnvVars = _getEnvVarsPtr
-      .asFunction<ffi.Pointer<ffi.Char> Function()>();
-
-  ffi.Pointer<ffi.Char> runURLTests() {
-    return _runURLTests();
-  }
-
-  late final _runURLTestsPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
-        'runURLTests',
-      );
-  late final _runURLTests = _runURLTestsPtr
-      .asFunction<ffi.Pointer<ffi.Char> Function()>();
-
-  ffi.Pointer<ffi.Char> updateConfig() {
-    return _updateConfig();
-  }
-
-  late final _updateConfigPtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
-        'updateConfig',
-      );
-  late final _updateConfig = _updateConfigPtr
-      .asFunction<ffi.Pointer<ffi.Char> Function()>();
-
-  ffi.Pointer<ffi.Char> clearTunnelCache() {
-    return _clearTunnelCache();
-  }
-
-  late final _clearTunnelCachePtr =
-      _lookup<ffi.NativeFunction<ffi.Pointer<ffi.Char> Function()>>(
-        'clearTunnelCache',
-      );
-  late final _clearTunnelCache = _clearTunnelCachePtr
       .asFunction<ffi.Pointer<ffi.Char> Function()>();
 }
 

--- a/macos/Runner/Handlers/MethodHandler.swift
+++ b/macos/Runner/Handlers/MethodHandler.swift
@@ -359,6 +359,9 @@ class MethodHandler {
       case "sendConfigRequest":
         self.sendConfigRequest(result: result)
 
+      case "clearTunnelCache":
+        self.clearTunnelCache(result: result)
+
       default:
         result(FlutterMethodNotImplemented)
       }
@@ -1234,6 +1237,18 @@ class MethodHandler {
       MobileSendConfigRequest(&error)
       if let error {
         await self.handleFlutterError(error, result: result, code: "SEND_CONFIG_REQUEST_ERROR")
+        return
+      }
+      await MainActor.run { result("ok") }
+    }
+  }
+
+  func clearTunnelCache(result: @escaping FlutterResult) {
+    Task {
+      var error: NSError?
+      MobileClearTunnelCache(&error)
+      if let error {
+        await self.handleFlutterError(error, result: result, code: "CLEAR_TUNNEL_CACHE_ERROR")
         return
       }
       await MainActor.run { result("ok") }


### PR DESCRIPTION
This pull request primarily adds and wires up support for clearing the tunnel cache via both Dart FFI bindings and the macOS method handler. It also includes a minor parameter renaming for clarity. The most important changes are outlined below.

**Dart FFI Bindings Updates:**

* Added new FFI methods to `LanternBindings` in `lantern_generated_bindings.dart` for patching and retrieving settings/environment variables, running URL tests, updating config, and specifically for clearing the tunnel cache. These methods provide Dart-side access to native functionality.
* Removed duplicate or misplaced definitions of these FFI methods from the end of the class, consolidating them in a single location for clarity and maintainability.

**macOS Method Handler Integration:**

* Added a new `"clearTunnelCache"` case to the Flutter method channel switch in `MethodHandler.swift`, allowing the Flutter app to invoke this functionality.
* Implemented the `clearTunnelCache` method in `MethodHandler`, which calls the native `MobileClearTunnelCache` function asynchronously and returns the result or handles errors appropriately.

**Minor Refactor:**

* Renamed parameters in the `loadInstalledAppIcon` method from `appPath`/`iconPath` to `appPathC`/`iconPathC` for improved clarity and consistency.