### PR TITLE
Bump radiance to pick up resilient front-retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260721113201-75b288b7d3ad
+	github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -168,9 +168,9 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
-	github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5 // indirect
+	github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
-	github.com/getlantern/kindling v0.0.0-20260720193730-b9d35ab1ec50 // indirect
+	github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad // indirect
 	github.com/getlantern/lantern-box v0.0.104 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5 h1:vIXvimju0LD59F/M2OTDs2j/2F0sUgXVaFPzbna7+mE=
-github.com/getlantern/domainfront v0.0.0-20260720182103-06118b2faed5/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 h1:/XB/H1/nRXANtAybB5NjRDjYMfZwR9X0Qs7eGSUGTK4=
+github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -243,8 +243,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260720193730-b9d35ab1ec50 h1:6Vvti1Enp+EUAa2UIFX4hn5uUMt+pu2GdQOE9gkZLWo=
-github.com/getlantern/kindling v0.0.0-20260720193730-b9d35ab1ec50/go.mod h1:Ew7czk3me7/WoL/3ww1gkxcQwQGefXqC8mzuwc3b/iI=
+github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad h1:FIWHYn9KnKVkgXGw3hXZ9tNzf0EzN3sY0FAbijIMNHo=
+github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad/go.mod h1:ECYSHrCeB9dVMhTHFnyoRAT/WDuEOgqy3suMVqPN4Ag=
 github.com/getlantern/lantern-box v0.0.104 h1:ASLpYelmYUnY/bgDXH+UKiIex1Pme/Zg9YtDY6qQThk=
 github.com/getlantern/lantern-box v0.0.104/go.mod h1:xrH8ZziXLy1pYN94cfHenczjVwUVcuuUzJWb9lY8duw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
@@ -259,10 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260720195017-810b71e9b994 h1:K6iM49ZhTTLkk5t2ffAvxaDO926MUXweTD6fnls1DW0=
-github.com/getlantern/radiance v0.0.0-20260720195017-810b71e9b994/go.mod h1:l7huAfBj4yY9YPF7wM7YxPSDiuc0/WHeTktJKa4rsQw=
-github.com/getlantern/radiance v0.0.0-20260721113201-75b288b7d3ad h1:dvdVYCkHnyfsxYRGk5w5REKXHmhnjr555lXTs53zAq0=
-github.com/getlantern/radiance v0.0.0-20260721113201-75b288b7d3ad/go.mod h1:l7huAfBj4yY9YPF7wM7YxPSDiuc0/WHeTktJKa4rsQw=
+github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4 h1:weUlEVCJFwhAZtHjEyohgAjTd329ifpQIkO7BBaF9Kk=
+github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4/go.mod h1:T7eJdawusvUiXuOF2QoqvhlmPRvcH4dSc8UNNYlC9yE=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Bumps `radiance` → `d7290e5`, carrying the domainfront **resilient front-retry** work into the client. `domainfront` (→ `db7c158`) and `kindling` (→ `ef87ee2`) move with it as indirect deps.

## Why

This is the last hop of the chain [domainfront#15](https://github.com/getlantern/domainfront/pull/15) → [kindling#43](https://github.com/getlantern/kindling/pull/43) → [radiance#571](https://github.com/getlantern/radiance/pull/571) → **here**.

It targets the "config fetch completely fails" reports from China/Iran, where `domainfront` connects (and even vets) hundreds of times but the fronted request never reaches the origin — a provider (e.g. an Aliyun edge behind the GFW) that accepts the TLS handshake but then answers `403`/`5xx` or silently drops the request.

After this bump, fronted config fetches:
- **retry on retryable error responses** (default `403` or `>= 500`) instead of accepting the bad response, and
- **prefer a different fronting provider on retry**, so a ready queue dominated by the misbehaving-but-vetting provider doesn't trap the retries.

## This PR

go.mod / go.sum only — no lantern code changes (the new behavior is automatic; the only new domainfront API is opt-in). Ran `go mod tidy`; `go build ./...` passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated underlying components to newer versions.
  * Included maintenance updates for supporting components without changing user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->