### PR TITLE
Make VPN toggle actions match displayed VPN state

### DIFF
--- a/lib/core/models/lantern_status.dart
+++ b/lib/core/models/lantern_status.dart
@@ -42,7 +42,7 @@ class LanternStatus {
   factory LanternStatus.fromJson(Map<String, dynamic> json) {
     appLogger.info('LanternStatus.fromJson $json');
     final VPNStatus status;
-    final String statusStr = json['status'].toLowerCase();
+    final String statusStr = (json['status'] as String?)?.toLowerCase() ?? '';
     if (statusStr == 'connected') {
       status = VPNStatus.connected;
     } else if (statusStr == 'disconnected') {

--- a/lib/features/vpn/provider/vpn_notifier.dart
+++ b/lib/features/vpn/provider/vpn_notifier.dart
@@ -1,6 +1,6 @@
+import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:fpdart/fpdart.dart';
 import 'package:lantern/core/common/common.dart';
@@ -20,11 +20,25 @@ part 'vpn_notifier.g.dart';
 class VpnNotifier extends _$VpnNotifier {
   @override
   VPNStatus build() {
-    ref.read(lanternServiceProvider).isVPNConnected();
+    unawaited(_hydrateInitialStatus());
     ref.listen(vPNStatusProvider, (previous, next) {
-      final previousStatus = previous?.value?.status;
-      final nextStatus = next.value!.status;
-      final nextOrigin = next.value!.origin;
+      if (next.hasError) {
+        appLogger.error(
+          'VPN status provider failed',
+          next.error,
+          next.stackTrace,
+        );
+        state = VPNStatus.error;
+        return;
+      }
+      if (!next.hasValue) return;
+      final lanternStatus = next.value;
+      if (lanternStatus == null) return;
+      final previousStatus = previous?.hasValue == true
+          ? previous!.value?.status
+          : null;
+      final nextStatus = lanternStatus.status;
+      final nextOrigin = lanternStatus.origin;
       // [vpn-state-trace] hop=dart_applied — moment Riverpod fires the listener
       // after the FFI ReceivePort delivers a status. Pairs with ffi_to_port
       // (lantern-core) and ssehandler_flushed / sse_parsed / daemon_setstatus
@@ -84,12 +98,33 @@ class VpnNotifier extends _$VpnNotifier {
     return VPNStatus.disconnected;
   }
 
-  Future<Either<Failure, String>> onVPNStateChange(BuildContext context) async {
+  Future<void> _hydrateInitialStatus() async {
+    final result = await ref.read(lanternServiceProvider).isVPNConnected();
+    if (!ref.mounted) return;
+    result.fold(
+      (failure) {
+        appLogger.error(
+          'Failed to hydrate VPN status: ${failure.error}',
+          failure.error,
+        );
+        if (state == VPNStatus.disconnected) {
+          state = VPNStatus.error;
+        }
+      },
+      (connected) {
+        if (state == VPNStatus.disconnected) {
+          state = connected ? VPNStatus.connected : VPNStatus.disconnected;
+        }
+      },
+    );
+  }
+
+  Future<Either<Failure, String>> onVPNStateChange() async {
     if (state == VPNStatus.connecting || state == VPNStatus.disconnecting) {
       return Right("");
     }
     appLogger.info("VPN State Change requested. Current state: $state");
-    return state == VPNStatus.disconnected ? startVPN() : stopVPN();
+    return state == VPNStatus.connected ? stopVPN() : startVPN();
   }
 
   /// Starts the VPN connection.

--- a/lib/features/vpn/provider/vpn_notifier.dart
+++ b/lib/features/vpn/provider/vpn_notifier.dart
@@ -18,11 +18,14 @@ part 'vpn_notifier.g.dart';
 
 @Riverpod(keepAlive: true)
 class VpnNotifier extends _$VpnNotifier {
+  bool _hasStatusStreamEmission = false;
+
   @override
   VPNStatus build() {
     unawaited(_hydrateInitialStatus());
     ref.listen(vPNStatusProvider, (previous, next) {
       if (next.hasError) {
+        _hasStatusStreamEmission = true;
         appLogger.error(
           'VPN status provider failed',
           next.error,
@@ -34,6 +37,7 @@ class VpnNotifier extends _$VpnNotifier {
       if (!next.hasValue) return;
       final lanternStatus = next.value;
       if (lanternStatus == null) return;
+      _hasStatusStreamEmission = true;
       final previousStatus = previous?.hasValue == true
           ? previous!.value?.status
           : null;
@@ -99,20 +103,31 @@ class VpnNotifier extends _$VpnNotifier {
   }
 
   Future<void> _hydrateInitialStatus() async {
-    final result = await ref.read(lanternServiceProvider).isVPNConnected();
-    if (!ref.mounted) return;
+    late final Either<Failure, bool> result;
+    try {
+      result = await ref.read(lanternServiceProvider).isVPNConnected();
+    } catch (e, stackTrace) {
+      appLogger.error('Failed to hydrate VPN status', e, stackTrace);
+      if (ref.mounted &&
+          !_hasStatusStreamEmission &&
+          state == VPNStatus.disconnected) {
+        state = VPNStatus.error;
+      }
+      return;
+    }
+    if (!ref.mounted || _hasStatusStreamEmission) return;
     result.fold(
       (failure) {
         appLogger.error(
           'Failed to hydrate VPN status: ${failure.error}',
           failure.error,
         );
-        if (state == VPNStatus.disconnected) {
+        if (!_hasStatusStreamEmission && state == VPNStatus.disconnected) {
           state = VPNStatus.error;
         }
       },
       (connected) {
-        if (state == VPNStatus.disconnected) {
+        if (!_hasStatusStreamEmission && state == VPNStatus.disconnected) {
           state = connected ? VPNStatus.connected : VPNStatus.disconnected;
         }
       },

--- a/lib/features/vpn/provider/vpn_notifier.dart
+++ b/lib/features/vpn/provider/vpn_notifier.dart
@@ -122,12 +122,12 @@ class VpnNotifier extends _$VpnNotifier {
           'Failed to hydrate VPN status: ${failure.error}',
           failure.error,
         );
-        if (!_hasStatusStreamEmission && state == VPNStatus.disconnected) {
+        if (state == VPNStatus.disconnected) {
           state = VPNStatus.error;
         }
       },
       (connected) {
-        if (!_hasStatusStreamEmission && state == VPNStatus.disconnected) {
+        if (state == VPNStatus.disconnected) {
           state = connected ? VPNStatus.connected : VPNStatus.disconnected;
         }
       },

--- a/lib/features/vpn/provider/vpn_status_notifier.dart
+++ b/lib/features/vpn/provider/vpn_status_notifier.dart
@@ -1,3 +1,4 @@
+import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/models/lantern_status.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
@@ -8,6 +9,18 @@ part 'vpn_status_notifier.g.dart';
 class VPNStatusNotifier extends _$VPNStatusNotifier {
   @override
   Stream<LanternStatus> build() async* {
-    yield* ref.read(lanternServiceProvider).watchVPNStatus();
+    final statusStream = ref.read(lanternServiceProvider).watchVPNStatus();
+    try {
+      await for (final status in statusStream) {
+        yield status;
+      }
+    } catch (e, stackTrace) {
+      appLogger.error('VPN status stream failed', e, stackTrace);
+      yield LanternStatus(
+        status: VPNStatus.error,
+        error: e.toString(),
+        origin: VPNStatusOrigin.system,
+      );
+    }
   }
 }

--- a/lib/features/vpn/provider/vpn_status_notifier.dart
+++ b/lib/features/vpn/provider/vpn_status_notifier.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/models/lantern_status.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
@@ -8,19 +10,22 @@ part 'vpn_status_notifier.g.dart';
 @Riverpod(keepAlive: true)
 class VPNStatusNotifier extends _$VPNStatusNotifier {
   @override
-  Stream<LanternStatus> build() async* {
+  Stream<LanternStatus> build() {
     final statusStream = ref.read(lanternServiceProvider).watchVPNStatus();
-    try {
-      await for (final status in statusStream) {
-        yield status;
-      }
-    } catch (e, stackTrace) {
-      appLogger.error('VPN status stream failed', e, stackTrace);
-      yield LanternStatus(
-        status: VPNStatus.error,
-        error: e.toString(),
-        origin: VPNStatusOrigin.system,
-      );
-    }
+    return statusStream.transform(
+      StreamTransformer.fromHandlers(
+        handleData: (status, sink) => sink.add(status),
+        handleError: (e, stackTrace, sink) {
+          appLogger.error('VPN status stream failed', e, stackTrace);
+          sink.add(
+            LanternStatus(
+              status: VPNStatus.error,
+              error: e.toString(),
+              origin: VPNStatusOrigin.system,
+            ),
+          );
+        },
+      ),
+    );
   }
 }

--- a/lib/features/vpn/provider/vpn_status_notifier.dart
+++ b/lib/features/vpn/provider/vpn_status_notifier.dart
@@ -12,9 +12,11 @@ class VPNStatusNotifier extends _$VPNStatusNotifier {
   @override
   Stream<LanternStatus> build() {
     final statusStream = ref.read(lanternServiceProvider).watchVPNStatus();
+    // Forward data events unchanged (the default when handleData is omitted)
+    // and convert stream errors into an error status without closing the
+    // subscription, so status updates keep flowing after a transient failure.
     return statusStream.transform(
       StreamTransformer.fromHandlers(
-        handleData: (status, sink) => sink.add(status),
         handleError: (e, stackTrace, sink) {
           appLogger.error('VPN status stream failed', e, stackTrace);
           sink.add(

--- a/lib/features/vpn/vpn_switch.dart
+++ b/lib/features/vpn/vpn_switch.dart
@@ -87,24 +87,22 @@ class VPNSwitch extends HookConsumerWidget {
     if (PlatformUtils.isMacOS) {
       final systemExtensionStatus = ref.read(macosExtensionProvider);
       if (!systemExtensionStatus.isReady) {
-        appRouter.push(const MacOSExtensionDialog()).then((value) {
+        final value = await appRouter.push(const MacOSExtensionDialog());
+        if (!context.mounted) return;
+        appLogger.info(
+          'Returned from MacOS Extension Dialog with value: $value',
+        );
+        if (value is bool && value) {
           appLogger.info(
-            'Returned from MacOS Extension Dialog with value: $value',
+            'Retrying VPN state change after MacOS Extension setup',
           );
-          if (value != null && value as bool) {
-            appLogger.info(
-              'Retrying VPN state change after MacOS Extension setup',
-            );
-            onVPNStateChange(ref, context);
-          }
-        });
+          await onVPNStateChange(ref, context);
+        }
         return;
       }
     }
 
-    final result = await ref
-        .read(vpnProvider.notifier)
-        .onVPNStateChange(context);
+    final result = await ref.read(vpnProvider.notifier).onVPNStateChange();
 
     if (!context.mounted) return;
     result.fold((failure) {

--- a/lib/features/vpn/vpn_switch.dart
+++ b/lib/features/vpn/vpn_switch.dart
@@ -96,7 +96,7 @@ class VPNSwitch extends HookConsumerWidget {
           appLogger.info(
             'Retrying VPN state change after MacOS Extension setup',
           );
-          await onVPNStateChange(ref, context);
+          return onVPNStateChange(ref, context);
         }
         return;
       }

--- a/test/features/vpn/provider/vpn_notifier_test.dart
+++ b/test/features/vpn/provider/vpn_notifier_test.dart
@@ -1,0 +1,145 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/models/lantern_status.dart';
+import 'package:lantern/features/vpn/provider/server_location_notifier.dart';
+import 'package:lantern/features/vpn/provider/vpn_notifier.dart';
+import 'package:lantern/features/vpn/provider/vpn_status_notifier.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
+
+class _FakeLanternService implements LanternService {
+  final statusController = StreamController<LanternStatus>.broadcast();
+
+  Either<Failure, bool> isConnectedResult = right(false);
+  int isVPNConnectedCalls = 0;
+  int startVPNCalls = 0;
+  int stopVPNCalls = 0;
+
+  @override
+  Future<Either<Failure, bool>> isVPNConnected() async {
+    isVPNConnectedCalls += 1;
+    return isConnectedResult;
+  }
+
+  @override
+  Stream<LanternStatus> watchVPNStatus() => statusController.stream;
+
+  @override
+  Future<Either<Failure, String>> startVPN() async {
+    startVPNCalls += 1;
+    return right('ok');
+  }
+
+  @override
+  Future<Either<Failure, String>> stopVPN() async {
+    stopVPNCalls += 1;
+    return right('ok');
+  }
+
+  @override
+  Future<bool> checkVpnConflict() async => false;
+
+  @override
+  Future<bool> isTagAvailable(String tag) async => true;
+
+  Future<void> dispose() => statusController.close();
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+ProviderContainer _container(_FakeLanternService service) {
+  return ProviderContainer(
+    overrides: [
+      lanternServiceProvider.overrideWithValue(service),
+      serverLocationProvider.overrideWithValue(initialServerLocation()),
+    ],
+  );
+}
+
+Future<void> _pumpProviderQueue() async {
+  await Future<void>.delayed(Duration.zero);
+  await Future<void>.delayed(Duration.zero);
+}
+
+void main() {
+  group('VpnNotifier', () {
+    test('hydrates initial connected state from core', () async {
+      final service = _FakeLanternService()..isConnectedResult = right(true);
+      final container = _container(service);
+      addTearDown(container.dispose);
+      addTearDown(service.dispose);
+
+      expect(container.read(vpnProvider), VPNStatus.disconnected);
+
+      await _pumpProviderQueue();
+
+      expect(service.isVPNConnectedCalls, 1);
+      expect(container.read(vpnProvider), VPNStatus.connected);
+    });
+
+    test(
+      'starts VPN from an error state because the switch displays off',
+      () async {
+        final service = _FakeLanternService();
+        final container = _container(service);
+        addTearDown(container.dispose);
+        addTearDown(service.dispose);
+        final statusSub = container.listen<AsyncValue<LanternStatus>>(
+          vPNStatusProvider,
+          (previous, next) {},
+          fireImmediately: true,
+        );
+        addTearDown(statusSub.close);
+
+        container.read(vpnProvider);
+        await _pumpProviderQueue();
+        service.statusController.add(
+          LanternStatus(status: VPNStatus.error, error: 'connect failed'),
+        );
+        await _pumpProviderQueue();
+
+        expect(container.read(vpnProvider), VPNStatus.error);
+
+        final result = await container
+            .read(vpnProvider.notifier)
+            .onVPNStateChange();
+
+        expect(result.isRight(), isTrue);
+        expect(service.startVPNCalls, 1);
+        expect(service.stopVPNCalls, 0);
+      },
+    );
+
+    test(
+      'status stream errors become VPNStatus.error instead of crashing',
+      () async {
+        final service = _FakeLanternService();
+        final container = _container(service);
+        addTearDown(container.dispose);
+        addTearDown(service.dispose);
+        final statusSub = container.listen<AsyncValue<LanternStatus>>(
+          vPNStatusProvider,
+          (previous, next) {},
+          fireImmediately: true,
+        );
+        addTearDown(statusSub.close);
+
+        container.read(vpnProvider);
+        await _pumpProviderQueue();
+        service.statusController.addError(StateError('status stream failed'));
+        await _pumpProviderQueue();
+
+        expect(container.read(vpnProvider), VPNStatus.error);
+        final status = container.read(vPNStatusProvider);
+        expect(status.hasValue, isTrue);
+        expect(status.value?.status, VPNStatus.error);
+        expect(status.value?.error, contains('status stream failed'));
+      },
+    );
+  });
+}

--- a/test/features/vpn/provider/vpn_notifier_test.dart
+++ b/test/features/vpn/provider/vpn_notifier_test.dart
@@ -15,6 +15,8 @@ class _FakeLanternService implements LanternService {
   final statusController = StreamController<LanternStatus>.broadcast();
 
   Either<Failure, bool> isConnectedResult = right(false);
+  Completer<Either<Failure, bool>>? isConnectedCompleter;
+  Object? isConnectedException;
   int isVPNConnectedCalls = 0;
   int startVPNCalls = 0;
   int stopVPNCalls = 0;
@@ -22,6 +24,13 @@ class _FakeLanternService implements LanternService {
   @override
   Future<Either<Failure, bool>> isVPNConnected() async {
     isVPNConnectedCalls += 1;
+    if (isConnectedException != null) {
+      throw isConnectedException!;
+    }
+    final completer = isConnectedCompleter;
+    if (completer != null) {
+      return completer.future;
+    }
     return isConnectedResult;
   }
 
@@ -61,6 +70,16 @@ ProviderContainer _container(_FakeLanternService service) {
   );
 }
 
+void _disposeContainerAndService(
+  ProviderContainer container,
+  _FakeLanternService service,
+) {
+  addTearDown(() async {
+    container.dispose();
+    await service.dispose();
+  });
+}
+
 Future<void> _pumpProviderQueue() async {
   await Future<void>.delayed(Duration.zero);
   await Future<void>.delayed(Duration.zero);
@@ -71,8 +90,7 @@ void main() {
     test('hydrates initial connected state from core', () async {
       final service = _FakeLanternService()..isConnectedResult = right(true);
       final container = _container(service);
-      addTearDown(container.dispose);
-      addTearDown(service.dispose);
+      _disposeContainerAndService(container, service);
 
       expect(container.read(vpnProvider), VPNStatus.disconnected);
 
@@ -82,13 +100,53 @@ void main() {
       expect(container.read(vpnProvider), VPNStatus.connected);
     });
 
+    test('stream status wins over slower initial hydration', () async {
+      final service = _FakeLanternService()
+        ..isConnectedCompleter = Completer<Either<Failure, bool>>();
+      final container = _container(service);
+      _disposeContainerAndService(container, service);
+      final statusSub = container.listen<AsyncValue<LanternStatus>>(
+        vPNStatusProvider,
+        (previous, next) {},
+        fireImmediately: true,
+      );
+      addTearDown(statusSub.close);
+
+      container.read(vpnProvider);
+      await _pumpProviderQueue();
+      service.statusController.add(
+        LanternStatus(status: VPNStatus.disconnected),
+      );
+      await _pumpProviderQueue();
+
+      expect(container.read(vpnProvider), VPNStatus.disconnected);
+
+      service.isConnectedCompleter!.complete(right(true));
+      await _pumpProviderQueue();
+
+      expect(container.read(vpnProvider), VPNStatus.disconnected);
+    });
+
+    test('thrown hydration failures become VPNStatus.error', () async {
+      final service = _FakeLanternService()
+        ..isConnectedException = StateError('hydration failed');
+      final container = _container(service);
+      _disposeContainerAndService(container, service);
+
+      expect(container.read(vpnProvider), VPNStatus.disconnected);
+
+      await _pumpProviderQueue();
+
+      expect(service.isVPNConnectedCalls, 1);
+      expect(container.read(vpnProvider), VPNStatus.error);
+    });
+
     test(
       'starts VPN from an error state because the switch displays off',
       () async {
         final service = _FakeLanternService();
         final container = _container(service);
-        addTearDown(container.dispose);
-        addTearDown(service.dispose);
+        _disposeContainerAndService(container, service);
         final statusSub = container.listen<AsyncValue<LanternStatus>>(
           vPNStatusProvider,
           (previous, next) {},
@@ -120,8 +178,7 @@ void main() {
       () async {
         final service = _FakeLanternService();
         final container = _container(service);
-        addTearDown(container.dispose);
-        addTearDown(service.dispose);
+        _disposeContainerAndService(container, service);
         final statusSub = container.listen<AsyncValue<LanternStatus>>(
           vPNStatusProvider,
           (previous, next) {},
@@ -139,6 +196,19 @@ void main() {
         expect(status.hasValue, isTrue);
         expect(status.value?.status, VPNStatus.error);
         expect(status.value?.error, contains('status stream failed'));
+
+        service.statusController.add(
+          LanternStatus(
+            status: VPNStatus.disconnected,
+            origin: VPNStatusOrigin.settingsMutation,
+          ),
+        );
+        await _pumpProviderQueue();
+
+        expect(container.read(vpnProvider), VPNStatus.disconnected);
+        final recoveredStatus = container.read(vPNStatusProvider);
+        expect(recoveredStatus.hasValue, isTrue);
+        expect(recoveredStatus.value?.status, VPNStatus.disconnected);
       },
     );
   });


### PR DESCRIPTION
Resolves https://github.com/getlantern/engineering/issues/3636

Fixes a VPN toggle mismatch where the UI could show the VPN as off or errored, but tapping the toggle would try to disconnect instead of reconnect.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Enhanced VPN status handling for clearer connected/disconnected/error behavior, including improved startup hydration and recovery after stream failures.
  * Added automated tests covering VPN initialization, stream error handling, and recovery scenarios.

* **Bug Fixes**
  * Improved lantern status parsing to be null-safe when the status value is missing.
  * Updated VPN status stream processing to handle errors safely and surface them as a recoverable error state.

* **Bug Fixes**
  * Refined the macOS VPN retry flow to properly await the dialog result and only continue when approved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->