### PR TITLE
Run desktop smoke tests by default for release builds

### DIFF
--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -1,0 +1,126 @@
+name: App Smoke Tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: "Platforms to smoke test"
+        required: true
+        type: choice
+        options:
+          - all
+          - linux
+          - windows
+        default: all
+      linux_arch:
+        description: "Linux arch to test"
+        required: false
+        type: choice
+        options:
+          - amd64
+          - arm64
+          - all
+        default: amd64
+      windows_connect_smoke:
+        description: "Run Windows connect/disconnect smoke"
+        required: false
+        type: boolean
+        default: true
+      windows_config_url_smoke:
+        description: "Run Windows config URL smoke when secrets are present"
+        required: false
+        type: boolean
+        default: true
+      windows_split_tunnel_website_smoke:
+        description: "Run Windows split-tunneling website smoke"
+        required: false
+        type: boolean
+        default: false
+      auth_smoke:
+        description: "Run existing auth smoke tests"
+        required: false
+        type: boolean
+        default: false
+      enable_ip_check:
+        description: "Validate public IP change during VPN connect smoke"
+        required: false
+        type: boolean
+        default: false
+      force_full_tunnel_smoke:
+        description: "Force full-tunnel mode during VPN connect smoke"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: app-smoke-tests-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      installer_base_name: ${{ steps.meta.outputs.installer_base_name }}
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - id: meta
+        shell: bash
+        run: |
+          set -euo pipefail
+          VERSION="$(./scripts/ci/version.sh generate nightly)"
+          BASE_VERSION="$(./scripts/ci/version.sh extract "$VERSION")"
+          FULL_VERSION="${BASE_VERSION}+${GITHUB_RUN_NUMBER}"
+          INSTALLER_BASE_NAME="lantern-smoke-test"
+
+          sed -i.bak -E "s/^version:.*/version: ${FULL_VERSION}/" pubspec.yaml
+          grep '^version:' pubspec.yaml
+
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "installer_base_name=$INSTALLER_BASE_NAME" >> "$GITHUB_OUTPUT"
+
+      - name: Upload pubspec.yaml
+        uses: actions/upload-artifact@v4
+        with:
+          name: pubspec
+          path: pubspec.yaml
+
+  linux:
+    needs: prepare
+    if: ${{ inputs.platforms == 'all' || inputs.platforms == 'linux' }}
+    uses: ./.github/workflows/build-linux.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      build_type: nightly
+      installer_base_name: ${{ needs.prepare.outputs.installer_base_name }}
+      linux_arch: ${{ inputs.linux_arch }}
+      enable_ip_check: ${{ inputs.enable_ip_check }}
+      force_full_tunnel_smoke: ${{ inputs.force_full_tunnel_smoke }}
+      run_auth_smoke: ${{ inputs.auth_smoke }}
+
+  windows:
+    needs: prepare
+    if: ${{ inputs.platforms == 'all' || inputs.platforms == 'windows' }}
+    uses: ./.github/workflows/build-windows.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prepare.outputs.version }}
+      build_type: nightly
+      installer_base_name: ${{ needs.prepare.outputs.installer_base_name }}
+      skip_signing: true
+      enable_ip_check: ${{ inputs.enable_ip_check }}
+      run_connect_smoke: ${{ inputs.windows_connect_smoke }}
+      run_split_tunnel_website_smoke: ${{ inputs.windows_split_tunnel_website_smoke }}
+      run_config_url_smoke: ${{ inputs.windows_config_url_smoke }}
+      force_full_tunnel_smoke: ${{ inputs.force_full_tunnel_smoke }}
+      run_auth_smoke: ${{ inputs.auth_smoke }}

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -26,11 +26,6 @@ on:
         required: false
         type: boolean
         default: true
-      windows_config_url_smoke:
-        description: "Run Windows config URL smoke when secrets are present"
-        required: false
-        type: boolean
-        default: true
       windows_split_tunnel_website_smoke:
         description: "Run Windows split-tunneling website smoke"
         required: false
@@ -72,6 +67,7 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+          persist-credentials: false
 
       - id: meta
         shell: bash
@@ -121,6 +117,6 @@ jobs:
       enable_ip_check: ${{ inputs.enable_ip_check }}
       run_connect_smoke: ${{ inputs.windows_connect_smoke }}
       run_split_tunnel_website_smoke: ${{ inputs.windows_split_tunnel_website_smoke }}
