### PR TITLE
Treat sustained probe failures as unreachable

### DIFF
--- a/lib/core/models/available_servers.dart
+++ b/lib/core/models/available_servers.dart
@@ -35,15 +35,18 @@ class AvailableServers {
     return null;
   }
 
-  /// Lantern server with the lowest successful probe delay. Null when no
-  /// Lantern server has a successful probe.
+  /// Lantern server with the lowest usable successful probe delay. Null when no
+  /// Lantern server has a successful probe that is not currently hard-failing.
   Server? get fastestLanternServer {
-    final ranked = lanternServers.where((s) => s.hasSuccessfulProbe).toList()
-      ..sort(
-        (a, b) => a.selectionHistory!.lastSuccessDelayMs.compareTo(
-          b.selectionHistory!.lastSuccessDelayMs,
-        ),
-      );
+    final ranked =
+        lanternServers
+            .where((s) => s.hasSuccessfulProbe && !s.isProbedUnreachable)
+            .toList()
+          ..sort(
+            (a, b) => a.selectionHistory!.lastSuccessDelayMs.compareTo(
+              b.selectionHistory!.lastSuccessDelayMs,
+            ),
+          );
     return ranked.isEmpty ? null : ranked.first;
   }
 }
@@ -63,7 +66,9 @@ String _locationKey(Server server) {
 }
 
 Server _bestServerForLocation(List<Server> servers) {
-  final successful = servers.where((s) => s.hasSuccessfulProbe).toList();
+  final successful = servers
+      .where((s) => s.hasSuccessfulProbe && !s.isProbedUnreachable)
+      .toList();
   if (successful.isNotEmpty) {
     successful.sort((a, b) {
       final delay = a.selectionHistory!.lastSuccessDelayMs.compareTo(
@@ -81,9 +86,7 @@ Server _bestServerForLocation(List<Server> servers) {
   // has sustained enough failures — so a location is "unavailable" only once
   // all of its servers are.
   final awaiting = servers.where((s) => s.isAwaitingProbe).toList();
-  final notUnreachable = servers
-      .where((s) => !s.isProbedUnreachable)
-      .toList();
+  final notUnreachable = servers.where((s) => !s.isProbedUnreachable).toList();
   final pool = awaiting.isNotEmpty
       ? awaiting
       : (notUnreachable.isNotEmpty ? notUnreachable : servers);
@@ -151,10 +154,11 @@ class Server {
   bool get hasProbeVerdict =>
       hasSuccessfulProbe || (selectionHistory?.consecutiveFailures ?? 0) > 0;
 
-  /// Sustained probe failures past
-  /// [_manualSelectionFailureWarningThreshold] with no success — enough
-  /// evidence to treat the server as unreachable rather than merely uncertain.
-  /// One or two failures are still "unknown", not "unavailable".
+  /// Sustained probe failures past [_manualSelectionFailureWarningThreshold] —
+  /// enough current evidence to treat the server as unreachable rather than
+  /// merely uncertain. One or two failures are still "unknown", not
+  /// "unavailable". A prior success can still provide historical latency, but
+  /// it does not override repeated current failures.
   bool get hasFailedProbeEvidence =>
       (selectionHistory?.consecutiveFailures ?? 0) >=
       _manualSelectionFailureWarningThreshold;
@@ -164,12 +168,10 @@ class Server {
   /// "testing", never as unavailable.
   bool get isAwaitingProbe => isLantern && !hasProbeVerdict;
 
-  /// Probed and sustained-failing: no probe has ever succeeded and failures
-  /// have passed the warning threshold. This is the only state that surfaces
-  /// the unreachable warning; a server failing only once or twice is shown
-  /// normally (uncertain, not unavailable).
-  bool get isProbedUnreachable =>
-      isLantern && !hasSuccessfulProbe && hasFailedProbeEvidence;
+  /// Probed and sustained-failing: failures have passed the warning threshold.
+  /// This is the only state that surfaces the unreachable warning; a server
+  /// failing only once or twice is shown normally (uncertain, not unavailable).
+  bool get isProbedUnreachable => isLantern && hasFailedProbeEvidence;
 
   /// Manual mode pins traffic to exactly this server. Warn before pinning only
   /// once the server has sustained enough failed probes — never while it is

--- a/test/core/models/available_servers_test.dart
+++ b/test/core/models/available_servers_test.dart
@@ -3,17 +3,28 @@ import 'package:lantern/core/models/available_servers.dart';
 
 void main() {
   group('AvailableServers', () {
-    test('fastestLanternServer only considers successful Lantern probes', () {
-      final slow = _server(tag: 'slow', delay: 320);
-      final failed = _server(tag: 'failed', delay: 0, failures: 3);
-      final noProbe = _server(tag: 'no-probe');
-      final fast = _server(tag: 'fast', delay: 85);
-      final private = _server(tag: 'private', isLantern: false, delay: 40);
+    test(
+      'fastestLanternServer only considers usable successful Lantern probes',
+      () {
+        final slow = _server(tag: 'slow', delay: 320);
+        final failed = _server(tag: 'failed', delay: 0, failures: 3);
+        final noProbe = _server(tag: 'no-probe');
+        final staleFast = _server(tag: 'stale-fast', delay: 10, failures: 3);
+        final fast = _server(tag: 'fast', delay: 85);
+        final private = _server(tag: 'private', isLantern: false, delay: 40);
 
-      final servers = AvailableServers([slow, failed, noProbe, fast, private]);
+        final servers = AvailableServers([
+          slow,
+          failed,
+          noProbe,
+          staleFast,
+          fast,
+          private,
+        ]);
 
-      expect(servers.fastestLanternServer, fast);
-    });
+        expect(servers.fastestLanternServer, fast);
+      },
+    );
 
     test('lanternServerLocations picks one best server per location', () {
       final nyFailed = _server(
@@ -147,6 +158,36 @@ void main() {
         expect(locations.single.shouldWarnBeforeManualSelection, isFalse);
       },
     );
+
+    test(
+      'lanternServerLocations does not prefer stale latency from a hard-failed server',
+      () {
+        final staleFailed = _server(
+          tag: 'paris-fast-stale',
+          delay: 10,
+          failures: 3,
+          city: 'Paris',
+          country: 'France',
+          countryCode: 'FR',
+        );
+        final usable = _server(
+          tag: 'paris-usable',
+          delay: 100,
+          city: 'Paris',
+          country: 'France',
+          countryCode: 'FR',
+        );
+
+        final locations = AvailableServers([
+          staleFailed,
+          usable,
+        ]).lanternServerLocations;
+
+        expect(locations, hasLength(1));
+        expect(locations.single, usable);
+        expect(locations.single.shouldWarnBeforeManualSelection, isFalse);
+      },
+    );
   });
 
   group('Server probe state', () {
@@ -168,6 +209,19 @@ void main() {
       expect(s.isProbedUnreachable, isTrue);
       expect(s.shouldWarnBeforeManualSelection, isTrue);
     });
+
+    test(
+      'stale successful probe with current sustained failures: warns and is unreachable',
+      () {
+        final s = _server(tag: 'stale-failed', delay: 100, failures: 3);
+        expect(s.hasSuccessfulProbe, isTrue);
+        expect(s.hasProbeVerdict, isTrue);
+        expect(s.hasFailedProbeEvidence, isTrue);
+        expect(s.isAwaitingProbe, isFalse);
+        expect(s.isProbedUnreachable, isTrue);
+        expect(s.shouldWarnBeforeManualSelection, isTrue);
+      },
+    );
 
     test('transient failure below threshold: uncertain, not unreachable', () {
       final s = _server(tag: 'flapping', delay: 0, failures: 2);


### PR DESCRIPTION
Follow-up to the testing-vs-unreachable split. This makes the current failure threshold win over stale successful latency, so servers with old `lastSuccessDelayMs` but repeated current probe failures are still treated as unreachable and excluded from fastest/location representative selection.