### PR TITLE
chore: update radiance for tun default fix (remove deprecated endpoint-independent NAT)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260710183028-11bcb86051fb
+	github.com/getlantern/radiance v0.0.0-20260713183736-b48373539f5e
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260710183028-11bcb86051fb h1:mZUHUAICydrjiLp+HlhzwFzl8jVA5YPdHxCuSm714Nc=
-github.com/getlantern/radiance v0.0.0-20260710183028-11bcb86051fb/go.mod h1:4eVZwxd9J7y113n/NGZpexis2MH06MoaA8uDUO4TXOU=
+github.com/getlantern/radiance v0.0.0-20260713183736-b48373539f5e h1:S1YPGuMuUUs0fxNB9/hBu9+VEEHswl8a47sKaSAb6vs=
+github.com/getlantern/radiance v0.0.0-20260713183736-b48373539f5e/go.mod h1:4eVZwxd9J7y113n/NGZpexis2MH06MoaA8uDUO4TXOU=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Updates `github.com/getlantern/radiance` from `11bcb86051fb` to `b48373539f5e` to pull in getlantern/radiance#563:

> **fix(vpn): remove deprecated endpoint-independent NAT from tun defaults** — `EndpointIndependentNat` is only supported on gVisor stacks and is deprecated, so drop it from the system stack tun configuration in `vpn/boxoptions_default.go`.

Pinned exactly at the #563 merge commit — radiance main has one later commit (#557, bandit selection-history failure reporting) that is intentionally **not** included here.

Ran `go mod tidy`; `go build ./...` passes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version, incorporating the latest available improvements and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->