### PR TITLE
fix(android): keep selected server across VPN consent dialog

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
@@ -51,10 +51,8 @@ class MainActivity : FlutterFragmentActivity() {
 
     private val serviceStartHandler = Handler(Looper.getMainLooper())
 
-    // Server tag selected before the VPN-consent dialog interrupted the connect;
-    // replayed after consent so consent can't collapse a selection into auto. Null = auto.
-    // Volatile: written from MethodHandler's IO coroutine, read on the main thread in the
-    // permission callbacks; single-variable access needs visibility, not atomicity.
+    // Pending tag replayed after the VPN-consent dialog so consent can't collapse the
+    // selection into auto. Null = auto.
     @Volatile
     private var pendingTag: String? = null
 
@@ -164,7 +162,7 @@ class MainActivity : FlutterFragmentActivity() {
         }
 
         // Check if VPN is already connected
-        // if so then user already have vpn on now wish to switch auto server
+        // if so then user already have vpn on now wish to switch server
         // Do not need to create service again just switch server
         if (Mobile.isVPNConnected()) {
             AppLogger.d(TAG, "VPN is already connected, switching auto server")
@@ -197,6 +195,7 @@ class MainActivity : FlutterFragmentActivity() {
         // Check if VPN is already connected
         // if so then user already have vpn on now wish to switch server
         // Do not need to create service again just switch server
+
         if (Mobile.isVPNConnected()) {
             AppLogger.d(TAG, "VPN is already connected, switching server")
             CoroutineScope(Dispatchers.Main).launch {
@@ -213,8 +212,7 @@ class MainActivity : FlutterFragmentActivity() {
             }
             ContextCompat.startForegroundService(this, vpnIntent)
             AppLogger.d(TAG, "VPN service started")
-            // Clear only after a successful dispatch so a failed start (below) keeps
-            // pendingTag for retry.
+            // Clear only after a successful dispatch so a failed start keeps it for retry.
             pendingTag = null
         } catch (e: Exception) {
             e.printStackTrace()
@@ -224,9 +222,7 @@ class MainActivity : FlutterFragmentActivity() {
     }
 
 
-    // Resumes the connect the VPN-consent dialog interrupted, replaying the user's
-    // server selection (pendingTag) instead of falling back to auto-select.
-    // connectToServer/startVPN own clearing pendingTag once the connect is dispatched.
+    // Replays the pending selection after VPN consent, so consent doesn't fall back to auto.
     private fun resumePendingConnect() {
         val tag = pendingTag
         if (tag != null) {

--- a/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
@@ -51,6 +51,10 @@ class MainActivity : FlutterFragmentActivity() {
 
     private val serviceStartHandler = Handler(Looper.getMainLooper())
 
+    // Server tag selected before the VPN-consent dialog interrupted the connect;
+    // replayed after consent so consent can't collapse a selection into auto. Null = auto.
+    private var pendingTag: String? = null
+
 
     override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
         super.configureFlutterEngine(flutterEngine)
@@ -150,6 +154,7 @@ class MainActivity : FlutterFragmentActivity() {
 
 
     fun startVPN() {
+        pendingTag = null
         if (!isVPNServiceReady()) {
             AppLogger.d(TAG, "VPN service not ready")
             return
@@ -181,6 +186,8 @@ class MainActivity : FlutterFragmentActivity() {
 
     fun connectToServer(tag: String) {
         if (!isVPNServiceReady()) {
+            // Preserve the selection across the consent dialog; resumePendingConnect replays it.
+            pendingTag = tag
             AppLogger.d(TAG, "VPN service not ready")
             return
         }
@@ -192,6 +199,7 @@ class MainActivity : FlutterFragmentActivity() {
             CoroutineScope(Dispatchers.Main).launch {
                 LanternVpnService.instance.connectToServer(tag)
             }
+            pendingTag = null
             return
         }
 
@@ -202,6 +210,9 @@ class MainActivity : FlutterFragmentActivity() {
             }
             ContextCompat.startForegroundService(this, vpnIntent)
             AppLogger.d(TAG, "VPN service started")
+            // Clear only after a successful dispatch so a failed start (below) keeps
+            // pendingTag for retry.
+            pendingTag = null
         } catch (e: Exception) {
             e.printStackTrace()
             AppLogger.e(TAG, "Error starting VPN service", e)
@@ -209,6 +220,18 @@ class MainActivity : FlutterFragmentActivity() {
         }
     }
 
+
+    // Resumes the connect the VPN-consent dialog interrupted, replaying the user's
+    // server selection (pendingTag) instead of falling back to auto-select.
+    // connectToServer/startVPN own clearing pendingTag once the connect is dispatched.
+    private fun resumePendingConnect() {
+        val tag = pendingTag
+        if (tag != null) {
+            connectToServer(tag)
+        } else {
+            startVPN()
+        }
+    }
 
     fun stopVPN() {
         if (isServiceRunning(this, LanternVpnService::class.java)) {
@@ -261,7 +284,7 @@ class MainActivity : FlutterFragmentActivity() {
         super.onActivityResult(requestCode, resultCode, data)
         if (requestCode == VPN_PERMISSION_REQUEST_CODE) {
             if (resultCode == RESULT_OK) {
-                startVPN()
+                resumePendingConnect()
             } else {
                 VpnStatusManager.postVPNStatus(VPNStatus.MissingPermission)
             }
@@ -285,7 +308,7 @@ class MainActivity : FlutterFragmentActivity() {
     ) {
         if (requestCode == NOTIFICATION_PERMISSION_REQUEST_CODE) {
             if (grantResults.isNotEmpty() && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
-                startVPN()
+                resumePendingConnect()
             } else {
                 VpnStatusManager.postVPNStatus(VPNStatus.MissingPermission)
             }

--- a/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
@@ -53,6 +53,9 @@ class MainActivity : FlutterFragmentActivity() {
 
     // Server tag selected before the VPN-consent dialog interrupted the connect;
     // replayed after consent so consent can't collapse a selection into auto. Null = auto.
+    // Volatile: written from MethodHandler's IO coroutine, read on the main thread in the
+    // permission callbacks; single-variable access needs visibility, not atomicity.
+    @Volatile
     private var pendingTag: String? = null
 
 


### PR DESCRIPTION
## Problem

On the **first connect of a session**, tapping a specific server routes the tunnel to the nearest exit instead. In `MainActivity`, `connectToServer(tag)` bails at the `isVPNServiceReady()` check that shows the OS VPN-consent dialog and **discards the tag**. `onActivityResult` then resumes unconditionally with `startVPN()` (auto-select), so the tunnel connects to the nearest server while the UI still shows the tapped one.

## Fix

- Record the pending selection (`pendingTag`) when the consent dialog interrupts the connect.
- After consent, `resumePendingConnect()` replays it via the tag-preserving `connectToServer()` path instead of falling back to auto.
- `connectToServer` owns the `pendingTag` lifecycle: set **only** when deferring for consent, cleared **only** after a successful dispatch — so a failed service start preserves the selection for retry.
- Both permission callbacks (`onActivityResult`, `onRequestPermissionsResult`) route through `resumePendingConnect()`.

The service side already handled `ACTION_CONNECT_TO_SERVER` correctly; the bug was entirely `MainActivity` dropping the tag across the consent round-trip.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the user-selected VPN server when the connection flow was interrupted by VPN consent/permissions.
  * After permissions were granted, the app now continues the intended connection instead of falling back to automatic server selection.
  * Improved behavior when switching VPN servers while a connection is already active, ensuring the correct server is selected and connected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->