### PR TITLE
Bump radiance for non-blocking fronted-config startup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4
+	github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -168,7 +168,7 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
-	github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 // indirect
+	github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad // indirect
 	github.com/getlantern/lantern-box v0.0.104 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 h1:/XB/H1/nRXANtAybB5NjRDjYMfZwR9X0Qs7eGSUGTK4=
-github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 h1:2Fiu74ER24v0JeSVA32A5NriP8xQ8RyaNrUpE5AV84s=
+github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4 h1:weUlEVCJFwhAZtHjEyohgAjTd329ifpQIkO7BBaF9Kk=
-github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4/go.mod h1:T7eJdawusvUiXuOF2QoqvhlmPRvcH4dSc8UNNYlC9yE=
+github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49 h1:uZUjmGk++OW57a+N3MqSPDmr0XswTTJHUwIbw72zVmQ=
+github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49/go.mod h1:euYiMzxGRGUCMV4lDHZ6sHhgLSL/MMsMhCDHXIrL8do=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Bumps `radiance` → `b72b27d`, carrying the fronted-config init fix into the client. `domainfront` (→ `2862f7a`) moves with it as an indirect dep.

## Why

This is the last hop of the chain [domainfront#16](https://github.com/getlantern/domainfront/pull/16) → [radiance#573](https://github.com/getlantern/radiance/pull/573) → **here**.

radiance previously fetched the fronting config (`fronted.yaml.gz`) from `raw.githubusercontent.com` **synchronously on the init critical path** with a 30s timeout. That host is blocked in China, so every cold start there burned the full 30s before falling back to cached/embedded config — stalling radiance init, which (with the Android startup race, symptom-fixed in #8915) left Pro users shown as logged-out.

After this bump, domainfront owns the config lifecycle: it fetches `configURL` **off the critical path**, **persists** each fetched config, and **bootstraps** from the persisted copy on the next start (preferring it over the embedded seed). Startup does **no blocking network I/O**.

## This PR

go.mod / go.sum only — no lantern code changes. Ran `go mod tidy`; `go build ./...` passes.

## Follow-up (not blocking)

This makes startup resilient and preserves the last-good config across restarts, but doesn't make the fetch *succeed* in China (raw.githubusercontent.com blocked; jsDelivr bans the getlantern org). getlantern/engineering#3721 tracks a China-reachable config mirror.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal libraries to newer versions.
  * No user-facing features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->