### PR TITLE
chore: update radiance to latest main

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260706185153-bce252479f03
+	github.com/getlantern/radiance v0.0.0-20260710183028-11bcb86051fb
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -166,7 +166,7 @@ require (
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c // indirect
 	github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc // indirect
-	github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b // indirect
+	github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437 // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -225,8 +225,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
 github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
-github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b h1:R6YoZuQFLdArpovoMtPxa3ohqJzx6bpJ+BRxDaoMdWk=
-github.com/getlantern/common v1.2.1-0.20260705172801-57aaafd97c1b/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
+github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437 h1:CXx0ek+MzSbwtJANHGlAWX48jHGLlNC1EM2ZW8iDPXw=
+github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260706185153-bce252479f03 h1:yKLQK9wMXlghg4ksSDenZVYbUBphblutaFMomS6ZqQU=
-github.com/getlantern/radiance v0.0.0-20260706185153-bce252479f03/go.mod h1:p6wcyzCrsFfrdrLNuQirB0ugeg7OjdFlZmBgNTu4D1w=
+github.com/getlantern/radiance v0.0.0-20260710183028-11bcb86051fb h1:mZUHUAICydrjiLp+HlhzwFzl8jVA5YPdHxCuSm714Nc=
+github.com/getlantern/radiance v0.0.0-20260710183028-11bcb86051fb/go.mod h1:4eVZwxd9J7y113n/NGZpexis2MH06MoaA8uDUO4TXOU=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Updates `github.com/getlantern/radiance` from `bce252479f03` (2026-07-06) to `11bcb86051fb` (2026-07-10, latest main). Also bumps transitive `getlantern/common` to `5d90dcb22437`.

## Radiance changes pulled in

- fa6714a75 Apply cached config during startup (#543)
- 382130c16 cmd/residential-urltest: in-region reachability + throughput repro tool (#540)
- ce70c50cd config: advertise the non_selectable_outbounds capability (#555)
- b9eadd112 fix: skipping amp transport based on country (#558)
- 9508f62d0 fix(bypass): use SOCKS5 so upstream dial failures propagate (#561)
- 11bcb8605 fix: disabling dnstt (#562)

Ran `go mod tidy`; `go build ./...` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions for improved stability and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->