### PR TITLE
Fix Android user data startup race

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -599,8 +599,9 @@ class MethodHandler : FlutterPlugin,
             }
 
             Methods.WaitForRadiance.method -> {
-                scope.handleResult(result, "wait_for_radiance") {
+                scope.handleValue<Any?>(result, "wait_for_radiance") {
                     LanternVpnService.awaitRadianceReady()
+                    null
                 }
             }
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -23,6 +23,7 @@ import lantern.io.mobile.Mobile
 import org.getlantern.lantern.MainActivity
 import org.getlantern.lantern.apps.AppFilters
 import org.getlantern.lantern.constant.VPNStatus
+import org.getlantern.lantern.service.LanternVpnService
 import org.getlantern.lantern.updater.AndroidSideloadInstaller
 import org.getlantern.lantern.updater.AndroidSideloadUpdateRequest
 import org.getlantern.lantern.utils.AppLogger
@@ -66,6 +67,7 @@ enum class Methods(val method: String) {
     //User data
     GetUserData("getUserData"),
     FetchUserData("fetchUserData"),
+    WaitForRadiance("waitForRadiance"),
 
     //Login
     Login("login"),
@@ -593,6 +595,12 @@ class MethodHandler : FlutterPlugin,
                             e
                         )
                     }
+                }
+            }
+
+            Methods.WaitForRadiance.method -> {
+                scope.handleResult(result, "wait_for_radiance") {
+                    LanternVpnService.awaitRadianceReady()
                 }
             }
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -79,11 +79,23 @@ class LanternVpnService :
         // flag clears when the orphan's coroutine actually completes.
         private val connectInFlight = AtomicBoolean(false)
 
-        private val radianceReady = MutableStateFlow(false)
+        private sealed class RadianceState {
+            data object Initializing : RadianceState()
+            data object Ready : RadianceState()
+            data class Failed(val cause: Throwable) : RadianceState()
+        }
+
+        private val radianceState = MutableStateFlow<RadianceState>(RadianceState.Initializing)
 
         suspend fun awaitRadianceReady() {
             if (Mobile.isRadianceConnected()) return
-            radianceReady.first { it }
+            when (val state = radianceState.first { it !is RadianceState.Initializing }) {
+                RadianceState.Ready -> check(Mobile.isRadianceConnected()) {
+                    "Radiance setup completed but the core is unavailable"
+                }
+                is RadianceState.Failed -> throw state.cause
+                RadianceState.Initializing -> error("Radiance is still initializing")
+            }
         }
 
         lateinit var instance: LanternVpnService
@@ -313,13 +325,23 @@ class LanternVpnService :
     private suspend fun startRadiance() {
         try {
             withContext(Dispatchers.IO) {
-                Mobile.startIPCServer(this@LanternVpnService, opts())
-                Mobile.setupRadiance(opts(), flutterEventListener)
-                radianceReady.value = true
+                setupRadiance()
             }
             AppLogger.d(TAG, "Radiance setup completed")
         } catch (e: Exception) {
             AppLogger.e(TAG, "Error in Radiance setup", e)
+        }
+    }
+
+    private fun setupRadiance() {
+        radianceState.value = RadianceState.Initializing
+        try {
+            Mobile.startIPCServer(this@LanternVpnService, opts())
+            Mobile.setupRadiance(opts(), flutterEventListener)
+            radianceState.value = RadianceState.Ready
+        } catch (e: Exception) {
+            radianceState.value = RadianceState.Failed(e)
+            throw e
         }
     }
 
@@ -364,9 +386,7 @@ class LanternVpnService :
             // to finish before we attempt to start the VPN tunnel.
             if (!Mobile.isRadianceConnected()) {
                 AppLogger.d(TAG, "Radiance not ready, setting up before VPN start")
-                Mobile.startIPCServer(this@LanternVpnService, opts())
-                Mobile.setupRadiance(opts(), flutterEventListener)
-                radianceReady.value = true
+                setupRadiance()
             }
             resetVpnAfterAppUpgradeIfNeeded()
             DefaultNetworkMonitor.setNetworkChangeCallback { updateUnderlyingNetworks() }

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -15,6 +15,8 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
@@ -76,6 +78,13 @@ class LanternVpnService :
         // new connect attempts while a previous one is still in flight. The
         // flag clears when the orphan's coroutine actually completes.
         private val connectInFlight = AtomicBoolean(false)
