### PR TITLE
build: inject BuildTime + Commit ldflags into the mobile binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,16 @@ APP_VERSION_PUBSPEC := $(firstword $(subst +, ,$(APP_VERSION)))
 ifeq ($(strip $(APP_VERSION_PUBSPEC)),)
 $(error APP_VERSION_PUBSPEC is empty; export APP_VERSION (e.g. "9.0.25+459") or ensure pubspec.yaml contains a `version:` line)
 endif
-EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'
+## Build stamp injected into the binary so logs and crash reports are
+## self-describing — this is how a stale build (linked deps not matching go.mod)
+## becomes visible. Overridable by the caller / CI.
+ifeq ($(OS),Windows_NT)
+BUILD_TIME ?= $(shell powershell -NoProfile -Command "[DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')")
+else
+BUILD_TIME ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+endif
+GIT_COMMIT ?= $(shell git rev-parse --short HEAD)
+EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)' -X '$(RADIANCE_REPO)/common.BuildTime=$(BUILD_TIME)' -X '$(RADIANCE_REPO)/common.Commit=$(GIT_COMMIT)'
 STEALTH_GO_IMPORT_PATH := github.com/getlantern/lantern/lantern-core
 STEALTH_GO_LOG_LEVEL ?= warn
 # Stealth can be activated via a stealth BUILD_TYPE or via STEALTH_MODE/STEALTH_PROFILE


### PR DESCRIPTION
## What
Extend `EXTRA_LDFLAGS` (already carrying `common.Version`) with:
- `common.BuildTime` — UTC RFC3339 build timestamp
- `common.Commit` — short git SHA

Both flow into the existing android/macOS/iOS gomobile-bind targets via `EXTRA_LDFLAGS`. Windows-safe (`powershell` branch for the timestamp).

## Why
Pairs with getlantern/radiance (https://github.com/getlantern/radiance/pull/556) to make a shipped binary self-describing. A 9.1.14 TestFlight build linked a stale, pre-fix keepcurrent despite go.mod declaring the fix; a build-time + commit stamp (with radiance now logging linked dep versions) makes such a stale build obvious in logs and crash reports instead of silent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WGpKfgkbfdJwwsTaouMDoR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Builds now include additional metadata, such as build time and commit information, alongside the version number.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->