### PR TITLE
Bump radiance for X-Lantern-Fronted-Via provider labeling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260717225005-03be39750a10
+	github.com/getlantern/radiance v0.0.0-20260720195017-810b71e9b994
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -168,9 +168,9 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
-	github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b // indirect
+	github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
-	github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c // indirect
+	github.com/getlantern/kindling v0.0.0-20260720193730-b9d35ab1ec50 // indirect
 	github.com/getlantern/lantern-box v0.0.104 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b h1:cM+Cwgg6EN279knxvHc4vd3MyNOpZk/49TLlg2F78Rk=
-github.com/getlantern/domainfront v0.0.0-20260625001429-518c0256669b/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5 h1:vIXvimju0LD59F/M2OTDs2j/2F0sUgXVaFPzbna7+mE=
+github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -243,8 +243,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c h1:F4/LE+5zehr6AUfuJBab3iubscOOTdFZxwYldIpLgg8=
-github.com/getlantern/kindling v0.0.0-20260625002640-7cdf7184420c/go.mod h1:rN6O8pIQ9nc7Gyvtf2GGSjiWEFIApGsRCHkgYz0h3Ak=
+github.com/getlantern/kindling v0.0.0-20260720193730-b9d35ab1ec50 h1:6Vvti1Enp+EUAa2UIFX4hn5uUMt+pu2GdQOE9gkZLWo=
+github.com/getlantern/kindling v0.0.0-20260720193730-b9d35ab1ec50/go.mod h1:Ew7czk3me7/WoL/3ww1gkxcQwQGefXqC8mzuwc3b/iI=
 github.com/getlantern/lantern-box v0.0.104 h1:ASLpYelmYUnY/bgDXH+UKiIex1Pme/Zg9YtDY6qQThk=
 github.com/getlantern/lantern-box v0.0.104/go.mod h1:xrH8ZziXLy1pYN94cfHenczjVwUVcuuUzJWb9lY8duw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260717225005-03be39750a10 h1:GjpOIGKexGc98B+W3pywzHkc5BNZomIB+tSLaQ8OOJk=
-github.com/getlantern/radiance v0.0.0-20260717225005-03be39750a10/go.mod h1:jj5IxRX6dge1FKfzbKp/fjcfuGQlQYMY7FwRKxwug+E=
+github.com/getlantern/radiance v0.0.0-20260720195017-810b71e9b994 h1:K6iM49ZhTTLkk5t2ffAvxaDO926MUXweTD6fnls1DW0=
+github.com/getlantern/radiance v0.0.0-20260720195017-810b71e9b994/go.mod h1:l7huAfBj4yY9YPF7wM7YxPSDiuc0/WHeTktJKa4rsQw=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Final client hop for fronting-provider labeling. Bumps:

- `github.com/getlantern/radiance` → `v0.0.0-20260720195017-810b71e9b994` ([radiance#570](https://github.com/getlantern/radiance/pull/570))
- `github.com/getlantern/kindling` → `v0.0.0-20260720193730-b9d35ab1ec50` (indirect, [kindling#42](https://github.com/getlantern/kindling/pull/42))
- `github.com/getlantern/domainfront` → `v0.0.0-20260720182103-06118b2faed5` (indirect, [domainfront#14](https://github.com/getlantern/domainfront/pull/14))

With these, fronted config-fetch requests carry `X-Lantern-Fronted-Via` = the selected front's `ProviderID`, so the origin (lantern-cloud) attributes fronted traffic **per provider** (akamai / cloudfront / aliyun) instead of bucketing non-Akamai fronts as `direct` in SigNoz. Server-side mapping is already merged: lantern-cloud [#3002](https://github.com/getlantern/lantern-cloud/pull/3002) (`aliyun`) + [#3004](https://github.com/getlantern/lantern-cloud/pull/3004) (`domainfront` catch-all).

`go get …@main` + `go mod tidy` — go.mod/go.sum only; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal networking components to newer versions.
  * Refreshed related supporting components to maintain compatibility and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->