+
+        private val radianceReady = MutableStateFlow(false)
+
+        suspend fun awaitRadianceReady() {
+            if (Mobile.isRadianceConnected()) return
+            radianceReady.first { it }
+        }
 
         lateinit var instance: LanternVpnService
 
@@ -306,6 +315,7 @@ class LanternVpnService :
             withContext(Dispatchers.IO) {
                 Mobile.startIPCServer(this@LanternVpnService, opts())
                 Mobile.setupRadiance(opts(), flutterEventListener)
+                radianceReady.value = true
             }
             AppLogger.d(TAG, "Radiance setup completed")
         } catch (e: Exception) {
@@ -356,6 +366,7 @@ class LanternVpnService :
                 AppLogger.d(TAG, "Radiance not ready, setting up before VPN start")
                 Mobile.startIPCServer(this@LanternVpnService, opts())
                 Mobile.setupRadiance(opts(), flutterEventListener)
+                radianceReady.value = true
             }
             resetVpnAfterAppUpgradeIfNeeded()
             DefaultNetworkMonitor.setNetworkChangeCallback { updateUnderlyingNetworks() }

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -19,6 +19,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import lantern.io.libbox.Notification
@@ -86,6 +88,7 @@ class LanternVpnService :
         }
 
         private val radianceState = MutableStateFlow<RadianceState>(RadianceState.Initializing)
+        private val radianceSetupMutex = Mutex()
 
         suspend fun awaitRadianceReady() {
             if (Mobile.isRadianceConnected()) return
@@ -333,15 +336,22 @@ class LanternVpnService :
         }
     }
 
