### PR TITLE
fix(android): avoid API 26 network callback overload on Android 7

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkListener.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkListener.kt
@@ -169,8 +169,12 @@ object DefaultNetworkListener {
                     mainHandler
                 )
             }
-            in 24..30 -> {
+            in 26..30 -> {
                 LanternApp.connectivity.registerDefaultNetworkCallback(Callback, mainHandler)
+            }
+            // Handler overload was added in API 26; API 24-25 only have the one-arg version.
+            in 24..25 -> {
+                LanternApp.connectivity.registerDefaultNetworkCallback(Callback)
             }
             else -> try {
                 fallback = false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android network callback registration across different OS versions.
  * Fixed behavior on older Android releases so the app uses the supported callback method for each API level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->