### PR TITLE
Stabilize macOS connect smoke preflight

### DIFF
--- a/.github/scripts/macos_smoke_suite.sh
+++ b/.github/scripts/macos_smoke_suite.sh
@@ -231,13 +231,38 @@ wait_for_packet_tunnel_exit() {
   return 1
 }
 
+run_with_timeout() {
+  local timeout_seconds="$1"
+  shift
+
+  "$@" &
+  local command_pid=$!
+  local deadline=$((SECONDS + timeout_seconds))
+
+  while kill -0 "$command_pid" 2>/dev/null; do
+    if ((SECONDS >= deadline)); then
+      kill -TERM "$command_pid" 2>/dev/null || true
+      sleep 2
+      kill -KILL "$command_pid" 2>/dev/null || true
+      wait "$command_pid" 2>/dev/null || true
+      return 124
+    fi
+    sleep 1
+  done
+
+  local exit_code=0
+  wait "$command_pid" || exit_code=$?
+  return "$exit_code"
+}
+
 run_system_extension_preflight() {
   local app_executable="$1"
   local output="$ARTIFACT_DIR/system-extension-preflight.jsonl"
+  local process_timeout=$((EXTENSION_TIMEOUT_SECONDS + 10))
 
   log_step "Running macOS system extension preflight"
   set +e
-  "$app_executable" \
+  run_with_timeout "$process_timeout" "$app_executable" \
     --smoke-activate-system-extension \
     --timeout-seconds "$EXTENSION_TIMEOUT_SECONDS" \
     >"$output" 2>&1

--- a/.github/scripts/macos_smoke_suite.sh
+++ b/.github/scripts/macos_smoke_suite.sh
@@ -11,6 +11,12 @@ APP_INSTALL_DIR="${APP_INSTALL_DIR:-/Applications/Lantern.app}"
 LANTERN_LOG_DIR="${LANTERN_LOG_DIR:-/Users/Shared/Lantern/Logs}"
 DMG_MOUNT_DIR=""
 
+if ! [[ "$EXTENSION_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]]; then
+  printf 'EXTENSION_TIMEOUT_SECONDS must be a positive integer, got %q.\n' \
+    "$EXTENSION_TIMEOUT_SECONDS" >&2
+  exit 2
+fi
+
 log_step() {
   printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*" >&2
 }
@@ -243,7 +249,9 @@ run_with_timeout() {
     if ((SECONDS >= deadline)); then
       kill -TERM "$command_pid" 2>/dev/null || true
       sleep 2
-      kill -KILL "$command_pid" 2>/dev/null || true
+      if kill -0 "$command_pid" 2>/dev/null; then
+        kill -KILL "$command_pid" 2>/dev/null || true
+      fi
       wait "$command_pid" 2>/dev/null || true
       return 124
     fi
@@ -281,7 +289,8 @@ run_system_extension_preflight() {
       printf 'System extension activation requires a reboot before this smoke test can connect.\n' >&2
       ;;
     124)
-      printf 'System extension preflight timed out after %s seconds.\n' "$EXTENSION_TIMEOUT_SECONDS" >&2
+      printf 'System extension preflight exceeded the %s-second wrapper deadline (activation timeout: %s seconds), followed by a 2-second termination grace period.\n' \
+        "$process_timeout" "$EXTENSION_TIMEOUT_SECONDS" >&2
       ;;
     *)
       printf 'System extension preflight failed with exit code %s.\n' "$exit_code" >&2

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -128,7 +128,7 @@ jobs:
       build_type: nightly
       installer_base_name: ${{ needs.prepare.outputs.installer_base_name }}
       runner_label: lantern-macos-smoke
-      run_connect_smoke: ${{ inputs.macos_connect_smoke }}
+      run_connect_smoke: true
       enable_ip_check: ${{ inputs.enable_ip_check }}
       force_full_tunnel_smoke: ${{ inputs.force_full_tunnel_smoke }}
 

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -128,7 +128,7 @@ jobs:
       build_type: nightly
       installer_base_name: ${{ needs.prepare.outputs.installer_base_name }}
       runner_label: lantern-macos-smoke
-      run_connect_smoke: true
+      run_connect_smoke: ${{ inputs.macos_connect_smoke }}
       enable_ip_check: ${{ inputs.enable_ip_check }}
       force_full_tunnel_smoke: ${{ inputs.force_full_tunnel_smoke }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         default: "linux"
+      use_self_hosted_macos:
+        description: "Build macOS on the persistent EC2 runner"
+        required: false
+        type: boolean
+        default: false
       sign_windows:
         description: "Sign Windows binaries (nightly skips signing by default)"
         required: false
@@ -374,6 +379,7 @@ jobs:
       version: ${{ needs.set-metadata.outputs.version }}
       build_type: ${{ needs.set-metadata.outputs.build_type }}
       installer_base_name: ${{ needs.set-metadata.outputs.installer_base_name }}
+      runner_label: ${{ github.event_name == 'workflow_dispatch' && inputs.use_self_hosted_macos && 'lantern-macos-smoke' || 'macos-15' }}
 
   build-windows:
     needs: [set-metadata, release-create, release-approval]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -379,7 +379,7 @@ jobs:
       version: ${{ needs.set-metadata.outputs.version }}
       build_type: ${{ needs.set-metadata.outputs.build_type }}
       installer_base_name: ${{ needs.set-metadata.outputs.installer_base_name }}
-      runner_label: ${{ github.event_name == 'workflow_dispatch' && inputs.use_self_hosted_macos && 'lantern-macos-smoke' || 'macos-15' }}
+      runner_label: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.use_self_hosted_macos == 'true' && 'lantern-macos-smoke' || 'macos-15' }}
 
   build-windows:
     needs: [set-metadata, release-create, release-approval]

--- a/macos/Runner/VPN/VPNManager.swift
+++ b/macos/Runner/VPN/VPNManager.swift
@@ -159,7 +159,7 @@ class VPNManager: VPNBase {
   }
 
   func connectToServer(
-    serverName: String,
+    serverName: String
   ) async throws {
     await self.setupVPN()
     let options: [String: NSObject] = [


### PR DESCRIPTION
Adds a hard timeout around System Extension activation so macOS smoke runs cannot hang indefinitely, and fixes Swift syntax compatibility with the self-hosted runner’s Xcode 16.2 toolchain

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option for manually triggered releases to build macOS packages on a designated self-hosted runner.

- **Bug Fixes**
  - Improved macOS smoke-test timeout handling with validation, enforced deadlines, and clearer timeout reporting.

- **Maintenance**
  - Simplified a macOS VPN manager method declaration without changing its behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->