-    private fun setupRadiance() {
-        radianceState.value = RadianceState.Initializing
-        try {
-            Mobile.startIPCServer(this@LanternVpnService, opts())
-            Mobile.setupRadiance(opts(), flutterEventListener)
-            radianceState.value = RadianceState.Ready
-        } catch (e: Exception) {
-            radianceState.value = RadianceState.Failed(e)
-            throw e
+    private suspend fun setupRadiance() {
+        radianceSetupMutex.withLock {
+            if (Mobile.isRadianceConnected()) {
+                radianceState.value = RadianceState.Ready
+                return@withLock
+            }
+
+            radianceState.value = RadianceState.Initializing
+            try {
+                Mobile.startIPCServer(this@LanternVpnService, opts())
+                Mobile.setupRadiance(opts(), flutterEventListener)
+                radianceState.value = RadianceState.Ready
+            } catch (e: Exception) {
+                radianceState.value = RadianceState.Failed(e)
+                throw e
+            }
         }
     }
 

--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -17,7 +17,9 @@ class HomeNotifier extends _$HomeNotifier {
   Future<UserResponseModel> build() async {
     /// Check if user data is stored locally
     /// If yes, load it first to avoid delay in UI
-    final result = await ref.read(lanternServiceProvider).getUserData();
+    final service = ref.read(lanternServiceProvider);
+    await service.waitForRadiance();
+    final result = await service.getUserData();
     return result.fold(
       (failure) {
         appLogger.error(

--- a/lib/lantern/lantern_platform_service.dart
+++ b/lib/lantern/lantern_platform_service.dart
@@ -94,6 +94,10 @@ class LanternPlatformService implements LanternCoreService {
     return _appEventStatus;
   }
 
+  Future<void> waitForRadiance() async {
+    await _methodChannel.invokeMethod<void>('waitForRadiance');
+  }
+
   @override
   Future<Either<Failure, Unit>> updateLocal(String locale) async {
     try {

--- a/lib/lantern/lantern_service.dart
+++ b/lib/lantern/lantern_service.dart
@@ -42,6 +42,13 @@ class LanternService implements LanternCoreService {
     return _platformService.init();
   }
 
+  Future<void> waitForRadiance() {
+    if (PlatformUtils.isAndroid) {
+      return _platformService.waitForRadiance();
+    }
+    return Future.value();
+  }
+
   @override
   Future<Either<Failure, String>> startVPN() async {
     if (PlatformUtils.isFFISupported) {

--- a/test/features/home/provider/home_notifier_test.dart
+++ b/test/features/home/provider/home_notifier_test.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/models/app_setting.dart';
+import 'package:lantern/core/models/user.dart';
+import 'package:lantern/core/utils/failure.dart';
+import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/features/home/provider/home_notifier.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
+
+const _user = UserResponseModel(
+  legacyID: 1,
+  legacyToken: 'token',
+  emailConfirmed: true,
+  success: true,
+  legacyUserData: UserDataModel(userLevel: 'pro'),
+);
+
+class _FakeLanternService implements LanternService {
+  final ready = Completer<void>();
+  int getUserDataCalls = 0;
+
+  @override
+  Future<void> waitForRadiance() => ready.future;
+
+  @override
+  Future<Either<Failure, UserResponseModel>> getUserData() async {
+    getUserDataCalls += 1;
+    return right(_user);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  test('waits for Radiance before loading user data', () async {
+    final service = _FakeLanternService();
+    final container = ProviderContainer(
+      overrides: [
+        lanternServiceProvider.overrideWithValue(service),
+        appSettingProvider.overrideWithValue(
+          const AppSetting(userLoggedIn: true),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final user = container.read(homeProvider.future);
+    await Future<void>.delayed(Duration.zero);
+
+    expect(service.getUserDataCalls, 0);
+
+    service.ready.complete();
+
+    expect(await user, _user);
+    expect(service.getUserDataCalls, 1);
+  });
+}

--- a/test/features/home/provider/home_notifier_test.dart
+++ b/test/features/home/provider/home_notifier_test.dart
@@ -21,10 +21,16 @@ const _user = UserResponseModel(
 
 class _FakeLanternService implements LanternService {
   final ready = Completer<void>();
+  final waitStarted = Completer<void>();
+  int waitForRadianceCalls = 0;
   int getUserDataCalls = 0;
 
   @override
-  Future<void> waitForRadiance() => ready.future;
+  Future<void> waitForRadiance() {
+    waitForRadianceCalls += 1;
+    waitStarted.complete();
+    return ready.future;
+  }
 
   @override
   Future<Either<Failure, UserResponseModel>> getUserData() async {
@@ -50,8 +56,9 @@ void main() {
     addTearDown(container.dispose);
 
     final user = container.read(homeProvider.future);
-    await Future<void>.delayed(Duration.zero);
+    await service.waitStarted.future;
 
+    expect(service.waitForRadianceCalls, 1);
     expect(service.getUserDataCalls, 0);
 
     service.ready.complete();


### PR DESCRIPTION
Wait for Radiance initialization before loading user data on Android, preventing a temporary radiance not initialized error from leaving the app in an incorrect logged-out state.

Adds a regression test covering the startup ordering.

Resolves https://github.com/getlantern/engineering/issues/3716

Using a readiness handshake keeps responsibilities cleaner:
- Native Android owns and reports Radiance readiness
- Flutter owns when and why it loads user data
- Existing user-data error handling and state updates remain unchanged
- Other Radiance-dependent startup calls can reuse the same boundary later

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Radiance readiness synchronization via a new `waitForRadiance()` call across the platform layer.
  * Introduced a native readiness mechanism that reports when Radiance is ready (or failed) and exposes an awaitable hook to Flutter.

* **Bug Fixes**
  * Prevented cached user data from loading before Radiance is ready, improving startup reliability (including pre-tunnel flow).

* **Tests**
  * Added a unit test verifying user data is requested only after Radiance readiness is signaled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->