### PR TITLE
Fix: forced re-login on cold start when radiance core not yet ready

### DIFF
--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -16,21 +16,51 @@ class HomeNotifier extends _$HomeNotifier {
   @override
   Future<UserResponseModel> build() async {
     /// Check if user data is stored locally
-    /// If yes, load it first to avoid delay in UI
-    final result = await ref.read(lanternServiceProvider).getUserData();
-    return result.fold(
-      (failure) {
-        appLogger.error(
-          'Error getting user data: ${failure.error}',
-        );
-        throw Exception('Failed to get user data');
-      },
-      (userData) {
+    /// If yes, load it first to avoid delay in UI.
+    ///
+    /// On a cold start the Go core (radiance) is initialized asynchronously and
+    /// may not be ready when this provider first builds. In that window
+    /// getUserData fails with "radiance not initialized"; throwing immediately
+    /// would leave the app looking logged-out and force a manual re-login on
+    /// every launch — worst on high-latency/censored networks where init is
+    /// slow. Retry a bounded number of times so the persisted session is
+    /// restored once the core comes up, instead of failing permanently.
+    Failure? lastFailure;
+    for (var attempt = 0; attempt < _userDataMaxAttempts; attempt++) {
+      final result = await ref.read(lanternServiceProvider).getUserData();
+      final userData = result.fold<UserResponseModel?>(
+        (failure) {
+          lastFailure = failure;
+          return null;
+        },
+        (userData) => userData,
+      );
+      if (userData != null) {
         appLogger.debug('Got the userdata: ${userData.toJson()}');
         _applyUserData(userData);
         return userData;
-      },
-    );
+      }
+      // Only the core-not-ready race is worth waiting on; any other failure is
+      // surfaced immediately with the original behaviour.
+      if (!_isCoreNotReady(lastFailure!)) break;
+      appLogger.info(
+        'User data not available yet (core initializing); '
+        'retrying (${attempt + 1}/$_userDataMaxAttempts)',
+      );
+      await Future<void>.delayed(_userDataRetryDelay);
+    }
+    appLogger.error('Error getting user data: ${lastFailure?.error}');
+    throw Exception('Failed to get user data');
+  }
+
+  static const _userDataMaxAttempts = 10;
+  static const _userDataRetryDelay = Duration(milliseconds: 500);
+
+  /// True when a getUserData failure is the transient "core not initialized"
+  /// startup race rather than a genuine, persistent error.
+  bool _isCoreNotReady(Failure failure) {
+    final err = failure.error.toLowerCase();
+    return err.contains('not initialized') || err.contains('not ready');
   }
 
   /// Fetches the latest user data from the server


### PR DESCRIPTION
## Summary
Auto-fix for Freshdesk ticket [#180375](https://lantern.freshdesk.com/a/tickets/180375).

Chinese Android Pro user on v9.1.15 beta (China Mobile) reports that after upgrading, the app forces a fresh login on **every** launch — the cached session is never restored.

**Root cause:** On cold start, `HomeNotifier.build()` calls `getUserData()` before the asynchronously-started `SetupRadiance` has stored the Go core. `Mobile.userData()` returns `radiance not initialized`, so `build()` throws with no fallback and the persisted logged-in/Pro session is never restored (`checkIfUserProAndDeviceIsAdded` never runs). The stored setting still reads `userLoggedIn: true`, yet the app looks logged-out. Reliably reproduced in China, where GFW-blocked config/auth traffic (`df.iantem.io` reset) widens the init window so the race is lost on every launch. Confirmed against logs: 9.1.9/9.1.11 launches on the same device succeed; the first 9.1.15 launch onward throws `radiance not initialized` at `getUserData`.

**What changed:** `lib/features/home/provider/home_notifier.dart` — `build()` now retries the local `getUserData()` read a bounded number of times (10 x 500ms) **only** while the failure is the transient "core not initialized" race, restoring the session once radiance comes up. Any other failure surfaces immediately with the original throw behaviour, so genuine errors are unchanged.

## Test plan
- [ ] Cold-start 9.1.15 on Android with radiance init artificially delayed (slow/blocked network, e.g. block `df.iantem.io`) — verify the session is restored instead of showing logged-out
- [ ] Verify no added startup delay on the happy path (core already ready -> first attempt succeeds)
- [ ] Confirm genuine getUserData failures still surface (no infinite/masked retry)
- [ ] Check for regressions in `refreshUser` / `fetchUserData` (unchanged, but same provider)

## Notes for reviewer
This is a Dart-side mitigation of a startup ordering race. A more complete fix would have `SetupRadiance` signal readiness so `build()` can `await` it rather than poll; that's a larger change spanning the platform channel and is left for follow-up. See ticket diagnosis for the full call path and the unresolved question of which radiance bump between 9.1.11 and 9.1.13 widened the window.

---
*Auto-generated by `/ticket-autodiagnose` -> `/issue-fix`.*