### PR TITLE
deps: bump radiance/domainfront/kindling (legit SNI for fronting)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260624235030-d13f227a31cc
+	github.com/getlantern/radiance v0.0.0-20260625003855-687d6be3d5f0
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.42.0
@@ -168,9 +168,9 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc // indirect
 	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46 // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
-	github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736 // indirect
+	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
-	github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860 // indirect
+	github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c // indirect
 	github.com/getlantern/lantern-box v0.0.95 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736 h1:Y5d0XP7ammE/ryHj8fPR3JKBYKmOQaYQFN31oF3my7E=
-github.com/getlantern/domainfront v0.0.0-20260624004218-93591749d736/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b h1:cM+Cwgg6EN279knxvHc4vd3MyNOpZk/49TLlg2F78Rk=
+github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -243,8 +243,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860 h1:QPS7mJMor1Zfd/+/Au4DKlVBobz3k0hn8fcIV+LP92Q=
-github.com/getlantern/kindling v0.0.0-20260624005117-737fcffe2860/go.mod h1:hVrWMg592ICfNj9gbfV7Xsa6Bpb4TV2UCVAo0ssMFMk=
+github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c h1:F4/LE+5zehr6AUfuJBab3iubscOOTdFZxwYldIpLgg8=
+github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c/go.mod h1:rN6O8pIQ9nc7Gyvtf2GGSjiWEFIApGsRCHkgYz0h3Ak=
 github.com/getlantern/lantern-box v0.0.95 h1:tsgjKQjWjPy3ZyCIYijT91W3XJY+8XENxb6mUogthI0=
 github.com/getlantern/lantern-box v0.0.95/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260624235030-d13f227a31cc h1:LsnDrl92WwC14UteAwfCLKwJvwQ7+PnyIcOTLOPSduU=
-github.com/getlantern/radiance v0.0.0-20260624235030-d13f227a31cc/go.mod h1:0JUKTOv39QqoYeOzYJpiX435SSLh2cp6UGlQpDGXZVI=
+github.com/getlantern/radiance v0.0.0-20260625003855-687d6be3d5f0 h1:II60VhEWa7xj2WdkftSOkCoMIhV2CtW2Yh/YuU387dE=
+github.com/getlantern/radiance v0.0.0-20260625003855-687d6be3d5f0/go.mod h1:rXbNFXzQvbnlIlaIF/6EJTwxK9DrAyKowkpUq/5udkI=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Summary

Final link in the fronting-SNI chain — bump the Go deps so the client sends a **legit SNI** instead of the conspicuous no-SNI it uses today:

- `getlantern/radiance` → `v0.0.0-20260625003855-687d6be3d5f0` (**radiance#539**)
- `getlantern/domainfront` → `v0.0.0-20260625001429-518c0256669b` (**domainfront#11**, indirect)
- `getlantern/kindling` → `v0.0.0-20260625002640-7cdf7184420c` (**kindling#41**, indirect)

## What it enables

`domainfront.ExpandedProvider` now lets providers front with a real SNI (the production path — radiance `NewFronted` — passes no country code, which previously left every arbitrary-SNI strategy inert, so all fronting went out with no SNI — anomalous for a Chrome-fingerprinted ClientHello):

- **`default` frontingsnis applies with no country code** → akamai sends its arbitrary SNIs (real akamai-customer domains) globally. Validated: no regression vs no-SNI (20/20 edges front either way).
- **Baked-in per-masquerade SNI preserved** → aliyun uses `www.mobgslb.tbcache.com`, the service domain its edges actually accept (~83%, vs ~17% for `img.alicdn.com`).
- **SNI-path cert verified against the front Domain** (not chain-only) → closes a MITM gap without breaking akamai (whose arbitrary SNI is a decoy the served cert doesn't cover).

## Validation

`go.mod` change is **only** these three getlantern deps (`go mod tidy` run; `go.mod`+`go.sum` committed together). `go build ./...` and `go vet ./...` are clean.

## Companion

lantern-cloud#2897 sets aliyun's front SNI in the published config. Backward-safe end to end: pre-bump clients omit SNI exactly as today, so config and client can roll out in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated several indirect library versions to newer releases.
  * Kept one existing dependency version unchanged while refreshing related packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->