### PR TITLE
Provide a writable WebView2 user-data folder on Windows

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,10 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/alexflint/go-arg v1.6.1 h1:uZogJ6VDBjcuosydKgvYYRhh9sRCusjOvoOLZopBlnA=
+github.com/alexflint/go-arg v1.6.1/go.mod h1:nQ0LFYftLJ6njcaee0sU+G0iS2+2XJQfA8I062D0LGc=
+github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
+github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/alitto/pond v1.9.2 h1:9Qb75z/scEZVCoSU+osVmQ0I0JOeLfdTDafrbcJ8CLs=
 github.com/alitto/pond v1.9.2/go.mod h1:xQn3P/sHTYcU/1BR3i86IGIrilcrGC2LiS+E2+CJWsI=
 github.com/anacrolix/btree v0.0.0-20251201064447-d86c3fa41bd8 h1:c02PsmoaChabVqAFm7pqPI1UIkDdDAjUaWa6ZmfxybQ=

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
-github.com/alexflint/go-arg v1.6.1 h1:uZogJ6VDBjcuosydKgvYYRhh9sRCusjOvoOLZopBlnA=
-github.com/alexflint/go-arg v1.6.1/go.mod h1:nQ0LFYftLJ6njcaee0sU+G0iS2+2XJQfA8I062D0LGc=
-github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
-github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/alitto/pond v1.9.2 h1:9Qb75z/scEZVCoSU+osVmQ0I0JOeLfdTDafrbcJ8CLs=
 github.com/alitto/pond v1.9.2/go.mod h1:xQn3P/sHTYcU/1BR3i86IGIrilcrGC2LiS+E2+CJWsI=
 github.com/anacrolix/btree v0.0.0-20251201064447-d86c3fa41bd8 h1:c02PsmoaChabVqAFm7pqPI1UIkDdDAjUaWa6ZmfxybQ=

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -39,6 +39,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // running Lantern instances before launch; handing off here could silently
   // keep a pre-single-instance build alive.
 
+  // Ensure WebView2 uses a writable per-user data folder before the engine
+  // (and any WebView2-backed plugin) starts. Otherwise production installs
+  // under Program Files can't initialize WebView2 and in-app webviews go blank.
+  EnsureWebView2UserDataFolder();
+
   // Initialize COM, so that it is available for use in the library and/or
   // plugins.
   ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -36,13 +36,13 @@ void EnsureWebView2UserDataFolder() {
     return;
   }
 
-  // If a referenced variable (e.g. %LOCALAPPDATA%) is undefined, it is left
-  // literally in the output. Don't proceed with an unexpanded path — that would
-  // create a garbage relative folder and point WebView2 at an unusable value.
-  for (const wchar_t* p = path; *p != L'\0'; ++p) {
-    if (*p == L'%') {
-      return;
-    }
+  // If %LOCALAPPDATA% is undefined, ExpandEnvironmentStringsW leaves the
+  // template literal, so the result starts with '%'; a real expanded path
+  // starts with a drive letter. Only the leading char is a reliable signal —
+  // '%' is legal elsewhere in a folder name — so don't reject those. Bail on an
+  // unexpanded path rather than create a garbage relative folder.
+  if (path[0] == L'%') {
+    return;
   }
 
   // Create each directory component in turn; CreateDirectoryW only creates the

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -36,6 +36,15 @@ void EnsureWebView2UserDataFolder() {
     return;
   }
 
+  // If a referenced variable (e.g. %LOCALAPPDATA%) is undefined, it is left
+  // literally in the output. Don't proceed with an unexpanded path — that would
+  // create a garbage relative folder and point WebView2 at an unusable value.
+  for (const wchar_t* p = path; *p != L'\0'; ++p) {
+    if (*p == L'%') {
+      return;
+    }
+  }
+
   // Create each directory component in turn; CreateDirectoryW only creates the
   // final segment, so intermediate parents must be created first.
   for (wchar_t* cursor = path; *cursor != L'\0'; ++cursor) {
@@ -46,6 +55,15 @@ void EnsureWebView2UserDataFolder() {
     }
   }
   ::CreateDirectoryW(path, nullptr);
+
+  // Only advertise the folder if it now exists as a directory: CreateDirectoryW
+  // may have failed (permissions, invalid path), and pointing WebView2 at a
+  // nonexistent folder just moves the failure somewhere harder to diagnose. If
+  // we couldn't create it, leave WebView2 to its default.
+  DWORD attrs = ::GetFileAttributesW(path);
+  if (attrs == INVALID_FILE_ATTRIBUTES || !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+    return;
+  }
 
   ::SetEnvironmentVariableW(L"WEBVIEW2_USER_DATA_FOLDER", path);
 }

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -21,6 +21,35 @@ void CreateAndAttachConsole() {
   }
 }
 
