### PR TITLE
deps: bump radiance for unbounded memory-leak fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260713183736-b48373539f5e
+	github.com/getlantern/radiance v0.0.0-20260717205323-e6267cfddb00
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -165,13 +165,13 @@ require (
 	github.com/gaukas/wazerofs v0.1.0 // indirect
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c // indirect
-	github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc // indirect
-	github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437 // indirect
+	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
+	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
 	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c // indirect
-	github.com/getlantern/lantern-box v0.0.100 // indirect
+	github.com/getlantern/lantern-box v0.0.103 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -223,10 +223,10 @@ github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7Pb
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6wPYUq8Smntlgg+y39L5OOyMJY+k=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
-github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc h1:AVY56mzJHM4CBTrW9oBgpShB5S68gGunvk9GMvJrkzM=
-github.com/getlantern/broflake v0.0.0-20260612203837-c4d1516de8dc/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
-github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437 h1:CXx0ek+MzSbwtJANHGlAWX48jHGLlNC1EM2ZW8iDPXw=
-github.com/getlantern/common v1.2.1-0.20260707190506-5d90dcb22437/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
+github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 h1:r7j54Ol1wak59OY0SK2Fw5lOI3YvrAEDW3QAQEj12mA=
+github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
+github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c h1:Hpxu12ORnAcyYuIqV2yAqrmDAnTaY1Cd3yL7TvFB6ME=
+github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
@@ -245,8 +245,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c h1:F4/LE+5zehr6AUfuJBab3iubscOOTdFZxwYldIpLgg8=
 github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c/go.mod h1:rN6O8pIQ9nc7Gyvtf2GGSjiWEFIApGsRCHkgYz0h3Ak=
-github.com/getlantern/lantern-box v0.0.100 h1:mnWdy4lfPBABtu8ClWQ/8qzfV5PAJWjrbKapk37dw/o=
-github.com/getlantern/lantern-box v0.0.100/go.mod h1:yQhnLpnDY17+c/s+4WiiUhun3HtoHNj5NFb355ThKQk=
+github.com/getlantern/lantern-box v0.0.103 h1:2Oqq1Ucaa3Va73XYpXCecU+7vkTxfWD0NSHETbrSrTw=
+github.com/getlantern/lantern-box v0.0.103/go.mod h1:qMpxONKk4Gd/9Zd9vOY4q+uHCAfXG/xUF87/K4bO6AA=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260713183736-b48373539f5e h1:S1YPGuMuUUs0fxNB9/hBu9+VEEHswl8a47sKaSAb6vs=
-github.com/getlantern/radiance v0.0.0-20260713183736-b48373539f5e/go.mod h1:4eVZwxd9J7y113n/NGZpexis2MH06MoaA8uDUO4TXOU=
+github.com/getlantern/radiance v0.0.0-20260717205323-e6267cfddb00 h1:aoKwFuWymKtjCfZF+YbxX6XKrabQoqEPqeMdWzRbmqE=
+github.com/getlantern/radiance v0.0.0-20260717205323-e6267cfddb00/go.mod h1:nOydBjNr9ELIlgtV1jonxSD8XSeuKFkcs3SQG2JdiIA=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Why

Ships the unbounded consumer-side memory-leak fixes (getlantern/engineering#3698) to the client. The ticket-180321 repro: an iOS network extension jetsam-killed after the unbounded outbound leaked memory/goroutines/sockets while the client roamed networks.

## What

Bumps `github.com/getlantern/radiance` → `e6267cf` (main), which carries the fix chain down through the module graph:

```
radiance e6267cf
  → lantern-box v0.0.103        (getlantern/lantern-box#288)
    → broflake f2cacf69         (broflake #371, #372, #373)
```

- **broflake#371** — engine teardown no longer leaks the bus observer, routers, UI ticker, or a live `PeerConnection` per connect/disconnect cycle.
- **broflake#372** — context-aware signaling backoff (`sleepOrDone`); a torn-down outbound exits its retry backoff immediately instead of lingering a full `ErrorBackoff` (stacked overlapping FSMs during roaming).
- **broflake#373** — `QUICLayer` initializes `ctx`/`cancel` in its constructor, fixing the `Close()` data race + lost-cancel leak.

Transitive bumps in this PR: `lantern-box v0.0.100 → v0.0.103`, `broflake c4d1516 → f2cacf69`, `common` (radiance requirement).

## Verification

- `go mod tidy` run; `go.mod` + `go.sum` committed together, with the new broflake/lantern-box `h1:`+`/go.mod` hashes present in `go.sum` — so `gomobile bind` resolves the new transitive versions consistently (this is where the 2026-04-13 stale-`go.sum` regression bit us).
- `go build ./lantern-core/...` passes (the package tree that wires radiance: mobile bindings, `vpn_tunnel`, `ffi`, init).

## After merge

`unbounded-linode-free` is still disabled as the interim mitigation. Once a build from this ships, re-enable it on a canary and soak-test the iOS extension footprint under network roaming to confirm the leak is gone before broad re-enable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)