-      run_config_url_smoke: ${{ inputs.windows_config_url_smoke }}
+      run_config_url_smoke: false
       force_full_tunnel_smoke: ${{ inputs.force_full_tunnel_smoke }}
       run_auth_smoke: ${{ inputs.auth_smoke }}

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -49,7 +49,7 @@ on:
 
 permissions:
   contents: read
-  id-token: write
+  id-token: none
 
 concurrency:
   group: app-smoke-tests-${{ github.ref }}
@@ -94,7 +94,8 @@ jobs:
     needs: prepare
     if: ${{ inputs.platforms == 'all' || inputs.platforms == 'linux' }}
     uses: ./.github/workflows/build-linux.yml
-    secrets: inherit
+    secrets:
+      APP_ENV: ${{ secrets.APP_ENV }}
     with:
       version: ${{ needs.prepare.outputs.version }}
       build_type: nightly
@@ -108,7 +109,8 @@ jobs:
     needs: prepare
     if: ${{ inputs.platforms == 'all' || inputs.platforms == 'windows' }}
     uses: ./.github/workflows/build-windows.yml
-    secrets: inherit
+    secrets:
+      APP_ENV: ${{ secrets.APP_ENV }}
     with:
       version: ${{ needs.prepare.outputs.version }}
       build_type: nightly

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -2,6 +2,11 @@ name: Build Linux App
 
 on:
   workflow_call:
+    secrets:
+      APP_ENV:
+        required: true
+      JOIN_SERVER_CONFIG_URLS:
+        required: false
     inputs:
       version:
         required: true

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,6 +2,13 @@ name: Build Windows
 
 on:
   workflow_call:
+    secrets:
+      APP_ENV:
+        required: true
+      JOIN_SERVER_CONFIG_URLS:
+        required: false
+      SIGNPATH_API_TOKEN:
+        required: false
     inputs:
       version:
         required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -392,7 +392,7 @@ jobs:
       enable_ip_check: ${{ needs.set-metadata.outputs.smoke_enable_ip_check == 'true' }}
       run_connect_smoke: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.windows_connect_smoke == 'true' }}
       run_split_tunnel_website_smoke: false
-      run_config_url_smoke: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.windows_connect_smoke == 'true' }}
+      run_config_url_smoke: false
       force_full_tunnel_smoke: ${{ needs.set-metadata.outputs.build_type == 'nightly' }}
       run_auth_smoke: false
       skip_signing: ${{ needs.set-metadata.outputs.build_type == 'nightly' && (needs.set-metadata.outputs.is_test_run == 'true' || github.event.inputs.sign_windows != 'true') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,10 @@ on:
         type: boolean
         default: true
       windows_connect_smoke:
-        description: "Run Windows connect/disconnect smoke test on manual dispatch"
+        description: "Run Windows connect/disconnect smoke tests on manual dispatch"
         required: false
         type: boolean
-        default: false
+        default: true
       publish_mobile_stores:
         description: "Upload nightly Android/iOS artifacts to Play internal/TestFlight (default-branch dispatch only)"
         required: false
@@ -390,9 +390,9 @@ jobs:
       build_type: ${{ needs.set-metadata.outputs.build_type }}
       installer_base_name: ${{ needs.set-metadata.outputs.installer_base_name }}
       enable_ip_check: ${{ needs.set-metadata.outputs.smoke_enable_ip_check == 'true' }}
-      run_connect_smoke: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.windows_connect_smoke == 'true' }}
+      run_connect_smoke: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.windows_connect_smoke == 'true' }}
       run_split_tunnel_website_smoke: false
-      run_config_url_smoke: false
+      run_config_url_smoke: ${{ github.event_name != 'workflow_dispatch' || github.event.inputs.windows_connect_smoke == 'true' }}
       force_full_tunnel_smoke: ${{ needs.set-metadata.outputs.build_type == 'nightly' }}
       run_auth_smoke: false
       skip_signing: ${{ needs.set-metadata.outputs.build_type == 'nightly' && (needs.set-metadata.outputs.is_test_run == 'true' || github.event.inputs.sign_windows != 'true') }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual **App Smoke Tests** workflow with selectable platforms and toggles for multiple smoke-test subsets, including nightly version preparation and reusable platform runs.
* **Bug Fixes**
  * Updated the release workflow so Windows “connect” smoke tests run by default in more scenarios, while respecting the manual dispatch toggle.
* **Chores**
  * Extended Linux and Windows build workflows’ callable interfaces to require the app environment secret and optionally accept join configuration (and an additional token for Windows).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->