+void EnsureWebView2UserDataFolder() {
+  // Respect an existing value (e.g. a machine-level override or a debug
+  // configuration) rather than clobbering it.
+  if (::GetEnvironmentVariableW(L"WEBVIEW2_USER_DATA_FOLDER", nullptr, 0) > 0) {
+    return;
+  }
+
+  const wchar_t kUnexpanded[] = L"%LOCALAPPDATA%\\Lantern\\WebView2";
+  wchar_t path[MAX_PATH];
+  DWORD length =
+      ::ExpandEnvironmentStringsW(kUnexpanded, path, ARRAYSIZE(path));
+  if (length == 0 || length > ARRAYSIZE(path)) {
+    return;
+  }
+
+  // Create each directory component in turn; CreateDirectoryW only creates the
+  // final segment, so intermediate parents must be created first.
+  for (wchar_t* cursor = path; *cursor != L'\0'; ++cursor) {
+    if (*cursor == L'\\' && cursor != path && *(cursor - 1) != L':') {
+      *cursor = L'\0';
+      ::CreateDirectoryW(path, nullptr);
+      *cursor = L'\\';
+    }
+  }
+  ::CreateDirectoryW(path, nullptr);
+
+  ::SetEnvironmentVariableW(L"WEBVIEW2_USER_DATA_FOLDER", path);
+}
+
 std::vector<std::string> GetCommandLineArguments() {
   // Convert the UTF-16 command line arguments to UTF-8 for the Engine to use.
   int argc;

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -22,9 +22,15 @@ void CreateAndAttachConsole() {
 }
 
 void EnsureWebView2UserDataFolder() {
-  // Respect an existing value (e.g. a machine-level override or a debug
-  // configuration) rather than clobbering it.
-  if (::GetEnvironmentVariableW(L"WEBVIEW2_USER_DATA_FOLDER", nullptr, 0) > 0) {
+  // Respect an existing non-empty override (machine-level or debug config)
+  // rather than clobbering it. Read into a buffer instead of probing with a
+  // null one: the size probe can't tell "unset" from "set but empty", and an
+  // empty value isn't a meaningful override. GetEnvironmentVariableW returns the
+  // number of chars written — 0 when unset or empty, or the required size when
+  // an override is too long to fit (still counts as present).
+  wchar_t existing[MAX_PATH];
+  if (::GetEnvironmentVariableW(L"WEBVIEW2_USER_DATA_FOLDER", existing,
+                                ARRAYSIZE(existing)) > 0) {
     return;
   }
 

--- a/windows/runner/utils.h
+++ b/windows/runner/utils.h
@@ -8,6 +8,15 @@
 // it for both the runner and the Flutter library.
 void CreateAndAttachConsole();
 
+// Points WebView2 at a writable per-user data folder by setting the
+// WEBVIEW2_USER_DATA_FOLDER environment variable (creating the folder if
+// needed). Without this, production builds installed under Program Files
+// default their WebView2 data folder next to the read-only executable, so
+// WebView2 fails to initialize and in-app webviews (e.g. payment flows) stay
+// blank. Must be called before any WebView2 environment is created. Existing
+// values of the variable are left untouched so machine-level overrides win.
+void EnsureWebView2UserDataFolder();
+
 // Takes a null-terminated wchar_t* encoded in UTF-16 and returns a std::string
 // encoded in UTF-8. Returns an empty std::string on failure.
 std::string Utf8FromUtf16(const wchar_t* utf16_string);


### PR DESCRIPTION
## Problem

On Windows production installs (under `Program Files`), WebView2 defaults its user-data folder next to the read-only executable. It can't create that folder, so WebView2 fails to initialize and **in-app webviews render blank** (e.g. payment/checkout flows).

## Fix

`EnsureWebView2UserDataFolder()` (new, in `windows/runner/utils.cpp`) sets `WEBVIEW2_USER_DATA_FOLDER` to a writable per-user location — `%LOCALAPPDATA%\Lantern\WebView2` — creating the directory tree if needed, and is called from `wWinMain` **before** the Flutter engine (and any WebView2-backed plugin) starts.

- Idempotent / respectful: if `WEBVIEW2_USER_DATA_FOLDER` is already set (machine-level override or debug config), it's left untouched.
- Creates intermediate parents (CreateDirectoryW only makes the final segment).

## Also

Dropped `go-arg`/`go-scalar` from `go.sum` — they were added with no corresponding `go.mod` require and nothing imports them, so `go mod tidy` removes them. Orphaned `go.sum` entries can make gomobile resolve stale transitive deps, so keeping `go.sum` consistent with `go.mod` matters for the release build.

## Testing

`go build ./...` passes. The C++ change affects only the Windows runner; it needs a Windows install-under-`Program Files` smoke test to confirm in-app webviews render (can't be exercised by Go CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebView2 startup reliability on Windows, especially for installations in restricted locations.
  * WebView2 now uses a writable per-user data folder (creating it when necessary) while preserving any pre-existing environment configuration overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->