### PR TITLE
Fix referral reward UI edge cases

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -23,6 +23,7 @@ import lantern.io.mobile.Mobile
 import org.getlantern.lantern.MainActivity
 import org.getlantern.lantern.apps.AppFilters
 import org.getlantern.lantern.constant.VPNStatus
+import org.getlantern.lantern.service.LanternVpnService
 import org.getlantern.lantern.updater.AndroidSideloadInstaller
 import org.getlantern.lantern.updater.AndroidSideloadUpdateRequest
 import org.getlantern.lantern.utils.AppLogger
@@ -66,6 +67,7 @@ enum class Methods(val method: String) {
     //User data
     GetUserData("getUserData"),
     FetchUserData("fetchUserData"),
+    WaitForRadiance("waitForRadiance"),
 
     //Login
     Login("login"),
@@ -597,6 +599,13 @@ class MethodHandler : FlutterPlugin,
                             e
                         )
                     }
+                }
+            }
+
+            Methods.WaitForRadiance.method -> {
+                scope.handleValue<Any?>(result, "wait_for_radiance") {
+                    LanternVpnService.awaitRadianceReady()
+                    null
                 }
             }
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -15,8 +15,12 @@ import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.withTimeout
 import lantern.io.libbox.Notification
@@ -76,6 +80,26 @@ class LanternVpnService :
         // new connect attempts while a previous one is still in flight. The
         // flag clears when the orphan's coroutine actually completes.
         private val connectInFlight = AtomicBoolean(false)
+
+        private sealed class RadianceState {
+            data object Initializing : RadianceState()
+            data object Ready : RadianceState()
+            data class Failed(val cause: Throwable) : RadianceState()
+        }
+
+        private val radianceState = MutableStateFlow<RadianceState>(RadianceState.Initializing)
+        private val radianceSetupMutex = Mutex()
+
+        suspend fun awaitRadianceReady() {
+            if (Mobile.isRadianceConnected()) return
+            when (val state = radianceState.first { it !is RadianceState.Initializing }) {
+                RadianceState.Ready -> check(Mobile.isRadianceConnected()) {
+                    "Radiance setup completed but the core is unavailable"
+                }
+                is RadianceState.Failed -> throw state.cause
+                RadianceState.Initializing -> error("Radiance is still initializing")
+            }
+        }
 
         lateinit var instance: LanternVpnService
 
@@ -304,12 +328,30 @@ class LanternVpnService :
     private suspend fun startRadiance() {
         try {
             withContext(Dispatchers.IO) {
-                Mobile.startIPCServer(this@LanternVpnService, opts())
-                Mobile.setupRadiance(opts(), flutterEventListener)
+                setupRadiance()
             }
             AppLogger.d(TAG, "Radiance setup completed")
         } catch (e: Exception) {
             AppLogger.e(TAG, "Error in Radiance setup", e)
+        }
+    }
+
+    private suspend fun setupRadiance() {
+        radianceSetupMutex.withLock {
+            if (Mobile.isRadianceConnected()) {
+                radianceState.value = RadianceState.Ready
+                return@withLock
+            }
+
+            radianceState.value = RadianceState.Initializing
+            try {
+                Mobile.startIPCServer(this@LanternVpnService, opts())
+                Mobile.setupRadiance(opts(), flutterEventListener)
+                radianceState.value = RadianceState.Ready
+            } catch (e: Exception) {
+                radianceState.value = RadianceState.Failed(e)
+                throw e
+            }
         }
     }
 
@@ -354,8 +396,7 @@ class LanternVpnService :
             // to finish before we attempt to start the VPN tunnel.
             if (!Mobile.isRadianceConnected()) {
                 AppLogger.d(TAG, "Radiance not ready, setting up before VPN start")
-                Mobile.startIPCServer(this@LanternVpnService, opts())
-                Mobile.setupRadiance(opts(), flutterEventListener)
+                setupRadiance()
             }
             resetVpnAfterAppUpgradeIfNeeded()
             DefaultNetworkMonitor.setNetworkChangeCallback { updateUnderlyingNetworks() }

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1276,13 +1276,13 @@ msgid "discount_applied"
 msgstr "%s discount applied"
 
 msgid "referral_message_1m"
