### PR TITLE
deps: bump radiance — proxyless rule-set detour (#549)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260702205513-686b6b916dcb
+	github.com/getlantern/radiance v0.0.0-20260706174732-4356bc07f9a0
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -166,7 +166,7 @@ require (
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c // indirect
 	github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc // indirect
-	github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46 // indirect
+	github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
-github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46 h1:Ab2esudqgFz2K1WYQKtX+58kaiVMX0UohjW2XmdEgf4=
-github.com/getlantern/common v1.2.1-0.20260326210434-cb69537aaf46/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
+github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b h1:R6YoZuQFLdArpovoMtPxa3ohqJzx6bpJ+BRxDaoMdWk=
+github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260702205513-686b6b916dcb h1:BgAE2ZDK5jWjMUbW+54YyGX98teafgAgxFKr9DpujFA=
-github.com/getlantern/radiance v0.0.0-20260702205513-686b6b916dcb/go.mod h1:rXbNFXzQvbnlIlaIF/6EJTwxK9DrAyKowkpUq/5udkI=
+github.com/getlantern/radiance v0.0.0-20260706174732-4356bc07f9a0 h1:p8OFTbdCLa6fYSfivXosSSxEEt9j49yNMO2ds8VDkiw=
+github.com/getlantern/radiance v0.0.0-20260706174732-4356bc07f9a0/go.mod h1:clf0ipuVkFIY4YOdmM+3uufvlvA3t4h5FDt6NevPIjY=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## What

Bump `getlantern/radiance` `686b6b9` → `4356bc0`.

## Changes pulled (5 commits)

| Commit | Impact |
|---|---|
| `4356bc0` **radiance#549** — client honors `ConfigResponse.NonSelectableOutbounds` | the change we want |
| `166e907` iOS-only mobile memory-limits fix | fix (low risk) |
| `737cdb7` / `1485f2a` / `01d51f2` stale-bot CI workflow | CI-only, no runtime impact |

Transitively bumps `getlantern/common` to the merged `NonSelectableOutbounds` field (`common#27`).

## Why

This is the **client half** of the CN geosite cold-start fix. With #549, radiance merges server-declared infrastructure outbounds (e.g. the proxyless rule-set-fetch detour) into the box config so their references resolve, but excludes them from **both** the auto (URLTest) group and the manual selector — so such an outbound can never be auto-selected or user-picked (which would route traffic directly and expose the user's IP).

It's **inert** until the server (lantern-cloud#2936) enables the proxyless detour — which is itself gated behind a feature flag **and** a `PROXYLESS_MIN_CLIENT_VERSION` floor set to the release carrying this bump. So this needs to ship first, then the server flag is enabled.

Context: getlantern/engineering#3657.

## Testing

`go build ./...` passes; `go mod tidy` clean (only radiance + the transitive `common` bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGpKfgkbfdJwwsTaouMDoR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated two indirect dependencies to newer revisions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->