### PR TITLE
Fix: account unreachable after 9.1.15 update (radiance startup race)

### DIFF
--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -15,21 +15,39 @@ part 'home_notifier.g.dart';
 class HomeNotifier extends _$HomeNotifier {
   @override
   Future<UserResponseModel> build() async {
-    /// Check if user data is stored locally
-    /// If yes, load it first to avoid delay in UI
-    final result = await ref.read(lanternServiceProvider).getUserData();
-    return result.fold(
-      (failure) {
-        appLogger.error(
-          'Error getting user data: ${failure.error}',
-        );
-        throw Exception('Failed to get user data');
-      },
-      (userData) {
-        appLogger.debug('Got the userdata: ${userData.toJson()}');
-        _applyUserData(userData);
-        return userData;
-      },
+    /// Check if user data is stored locally and load it.
+    ///
+    /// On a cold start the Go core (radiance) is set up asynchronously and may
+    /// not be ready when this keepAlive provider first builds, in which case
+    /// getUserData() fails with "radiance not initialized". Retry with a short
+    /// backoff so the account loads once the core finishes starting, instead of
+    /// caching the transient startup failure for the rest of the session.
+    const maxAttempts = 10;
+    const retryDelay = Duration(seconds: 1);
+    Failure? lastFailure;
+    for (var attempt = 1; attempt <= maxAttempts; attempt++) {
+      final result = await ref.read(lanternServiceProvider).getUserData();
+      final userData = result.fold<UserResponseModel?>(
+        (failure) {
+          lastFailure = failure;
+          appLogger.error(
+            'Error getting user data '
+            '(attempt $attempt/$maxAttempts): ${failure.error}',
+          );
+          return null;
+        },
+        (userData) {
+          appLogger.debug('Got the userdata: ${userData.toJson()}');
+          _applyUserData(userData);
+          return userData;
+        },
+      );
+      if (userData != null) return userData;
+      if (attempt < maxAttempts) await Future<void>.delayed(retryDelay);
+    }
+    throw Exception(
+      'Failed to get user data after $maxAttempts attempts: '
+      '${lastFailure?.error}',
     );
   }
 


### PR DESCRIPTION
## Summary
Auto-fix for Freshdesk ticket [#180332](https://lantern.freshdesk.com/a/tickets/180332) — Pro Android users report "更新以后登录不了" (can't log in after updating) on client 9.1.15.

**Root cause:** `HomeNotifier.build()` (`lib/features/home/provider/home_notifier.dart`) fetched user data exactly once at cold start. On Android, the Go core (radiance) is set up asynchronously (`SetupRadiance` completes ~4–7s after launch) while the Flutter MethodChannel is live immediately. When `getUserData()` lands before `lanternCore.Store`, it returns `radiance not initialized`; the `keepAlive` provider caches that failure with no retry, so `user` stays null and every account tap shows "Unable to open account" for the whole session. The 9.1.15 radiance dependency bump made `SetupRadiance` deterministically finish after `build()`, turning a previously-winnable race into a 0/4 failure.

**What changed:** `build()` now retries `getUserData()` with a bounded backoff (up to 10 attempts, 1s apart) instead of throwing on the first failure. The provider stays in loading during the radiance-setup window and resolves once the core is ready; if it genuinely never succeeds it still throws after attempts are exhausted. Single-file, ~25 lines.

## Test plan
- [ ] Cold-start 9.1.15 on Android and confirm the account loads without a restart (force SetupRadiance to lose the race).
- [ ] Confirm the initial getUserData failure is followed by a later successful load.
- [ ] Check the normal (radiance-ready) path has no added delay.

## Follow-up (out of scope)
Cleaner long-term fix: invalidate homeProvider / call refreshUser() on a radiance-ready event. Left as follow-up per the diagnosis Unresolved notes.

---
*Auto-generated by `/ticket-autodiagnose` -> `/issue-fix`. Draft — needs human review + a build/analyze run before merge.*