-msgstr "+ 1 additional month free"
+msgstr "+ 15 additional days free"
 
 msgid "referral_message_1y"
 msgstr "+ 1 additional month free"
 
 msgid "referral_message_2y"
-msgstr "+ 2 additional month free"
+msgstr "+ 2 additional months free"
 
 msgid "referral_code_invalid"
 msgstr "The referral/promo code you entered is invalid. Please check the code and try again."
@@ -1718,5 +1718,4 @@ msgstr "Order Total"
 
 msgid "smart_routing_mode_description"
 msgstr "Smart Location picks the fastest server and switches automatically as it finds better routes."
-
 

--- a/assets/locales/vi.po
+++ b/assets/locales/vi.po
@@ -1238,7 +1238,7 @@ msgid "referral_message_1m"
 msgstr "+ 15 ngày bổ sung miễn phí"
 
 msgid "referral_message_1y"
-msgstr "+ 15 ngày bổ sung miễn phí"
+msgstr "+ 1 tháng bổ sung miễn phí"
 
 msgid "referral_message_2y"
 msgstr "+ 2 tháng bổ sung miễn phí"

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4
+	github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -168,7 +168,7 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
-	github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 // indirect
+	github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad // indirect
 	github.com/getlantern/lantern-box v0.0.104 // indirect

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49
+	github.com/getlantern/radiance v0.0.0-20260722205654-838849783d37
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -168,9 +168,9 @@ require (
 	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
-	github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 // indirect
+	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
-	github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad // indirect
+	github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04 // indirect
 	github.com/getlantern/lantern-box v0.0.104 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 h1:2Fiu74ER24v0JeSVA32A5NriP8xQ8RyaNrUpE5AV84s=
-github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 h1:7+eqGoiyszEQC0j5LasInlf3XIZIwgjQTturyLzclwg=
+github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -243,8 +243,8 @@ github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770 h1:cSrD9ryDfTV2y
 github.com/getlantern/hidden v0.0.0-20220104173330-f221c5a24770/go.mod h1:GOQsoDnEHl6ZmNIL+5uVo+JWRFWozMEp18Izcb++H+A=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvdWv+YvXDqADVwjxM0DyABg2x4UgLVKU9McKI=
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
-github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad h1:FIWHYn9KnKVkgXGw3hXZ9tNzf0EzN3sY0FAbijIMNHo=
-github.com/getlantern/kindling v0.0.0-20260721030225-ef87ee261cad/go.mod h1:ECYSHrCeB9dVMhTHFnyoRAT/WDuEOgqy3suMVqPN4Ag=
+github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04 h1:YaN1rTKlpkREh9GQIJ8sLnZDt2brzzAhpd+nqmr2Iss=
+github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04/go.mod h1:Mej4MXda67EuL+kM6k4xcgxysWarkYjR5XPcNr8oYUI=
 github.com/getlantern/lantern-box v0.0.104 h1:ASLpYelmYUnY/bgDXH+UKiIex1Pme/Zg9YtDY6qQThk=
 github.com/getlantern/lantern-box v0.0.104/go.mod h1:xrH8ZziXLy1pYN94cfHenczjVwUVcuuUzJWb9lY8duw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49 h1:uZUjmGk++OW57a+N3MqSPDmr0XswTTJHUwIbw72zVmQ=
-github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49/go.mod h1:euYiMzxGRGUCMV4lDHZ6sHhgLSL/MMsMhCDHXIrL8do=
+github.com/getlantern/radiance v0.0.0-20260722205654-838849783d37 h1:Fzn1UupMGhx2lLJCYjLQ0/eOP7z62EpYV/XfLPNpF88=
+github.com/getlantern/radiance v0.0.0-20260722205654-838849783d37/go.mod h1:3ioylshJuvd1dJEUydJvIWjSXllphapzDk8HQgiyPnc=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -231,8 +231,8 @@ github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wd
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac/go.mod h1:0+wlia2hljruM7rhjzBMFhve011lGRO0OxjVSOcXBoQ=
-github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8 h1:/XB/H1/nRXANtAybB5NjRDjYMfZwR9X0Qs7eGSUGTK4=
-github.com/getlantern/domainfront v0.0.0-20260721025733-db7c158ccac8/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
+github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558 h1:2Fiu74ER24v0JeSVA32A5NriP8xQ8RyaNrUpE5AV84s=
+github.com/getlantern/domainfront v0.0.0-20260722154128-2862f7ad2558/go.mod h1:eOcE66YcVTxLiASh77rngh83B9PQtm4gSr7ZxWnaxZU=
 github.com/getlantern/errors v1.0.4 h1:i2iR1M9GKj4WuingpNqJ+XQEw6i6dnAgKAmLj6ZB3X0=
 github.com/getlantern/errors v1.0.4/go.mod h1:/Foq8jtSDGP8GOXzAjeslsC4Ar/3kB+UiQH+WyV4pzY=
 github.com/getlantern/golog v0.0.0-20230503153817-8e72de7e0a65 h1:NlQedYmPI3pRAXJb+hLVVDGqfvvXGRPV8vp7XOjKAZ0=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4 h1:weUlEVCJFwhAZtHjEyohgAjTd329ifpQIkO7BBaF9Kk=
-github.com/getlantern/radiance v0.0.0-20260721174611-d7290e50e7b4/go.mod h1:T7eJdawusvUiXuOF2QoqvhlmPRvcH4dSc8UNNYlC9yE=
+github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49 h1:uZUjmGk++OW57a+N3MqSPDmr0XswTTJHUwIbw72zVmQ=
+github.com/getlantern/radiance v0.0.0-20260722161034-b72b27db0e49/go.mod h1:euYiMzxGRGUCMV4lDHZ6sHhgLSL/MMsMhCDHXIrL8do=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
 github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/lib/core/common/app_dialog.dart
+++ b/lib/core/common/app_dialog.dart
@@ -178,7 +178,7 @@ class AppDialog {
     required List<Widget> action,
     EdgeInsetsGeometry? actionPadding,
   }) {
-    return showDialog(
+    return showDialog<void>(
       context: context,
       barrierDismissible: false,
       builder: (context) {

--- a/lib/core/common/common.dart
+++ b/lib/core/common/common.dart
@@ -207,7 +207,9 @@ bool isSmallScreen(BuildContext context) {
 }
 
 String getReferralMessage() {
-  return 'referral_message_1m'.i18n;
+  // Referral rewards are now a fixed 30 days for every plan. The existing
+  // annual-plan key already has the correct one-month copy in every locale.
+  return 'referral_message_1y'.i18n;
 }
 
 /// Initial server location set to auto (fastest server)

--- a/lib/features/auth/choose_payment_method.dart
+++ b/lib/features/auth/choose_payment_method.dart
@@ -525,20 +525,12 @@ class PaymentCheckoutMethods extends HookConsumerWidget {
               ),
               DividerSpace(padding: EdgeInsets.symmetric(vertical: 10)),
               if (referral.isReferral) ...[
-                Row(
-                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                  children: [
-                    Text(
-                      getReferralMessage().replaceAll('free', '').toTitleCase(),
-                      style: theme.bodyMedium,
-                    ),
-                    Text(
-                      'free'.i18n,
-                      style: theme.bodyMedium!.copyWith(
-                        color: context.textDisabled,
-                      ),
-                    ),
-                  ],
+                Align(
+                  alignment: AlignmentDirectional.centerStart,
+                  child: Text(
+                    getReferralMessage().toTitleCase(),
+                    style: theme.bodyMedium,
+                  ),
                 ),
                 DividerSpace(padding: EdgeInsets.symmetric(vertical: 10)),
               ],

--- a/lib/features/auth/choose_payment_method.dart
+++ b/lib/features/auth/choose_payment_method.dart
@@ -525,12 +525,20 @@ class PaymentCheckoutMethods extends HookConsumerWidget {
               ),
               DividerSpace(padding: EdgeInsets.symmetric(vertical: 10)),
               if (referral.isReferral) ...[
-                Align(
-                  alignment: AlignmentDirectional.centerStart,
-                  child: Text(
-                    getReferralMessage().toTitleCase(),
-                    style: theme.bodyMedium,
-                  ),
+                Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  children: [
+                    Text(
+                      getReferralMessage().replaceAll('free', '').toTitleCase(),
+                      style: theme.bodyMedium,
+                    ),
+                    Text(
+                      'free'.i18n,
+                      style: theme.bodyMedium!.copyWith(
+                        color: context.textDisabled,
+                      ),
+                    ),
+                  ],
                 ),
                 DividerSpace(padding: EdgeInsets.symmetric(vertical: 10)),
               ],

--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -17,7 +17,9 @@ class HomeNotifier extends _$HomeNotifier {
   Future<UserResponseModel> build() async {
     /// Check if user data is stored locally
     /// If yes, load it first to avoid delay in UI
-    final result = await ref.read(lanternServiceProvider).getUserData();
+    final service = ref.read(lanternServiceProvider);
+    await service.waitForRadiance();
+    final result = await service.getUserData();
     return result.fold(
       (failure) {
         appLogger.error(

--- a/lib/features/setting/invite_friends.dart
+++ b/lib/features/setting/invite_friends.dart
@@ -25,105 +25,121 @@ class InviteFriends extends HookConsumerWidget {
 
     return BaseScreen(
       title: 'invite_friends'.i18n,
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: <Widget>[
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: Text(
-              'invite_friends_description'.i18n,
-              style: textTheme.bodyMedium!.copyWith(
-                color: context.textSecondary,
-              ),
-            ),
-          ),
-          SizedBox(height: defaultSize),
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16.0),
-            child: Text(
-              '${'your_referral_code'.i18n}:',
-              style: textTheme.labelLarge!.copyWith(
-                color: context.textSecondary,
-              ),
-            ),
-          ),
-          SizedBox(height: 4.0),
-          Card(
+      body: CustomScrollView(
+        slivers: [
+          SliverFillRemaining(
+            hasScrollBody: false,
             child: Column(
-              children: [
-                AppTile(
-                  icon: AppImagePaths.star,
-                  trailing: AnimatedCrossFade(
-                    duration: Duration(milliseconds: 400),
-                    firstCurve: Curves.bounceOut,
-                    crossFadeState: isCopied.value
-                        ? CrossFadeState.showSecond
-                        : CrossFadeState.showFirst,
-                    firstChild: AppImage(path: AppImagePaths.copy),
-                    secondChild: Icon(
-                      Icons.check_circle,
-                      color: context.statusSuccessBg,
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Text(
+                    'invite_friends_description'.i18n,
+                    style: textTheme.bodyMedium!.copyWith(
+                      color: context.textSecondary,
                     ),
                   ),
-                  label: referralCode,
-                  tileTextStyle: AppTextStyles.bodyMediumBold.copyWith(
-                    color: context.textPrimary,
-                  ),
-                  onPressed: () => _onCopyTap(isCopied, referralCode),
                 ),
-                if (bonusMonths > 0) ...[
-                  DividerSpace(),
-                  AppTile(
-                    icon: Icon(
-                      Icons.emoji_events_outlined,
-                      color: context.textPromoIcon,
-                    ),
-                    label: bonusMonths == 1
-                        ? 'month_earned'.i18n.fill([bonusMonths])
-                        : 'months_earned'.i18n.fill([bonusMonths]),
-                    trailing: AppTextButton(
-                      label: 'view_account'.i18n,
-                      underLine: false,
-                      padding: EdgeInsets.zero,
-                      onPressed: () => _onViewAccount(context, ref),
+                SizedBox(height: defaultSize),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: Text(
+                    '${'your_referral_code'.i18n}:',
+                    style: textTheme.labelLarge!.copyWith(
+                      color: context.textSecondary,
                     ),
                   ),
-                ],
+                ),
+                SizedBox(height: 4.0),
+                Card(
+                  child: Column(
+                    children: [
+                      AppTile(
+                        icon: AppImagePaths.star,
+                        trailing: AnimatedCrossFade(
+                          duration: Duration(milliseconds: 400),
+                          firstCurve: Curves.bounceOut,
+                          crossFadeState: isCopied.value
+                              ? CrossFadeState.showSecond
+                              : CrossFadeState.showFirst,
+                          firstChild: AppImage(path: AppImagePaths.copy),
+                          secondChild: Icon(
+                            Icons.check_circle,
+                            color: context.statusSuccessBg,
+                          ),
+                        ),
+                        label: referralCode,
+                        tileTextStyle: AppTextStyles.bodyMediumBold.copyWith(
+                          color: context.textPrimary,
+                        ),
+                        onPressed: () =>
+                            _onCopyTap(context, isCopied, referralCode),
+                      ),
+                      if (bonusMonths > 0) ...[
+                        DividerSpace(),
+                        AppTile(
+                          icon: Icon(
+                            Icons.emoji_events_outlined,
+                            color: context.textPromoIcon,
+                          ),
+                          label: bonusMonths == 1
+                              ? 'month_earned'.i18n.fill([bonusMonths])
+                              : 'months_earned'.i18n.fill([bonusMonths]),
+                          trailing: AppTextButton(
+                            label: 'view_account'.i18n,
+                            underLine: false,
+                            padding: EdgeInsets.zero,
+                            onPressed: () => _onViewAccount(context, ref),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                Spacer(),
+                PrimaryButton(
+                  label: 'share_referral_code'.i18n,
+                  icon: AppImagePaths.share,
+                  isTaller: true,
+                  onPressed: () => _onShareTap(referralCode),
+                ),
+                SizedBox(height: defaultSize),
+                SecondaryButton(
+                  label: 'show_download_links'.i18n,
+                  icon: AppImagePaths.qrCodeScanner,
+                  useThemeColor: true,
+                  onPressed: () =>
+                      _showDownloadLinksSheet(context, referralCode),
+                ),
+                SizedBox(height: defaultSize),
               ],
             ),
           ),
-          Spacer(),
-          PrimaryButton(
-            label: 'share_referral_code'.i18n,
-            icon: AppImagePaths.share,
-            isTaller: true,
-            onPressed: () => _onShareTap(referralCode),
-          ),
-          SizedBox(height: defaultSize),
-          SecondaryButton(
-            label: 'show_download_links'.i18n,
-            icon: AppImagePaths.qrCodeScanner,
-            useThemeColor: true,
-            onPressed: () => _showDownloadLinksSheet(context, referralCode),
-          ),
-          SizedBox(height: defaultSize),
         ],
       ),
     );
   }
 
   Future<void> _onCopyTap(
+    BuildContext context,
     ValueNotifier<bool> isCopied,
     String referralCode,
   ) async {
     copyToClipboard(referralCode);
     isCopied.value = true;
     await Future.delayed(Duration(seconds: 1));
-    isCopied.value = false;
+    if (context.mounted) {
+      isCopied.value = false;
+    }
   }
 
   void _onShareTap(String referralCode) {
-    Share.share('share_message_referral_code'.i18n.fill([referralCode]));
+    SharePlus.instance.share(
+      ShareParams(
+        text: 'share_message_referral_code'.i18n.fill([referralCode]),
+      ),
+    );
   }
 
   Future<void> _onViewAccount(BuildContext context, WidgetRef ref) async {
@@ -194,17 +210,16 @@ class _GetLanternSheet extends HookWidget {
       padding: EdgeInsets.symmetric(horizontal: 16.0),
       children: <Widget>[
         SizedBox(height: 10),
-        Row(
+        Wrap(
+          spacing: 8.0,
+          runSpacing: 8.0,
           children: _DownloadPlatform.values
               .map(
-                (platform) => Padding(
-                  padding: const EdgeInsets.only(right: 8.0),
-                  child: _platformTab(
-                    context,
-                    platform,
-                    platform == selectedPlatform.value,
-                    () => selectedPlatform.value = platform,
-                  ),
+                (platform) => _platformTab(
+                  context,
+                  platform,
+                  platform == selectedPlatform.value,
+                  () => selectedPlatform.value = platform,
                 ),
               )
               .toList(),
@@ -280,7 +295,7 @@ class _GetLanternSheet extends HookWidget {
     final textTheme = Theme.of(context).textTheme;
     return InkWell(
       borderRadius: BorderRadius.circular(8.0),
-      onTap: () => _onCopyTap(isCopied, downloadUrl),
+      onTap: () => _onCopyTap(context, isCopied, downloadUrl),
       child: Container(
         padding: EdgeInsets.symmetric(horizontal: 12.0, vertical: 12.0),
         decoration: BoxDecoration(
@@ -357,12 +372,15 @@ class _GetLanternSheet extends HookWidget {
   }
 
   Future<void> _onCopyTap(
+    BuildContext context,
     ValueNotifier<bool> isCopied,
     String downloadUrl,
   ) async {
     copyToClipboard(downloadUrl);
     isCopied.value = true;
     await Future.delayed(Duration(seconds: 1));
-    isCopied.value = false;
+    if (context.mounted) {
+      isCopied.value = false;
+    }
   }
 }

--- a/lib/features/setting/referral_reward_dialog.dart
+++ b/lib/features/setting/referral_reward_dialog.dart
@@ -30,30 +30,29 @@ Future<void> checkAndShowReferralReward(
   final seen = storage.getSeenConvertedReferrals().toSet();
   final unseen = converted.where((r) => !seen.contains(r.userId)).toList();
   if (unseen.isEmpty) return;
-  _rewardDialogVisible = true;
-
-  // Mark as seen before showing so the dialog can't repeat. Merge with the
-  // already-seen ids so referrals missing from this response stay seen.
-  await storage.saveSeenConvertedReferrals(
-    {...seen, ...converted.map((r) => r.userId)}.toList(),
-  );
 
   final newDays = unseen.fold<int>(0, (total, r) => total + r.bonusDaysEarned);
   final newMonths = max(1, newDays ~/ 30);
   final totalMonths = max(newMonths, user.legacyUserData.referralBonusMonths);
 
-  if (!context.mounted) {
+  if (!context.mounted) return;
+  _rewardDialogVisible = true;
+  try {
+    await _showReferralRewardDialog(
+      context: context,
+      newMonths: newMonths,
+      totalMonths: totalMonths,
+      referralCode: user.legacyUserData.referral.toUpperCase(),
+    );
+
+    // Persist only after the user dismisses the dialog. If the route cannot be
+    // shown or the app exits first, the notification is retried next time.
+    await storage.saveSeenConvertedReferrals(
+      {...seen, ...converted.map((r) => r.userId)}.toList(),
+    );
+  } finally {
     _rewardDialogVisible = false;
-    return;
   }
-  await _showReferralRewardDialog(
-    context: context,
-    newMonths: newMonths,
-    totalMonths: totalMonths,
-    referralCode: user.legacyUserData.referral.toUpperCase(),
-  );
-  // Reset once the dialog closes, however it was dismissed.
-  _rewardDialogVisible = false;
 }
 
 Future<void> _showReferralRewardDialog({

--- a/lib/features/setting/referral_reward_dialog.dart
+++ b/lib/features/setting/referral_reward_dialog.dart
@@ -38,7 +38,7 @@ Future<void> checkAndShowReferralReward(
   if (!context.mounted) return;
   _rewardDialogVisible = true;
   try {
-    await _showReferralRewardDialog(
+    _showReferralRewardDialog(
       context: context,
       newMonths: newMonths,
       totalMonths: totalMonths,

--- a/lib/lantern/lantern_platform_service.dart
+++ b/lib/lantern/lantern_platform_service.dart
@@ -95,6 +95,10 @@ class LanternPlatformService implements LanternCoreService {
     return _appEventStatus;
   }
 
+  Future<void> waitForRadiance() async {
+    await _methodChannel.invokeMethod<void>('waitForRadiance');
+  }
+
   @override
   Future<Either<Failure, Unit>> updateLocal(String locale) async {
     try {

--- a/lib/lantern/lantern_service.dart
+++ b/lib/lantern/lantern_service.dart
@@ -43,6 +43,13 @@ class LanternService implements LanternCoreService {
     return _platformService.init();
   }
 
+  Future<void> waitForRadiance() {
+    if (PlatformUtils.isAndroid) {
+      return _platformService.waitForRadiance();
+    }
+    return Future.value();
+  }
+
   @override
   Future<Either<Failure, String>> startVPN() async {
     if (PlatformUtils.isFFISupported) {

--- a/test/core/models/user_referral_test.dart
+++ b/test/core/models/user_referral_test.dart
@@ -1,0 +1,63 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/extensions/user_data.dart';
+import 'package:lantern/core/models/user.dart';
+
+void main() {
+  group('ReferralModel', () {
+    test('parses and serializes referral data', () {
+      final referral = ReferralModel.fromJson({
+        'userId': 123,
+        'converted': true,
+        'convertedAt': 456,
+        'bonusDaysEarned': 30,
+      });
+
+      expect(referral.userId, '123');
+      expect(referral.converted, isTrue);
+      expect(referral.convertedAt, 456);
+      expect(referral.bonusDaysEarned, 30);
+      expect(referral.toJson(), {
+        'userId': '123',
+        'converted': true,
+        'convertedAt': 456,
+        'bonusDaysEarned': 30,
+      });
+    });
+
+    test('treats unexpected converted values as false', () {
+      expect(ReferralModel.fromJson({'converted': 'true'}).converted, isFalse);
+      expect(ReferralModel.fromJson({'converted': 1}).converted, isFalse);
+    });
+  });
+
+  group('UserDataModel referrals', () {
+    test('parses referral maps and ignores malformed list entries', () {
+      final user = UserDataModel.fromJson({
+        'referrals': [
+          {'userId': 'converted', 'converted': true, 'bonusDaysEarned': 30},
+          'not-a-map',
+          {'userId': 'pending', 'converted': false},
+        ],
+      });
+
+      expect(user.referrals, hasLength(2));
+      expect(user.referrals.map((referral) => referral.userId), [
+        'converted',
+        'pending',
+      ]);
+    });
+
+    test('totals bonus time from converted referrals only', () {
+      const user = UserDataModel(
+        referrals: [
+          ReferralModel(converted: true, bonusDaysEarned: 30),
+          ReferralModel(converted: false, bonusDaysEarned: 30),
+          ReferralModel(converted: true, bonusDaysEarned: 60),
+        ],
+      );
+
+      expect(user.referralBonusDays, 90);
+      expect(user.referralBonusMonths, 3);
+    });
+  });
+}

--- a/test/features/home/provider/home_notifier_test.dart
+++ b/test/features/home/provider/home_notifier_test.dart
@@ -1,0 +1,69 @@
+import 'dart:async';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/models/app_setting.dart';
+import 'package:lantern/core/models/user.dart';
+import 'package:lantern/core/utils/failure.dart';
+import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/features/home/provider/home_notifier.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
+
+const _user = UserResponseModel(
+  legacyID: 1,
+  legacyToken: 'token',
+  emailConfirmed: true,
+  success: true,
+  legacyUserData: UserDataModel(userLevel: 'pro'),
+);
+
+class _FakeLanternService implements LanternService {
+  final ready = Completer<void>();
+  final waitStarted = Completer<void>();
+  int waitForRadianceCalls = 0;
+  int getUserDataCalls = 0;
+
+  @override
+  Future<void> waitForRadiance() {
+    waitForRadianceCalls += 1;
+    waitStarted.complete();
+    return ready.future;
+  }
+
+  @override
+  Future<Either<Failure, UserResponseModel>> getUserData() async {
+    getUserDataCalls += 1;
+    return right(_user);
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  test('waits for Radiance before loading user data', () async {
+    final service = _FakeLanternService();
+    final container = ProviderContainer(
+      overrides: [
+        lanternServiceProvider.overrideWithValue(service),
+        appSettingProvider.overrideWithValue(
+          const AppSetting(userLoggedIn: true),
+        ),
+      ],
+    );
+    addTearDown(container.dispose);
+
+    final user = container.read(homeProvider.future);
+    await service.waitStarted.future;
+
+    expect(service.waitForRadianceCalls, 1);
+    expect(service.getUserDataCalls, 0);
+
+    service.ready.complete();
+
+    expect(await user, _user);
+    expect(service.getUserDataCalls, 1);
+  });
+}

--- a/windows/runner/main.cpp
+++ b/windows/runner/main.cpp
@@ -39,6 +39,11 @@ int APIENTRY wWinMain(_In_ HINSTANCE instance, _In_opt_ HINSTANCE prev,
   // running Lantern instances before launch; handing off here could silently
   // keep a pre-single-instance build alive.
 
+  // Ensure WebView2 uses a writable per-user data folder before the engine
+  // (and any WebView2-backed plugin) starts. Otherwise production installs
+  // under Program Files can't initialize WebView2 and in-app webviews go blank.
+  EnsureWebView2UserDataFolder();
+
   // Initialize COM, so that it is available for use in the library and/or
   // plugins.
   ::CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED);

--- a/windows/runner/utils.cpp
+++ b/windows/runner/utils.cpp
@@ -21,6 +21,59 @@ void CreateAndAttachConsole() {
   }
 }
 
+void EnsureWebView2UserDataFolder() {
+  // Respect an existing non-empty override (machine-level or debug config)
+  // rather than clobbering it. Read into a buffer instead of probing with a
+  // null one: the size probe can't tell "unset" from "set but empty", and an
+  // empty value isn't a meaningful override. GetEnvironmentVariableW returns the
+  // number of chars written — 0 when unset or empty, or the required size when
+  // an override is too long to fit (still counts as present).
+  wchar_t existing[MAX_PATH];
+  if (::GetEnvironmentVariableW(L"WEBVIEW2_USER_DATA_FOLDER", existing,
+                                ARRAYSIZE(existing)) > 0) {
+    return;
+  }
+
+  const wchar_t kUnexpanded[] = L"%LOCALAPPDATA%\\Lantern\\WebView2";
+  wchar_t path[MAX_PATH];
+  DWORD length =
+      ::ExpandEnvironmentStringsW(kUnexpanded, path, ARRAYSIZE(path));
+  if (length == 0 || length > ARRAYSIZE(path)) {
+    return;
+  }
+
+  // If %LOCALAPPDATA% is undefined, ExpandEnvironmentStringsW leaves the
+  // template literal, so the result starts with '%'; a real expanded path
+  // starts with a drive letter. Only the leading char is a reliable signal —
+  // '%' is legal elsewhere in a folder name — so don't reject those. Bail on an
+  // unexpanded path rather than create a garbage relative folder.
+  if (path[0] == L'%') {
+    return;
+  }
+
+  // Create each directory component in turn; CreateDirectoryW only creates the
+  // final segment, so intermediate parents must be created first.
+  for (wchar_t* cursor = path; *cursor != L'\0'; ++cursor) {
+    if (*cursor == L'\\' && cursor != path && *(cursor - 1) != L':') {
+      *cursor = L'\0';
+      ::CreateDirectoryW(path, nullptr);
+      *cursor = L'\\';
+    }
+  }
+  ::CreateDirectoryW(path, nullptr);
+
+  // Only advertise the folder if it now exists as a directory: CreateDirectoryW
+  // may have failed (permissions, invalid path), and pointing WebView2 at a
+  // nonexistent folder just moves the failure somewhere harder to diagnose. If
+  // we couldn't create it, leave WebView2 to its default.
+  DWORD attrs = ::GetFileAttributesW(path);
+  if (attrs == INVALID_FILE_ATTRIBUTES || !(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+    return;
+  }
+
+  ::SetEnvironmentVariableW(L"WEBVIEW2_USER_DATA_FOLDER", path);
+}
+
 std::vector<std::string> GetCommandLineArguments() {
   // Convert the UTF-16 command line arguments to UTF-8 for the Engine to use.
   int argc;

--- a/windows/runner/utils.h
+++ b/windows/runner/utils.h
@@ -8,6 +8,15 @@
 // it for both the runner and the Flutter library.
 void CreateAndAttachConsole();
 
+// Points WebView2 at a writable per-user data folder by setting the
+// WEBVIEW2_USER_DATA_FOLDER environment variable (creating the folder if
+// needed). Without this, production builds installed under Program Files
+// default their WebView2 data folder next to the read-only executable, so
+// WebView2 fails to initialize and in-app webviews (e.g. payment flows) stay
+// blank. Must be called before any WebView2 environment is created. Existing
+// values of the variable are left untouched so machine-level overrides win.
+void EnsureWebView2UserDataFolder();
+
 // Takes a null-terminated wchar_t* encoded in UTF-16 and returns a std::string
 // encoded in UTF-8. Returns an empty std::string on failure.
 std::string Utf8FromUtf16(const wchar_t* utf16_string);


### PR DESCRIPTION
Follow-up fixes for #8916:

- Make the Invite Friends screen scrollable on small screens and with large text.
- Persist converted referrals as seen only after the reward dialog is dismissed.
- Reset reward-dialog lock visibility after errors.
- Fix duplicated localized referral reward copy.
- Prevent delayed clipboard animations from updating disposed widgets.
- Replace the deprecated sharing API.
- Add referral model parsing and bonus-calculation tests.
- Merge the latest `main` and resolve the Radiance dependency conflict.