### PR TITLE
Verify checkout rendering from the installed app

### DIFF
--- a/.github/scripts/macos_payment_checkout_smoke.sh
+++ b/.github/scripts/macos_payment_checkout_smoke.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TEST_PATH="${TEST_PATH:-integration_test/payment/desktop_stripe_checkout_smoke_test.dart}"
+ARTIFACT_DIR="${ARTIFACT_DIR:-smoke-artifacts/macos-payment-checkout}"
+LANTERN_DATA_DIR="/Users/Shared/Lantern"
+LANTERN_LOG_DIR="$LANTERN_DATA_DIR/Logs"
+
+cleanup() {
+  local status=$?
+  mkdir -p "$ARTIFACT_DIR"
+  if [[ -d "$LANTERN_LOG_DIR" ]]; then
+    cp -R "$LANTERN_LOG_DIR/." "$ARTIFACT_DIR/" 2>/dev/null || true
+  fi
+  rm -rf "$LANTERN_DATA_DIR"
+  exit "$status"
+}
+
+trap cleanup EXIT
+
+pkill -x Lantern 2>/dev/null || true
+rm -rf "$LANTERN_DATA_DIR"
+mkdir -p "$LANTERN_LOG_DIR"
+
+flutter test \
+  "$TEST_PATH" \
+  -d macos \
+  --reporter=expanded \
+  --dart-define=DISABLE_SYSTEM_TRAY=true \
+  --dart-define=RADIANCE_ENV=staging

--- a/.github/scripts/macos_payment_checkout_smoke.sh
+++ b/.github/scripts/macos_payment_checkout_smoke.sh
@@ -5,10 +5,39 @@ TEST_PATH="${TEST_PATH:-integration_test/payment/desktop_stripe_checkout_smoke_t
 ARTIFACT_DIR="${ARTIFACT_DIR:-smoke-artifacts/macos-payment-checkout}"
 LANTERN_DATA_DIR="/Users/Shared/Lantern"
 LANTERN_LOG_DIR="$LANTERN_DATA_DIR/Logs"
+SCREENSHOT_READY_FILE="$LANTERN_DATA_DIR/.checkout-screenshot-ready"
+SCREENSHOT_CAPTURED_FILE="$LANTERN_DATA_DIR/.checkout-screenshot-captured"
+SCREENSHOT_PATH="$ARTIFACT_DIR/stripe-checkout.png"
+SCREENSHOT_WATCHER_PID=""
+
+capture_checkout_screenshot() {
+  local deadline=$((SECONDS + 300))
+  while ((SECONDS < deadline)); do
+    if [[ -f "$SCREENSHOT_READY_FILE" ]]; then
+      if /usr/sbin/screencapture -x "$SCREENSHOT_PATH"; then
+        printf 'Stripe Checkout screenshot captured at %s\n' "$SCREENSHOT_PATH" \
+          >"$ARTIFACT_DIR/screenshot-status.txt"
+      else
+        printf 'Unable to capture the Stripe Checkout screenshot\n' \
+          >"$ARTIFACT_DIR/screenshot-status.txt"
+      fi
+      touch "$SCREENSHOT_CAPTURED_FILE"
+      return
+    fi
+    sleep 0.1
+  done
+}
 
 cleanup() {
   local status=$?
+  if [[ -n "$SCREENSHOT_WATCHER_PID" ]]; then
+    kill "$SCREENSHOT_WATCHER_PID" 2>/dev/null || true
+    wait "$SCREENSHOT_WATCHER_PID" 2>/dev/null || true
+  fi
   mkdir -p "$ARTIFACT_DIR"
+  if [[ ! -f "$SCREENSHOT_PATH" ]]; then
+    /usr/sbin/screencapture -x "$SCREENSHOT_PATH" 2>/dev/null || true
+  fi
   if [[ -d "$LANTERN_LOG_DIR" ]]; then
     cp -R "$LANTERN_LOG_DIR/." "$ARTIFACT_DIR/" 2>/dev/null || true
   fi
@@ -21,6 +50,10 @@ trap cleanup EXIT
 pkill -x Lantern 2>/dev/null || true
 rm -rf "$LANTERN_DATA_DIR"
 mkdir -p "$LANTERN_LOG_DIR"
+mkdir -p "$ARTIFACT_DIR"
+
+capture_checkout_screenshot &
+SCREENSHOT_WATCHER_PID=$!
 
 flutter test \
   "$TEST_PATH" \

--- a/.github/scripts/windows_smoke_suite.ps1
+++ b/.github/scripts/windows_smoke_suite.ps1
@@ -384,14 +384,18 @@ finally {
     if ($UseInstaller) {
       Uninstall-FromInstalledService -Name $ServiceName
     } else {
-      $resolvedServiceExe = (Resolve-Path $ServiceExe -ErrorAction SilentlyContinue).Path
-      if ($resolvedServiceExe) {
-        Invoke-LanterndCommand `
-          -FilePath $resolvedServiceExe `
-          -ArgumentList @("uninstall") `
-          -Description "Uninstalling lanternd service from $resolvedServiceExe"
+      if (Get-Service -Name $ServiceName -ErrorAction SilentlyContinue) {
+        $resolvedServiceExe = (Resolve-Path $ServiceExe -ErrorAction SilentlyContinue).Path
+        if ($resolvedServiceExe) {
+          Invoke-LanterndCommand `
+            -FilePath $resolvedServiceExe `
+            -ArgumentList @("uninstall") `
+            -Description "Uninstalling lanternd service from $resolvedServiceExe"
+        } else {
+          Remove-ServiceIfPresent -Name $ServiceName
+        }
       } else {
-        Remove-ServiceIfPresent -Name $ServiceName
+        Write-Step "Windows service $ServiceName was not installed; skipping uninstall."
       }
     }
     Write-Step "Cleanup finished"

--- a/.github/scripts/windows_smoke_suite.ps1
+++ b/.github/scripts/windows_smoke_suite.ps1
@@ -3,6 +3,7 @@ param(
   [string]$ServiceExe = "build/windows/x64/runner/Release/lanternd.exe",
   [string]$InstallerPath = "",
   [string]$TestPath = "integration_test/vpn/windows_connect_smoke_test.dart",
+  [string]$PaymentCheckoutTestPath = "integration_test/payment/windows_stripe_checkout_smoke_test.dart",
   [string]$SplitTunnelWebsiteTestPath = "integration_test/vpn/split_tunneling_website_smoke_test.dart",
   [string]$ConfigUrlApiTestPath = "integration_test/vpn/windows_config_url_api_smoke_test.dart",
   [string]$ConfigUrlUiTestPath = "integration_test/vpn/windows_config_url_smoke_test.dart",
@@ -11,11 +12,14 @@ param(
   [int]$InstallerTimeoutSeconds = 180,
   [int]$UninstallTimeoutSeconds = 180,
   [int]$HeartbeatSeconds = 15,
+  [ValidateSet("prod", "staging")]
+  [string]$ServiceEnvironment = "prod",
   [bool]$RunConnectSmoke = $true,
   [switch]$EnableIpCheck,
   [switch]$ForceFullTunnel,
   [switch]$RunSplitTunnelWebsiteSmoke,
   [switch]$RunConfigUrlSmoke,
+  [switch]$RunPaymentCheckoutSmoke,
   [switch]$UseInstaller
 )
 
@@ -307,7 +311,7 @@ try {
     Remove-ServiceIfPresent -Name $ServiceName
     Invoke-LanterndCommand `
       -FilePath $resolvedServiceExe `
-      -ArgumentList @("install") `
+      -ArgumentList @("install", "--environment", $ServiceEnvironment) `
       -Description "Installing lanternd service from $resolvedServiceExe"
     Wait-ServiceRunning -Name $ServiceName -TimeoutSeconds $WaitSeconds
   }
@@ -320,6 +324,14 @@ try {
       -ForceFullTunnel:$ForceFullTunnel
   } else {
     Write-Step "Skipping Windows connect smoke test."
+  }
+
+  if ($RunPaymentCheckoutSmoke) {
+    Invoke-FlutterSmokeTest `
+      -Path $PaymentCheckoutTestPath `
+      -Description "Windows Stripe checkout smoke test"
+  } else {
+    Write-Step "Skipping Windows Stripe checkout smoke test."
   }
 
   if ($RunSplitTunnelWebsiteSmoke) {

--- a/.github/scripts/windows_smoke_suite.ps1
+++ b/.github/scripts/windows_smoke_suite.ps1
@@ -3,7 +3,7 @@ param(
   [string]$ServiceExe = "build/windows/x64/runner/Release/lanternd.exe",
   [string]$InstallerPath = "",
   [string]$TestPath = "integration_test/vpn/windows_connect_smoke_test.dart",
-  [string]$PaymentCheckoutTestPath = "integration_test/payment/windows_stripe_checkout_smoke_test.dart",
+  [string]$PaymentCheckoutTestPath = "integration_test/payment/desktop_stripe_checkout_smoke_test.dart",
   [string]$SplitTunnelWebsiteTestPath = "integration_test/vpn/split_tunneling_website_smoke_test.dart",
   [string]$ConfigUrlApiTestPath = "integration_test/vpn/windows_config_url_api_smoke_test.dart",
   [string]$ConfigUrlUiTestPath = "integration_test/vpn/windows_config_url_smoke_test.dart",
@@ -134,6 +134,8 @@ function Invoke-FlutterSmokeTest {
     [string]$Path,
     [Parameter(Mandatory = $true)]
     [string]$Description,
+    [ValidateSet("prod", "staging")]
+    [string]$RadianceEnvironment = "prod",
     [switch]$EnableIpCheck,
     [switch]$ForceFullTunnel
   )
@@ -146,6 +148,8 @@ function Invoke-FlutterSmokeTest {
     "--reporter=expanded",
     "--dart-define=DISABLE_SYSTEM_TRAY=true"
   )
+
+  $args += "--dart-define=RADIANCE_ENV=$RadianceEnvironment"
 
   if ($EnableIpCheck) {
     $args += "--dart-define=ENABLE_IP_CHECK=true"
@@ -329,7 +333,8 @@ try {
   if ($RunPaymentCheckoutSmoke) {
     Invoke-FlutterSmokeTest `
       -Path $PaymentCheckoutTestPath `
-      -Description "Windows Stripe checkout smoke test"
+      -Description "Windows Stripe checkout smoke test" `
+      -RadianceEnvironment $ServiceEnvironment
   } else {
     Write-Step "Skipping Windows Stripe checkout smoke test."
   }

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -132,6 +132,7 @@ jobs:
       installer_base_name: ${{ needs.prepare.outputs.installer_base_name }}
       runner_label: lantern-macos-smoke
       run_connect_smoke: true
+      run_payment_checkout_smoke: ${{ (inputs.tests || 'all') == 'all' }}
 
   windows:
     needs: prepare

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -146,3 +146,4 @@ jobs:
       force_full_tunnel_smoke: true
       run_auth_smoke: ${{ (inputs.tests || 'all') == 'all' }}
       run_split_tunnel_website_smoke: ${{ (inputs.tests || 'all') == 'all' }}
+      run_payment_checkout_smoke: ${{ (inputs.tests || 'all') == 'all' }}

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -27,6 +27,11 @@ on:
         required: false
         type: boolean
         default: true
+      windows_payment_checkout_smoke:
+        description: "Verify staging Stripe Checkout renders on Windows"
+        required: false
+        type: boolean
+        default: true
       macos_connect_smoke:
         description: "Include macOS connect/disconnect smoke when platforms=all (requires self-hosted runner with approved system extension)"
         required: false
@@ -145,6 +150,7 @@ jobs:
       skip_signing: true
       enable_ip_check: ${{ inputs.enable_ip_check }}
       run_connect_smoke: ${{ inputs.windows_connect_smoke }}
+      run_payment_checkout_smoke: ${{ inputs.windows_payment_checkout_smoke }}
       run_split_tunnel_website_smoke: ${{ inputs.windows_split_tunnel_website_smoke }}
       run_config_url_smoke: false
       force_full_tunnel_smoke: ${{ inputs.force_full_tunnel_smoke }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -37,6 +37,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_payment_checkout_smoke:
+        description: "Verify staging Stripe Checkout in a Flutter integration test"
+        required: false
+        type: boolean
+        default: false
       enable_ip_check:
         description: "Validate public IP change during the connect smoke"
         required: false
@@ -195,6 +200,23 @@ jobs:
 
       - name: Run macOS unit tests
         run: make macos-unit-tests
+
+      - name: macOS Stripe checkout smoke
+        if: ${{ inputs.run_payment_checkout_smoke }}
+        timeout-minutes: 15
+        shell: bash
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/macos-payment-checkout-smoke
+        run: bash ./.github/scripts/macos_payment_checkout_smoke.sh
+
+      - name: Upload macOS payment smoke diagnostics
+        if: ${{ always() && inputs.run_payment_checkout_smoke }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-payment-checkout-smoke
+          path: ${{ runner.temp }}/macos-payment-checkout-smoke
+          if-no-files-found: ignore
+          retention-days: 2
 
       - name: Build macOS release
         run: make macos-release-ci

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -211,12 +211,22 @@ jobs:
 
       - name: Upload macOS payment smoke diagnostics
         if: ${{ always() && inputs.run_payment_checkout_smoke }}
+        id: payment_smoke_diagnostics
         uses: actions/upload-artifact@v4
         with:
           name: macos-payment-checkout-smoke
           path: ${{ runner.temp }}/macos-payment-checkout-smoke
           if-no-files-found: ignore
           retention-days: 2
+
+      - name: Log macOS payment smoke diagnostics URL
+        if: ${{ always() && steps.payment_smoke_diagnostics.outputs.artifact-url != '' }}
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.payment_smoke_diagnostics.outputs.artifact-url }}
+        run: |
+          echo "::notice title=macOS payment smoke diagnostics::$ARTIFACT_URL"
+          echo "[Download the macOS payment smoke screenshot and diagnostics]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Build macOS release
         run: make macos-release-ci

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -54,6 +54,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_payment_checkout_smoke:
+        description: "Verify staging Stripe Checkout in a Flutter integration test"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   build-windows:
@@ -178,6 +183,17 @@ jobs:
           } else {
             Write-Warning "Release directory does not exist"
           }
+
+      - name: Windows Stripe checkout smoke
+        if: ${{ inputs.run_payment_checkout_smoke }}
+        shell: pwsh
+        timeout-minutes: 15
+        run: |
+          ./.github/scripts/windows_smoke_suite.ps1 `
+            -ServiceExe "build/windows/x64/runner/Release/lanternd.exe" `
+            -ServiceEnvironment staging `
+            -RunConnectSmoke:$false `
+            -RunPaymentCheckoutSmoke
 
       - name: Sign embedded binaries
         if: ${{ !inputs.skip_signing }}

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89
+	github.com/getlantern/radiance v0.0.0-20260809065423-4a83abc7c33a
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,10 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
+github.com/alexflint/go-arg v1.6.1 h1:uZogJ6VDBjcuosydKgvYYRhh9sRCusjOvoOLZopBlnA=
+github.com/alexflint/go-arg v1.6.1/go.mod h1:nQ0LFYftLJ6njcaee0sU+G0iS2+2XJQfA8I062D0LGc=
+github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
+github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/alitto/pond v1.9.2 h1:9Qb75z/scEZVCoSU+osVmQ0I0JOeLfdTDafrbcJ8CLs=
 github.com/alitto/pond v1.9.2/go.mod h1:xQn3P/sHTYcU/1BR3i86IGIrilcrGC2LiS+E2+CJWsI=
 github.com/anacrolix/btree v0.0.0-20251201064447-d86c3fa41bd8 h1:c02PsmoaChabVqAFm7pqPI1UIkDdDAjUaWa6ZmfxybQ=
@@ -261,6 +265,8 @@ github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmI
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
 github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89 h1:ZgdE/qPjx7ptpv0msnu4NSReL9neFlXQzC7kDVYty6g=
 github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89/go.mod h1:ZfvjwdgV6HbffcH7ZAkLsmt5Vs3TTd4AbWJMajOeyww=
+github.com/getlantern/radiance v0.0.0-20260809065423-4a83abc7c33a h1:Trb3QueFk+fYxoJHqrnpkRAmH/NrVftQzJeWPABdLVQ=
+github.com/getlantern/radiance v0.0.0-20260809065423-4a83abc7c33a/go.mod h1:ZfvjwdgV6HbffcH7ZAkLsmt5Vs3TTd4AbWJMajOeyww=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/integration_test/payment/desktop_stripe_checkout_smoke_test.dart
+++ b/integration_test/payment/desktop_stripe_checkout_smoke_test.dart
@@ -6,6 +6,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/utils/storage_utils.dart';
 import 'package:lantern/core/widgets/app_webview.dart';
 import 'package:lantern/features/plans/provider/plans_notifier.dart';
 import 'package:lantern/lantern_app.dart';
@@ -103,6 +104,7 @@ void main() {
       expect(find.byKey(const ValueKey('app-webview')), findsOneWidget);
       expect(observer.uri?.host, _stripeHost);
       expect(observer.documentLength, greaterThan(0));
+      await _captureMacOSCheckoutScreenshot(tester);
       debugPrint(
         'Stripe Checkout rendered from $_stripeHost '
         '(${observer.documentLength} document characters)',
@@ -110,6 +112,21 @@ void main() {
     },
     timeout: const Timeout(Duration(minutes: 5)),
   );
+}
+
+Future<void> _captureMacOSCheckoutScreenshot(WidgetTester tester) async {
+  if (!Platform.isMacOS) return;
+
+  final directory = await AppStorageUtils.getAppDirectory();
+  final ready = File('${directory.path}/.checkout-screenshot-ready');
+  final captured = File('${directory.path}/.checkout-screenshot-captured');
+  await ready.create(recursive: true);
+  final deadline = DateTime.now().add(const Duration(seconds: 10));
+  while (DateTime.now().isBefore(deadline)) {
+    if (await captured.exists()) return;
+    await tester.pump(const Duration(milliseconds: 100));
+  }
+  debugPrint('Timed out waiting for the macOS checkout screenshot');
 }
 
 Future<void> _waitFor(

--- a/integration_test/payment/desktop_stripe_checkout_smoke_test.dart
+++ b/integration_test/payment/desktop_stripe_checkout_smoke_test.dart
@@ -6,12 +6,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:lantern/core/common/common.dart';
-import 'package:lantern/core/utils/storage_utils.dart';
 import 'package:lantern/core/widgets/app_webview.dart';
 import 'package:lantern/features/plans/provider/plans_notifier.dart';
 import 'package:lantern/lantern_app.dart';
 import 'package:lantern/main.dart' as app;
-import 'package:path/path.dart' as p;
 
 const _stripeHost = 'checkout.stripe.com';
 
@@ -19,16 +17,13 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'staging Stripe Checkout renders in the Windows WebView',
+    'staging Stripe Checkout renders in the desktop WebView',
     (tester) async {
-      expect(Platform.isWindows, isTrue, reason: 'This smoke runs on Windows');
-
-      final stagingMarker = await _enableStaging();
-      addTearDown(() async {
-        if (stagingMarker.createdByTest && await stagingMarker.file.exists()) {
-          await stagingMarker.file.delete();
-        }
-      });
+      expect(
+        Platform.isWindows || Platform.isMacOS,
+        isTrue,
+        reason: 'This smoke runs on Windows and macOS',
+      );
 
       await app.main();
       await _waitFor(
@@ -117,16 +112,6 @@ void main() {
   );
 }
 
-Future<_StagingMarker> _enableStaging() async {
-  final appDirectory = await AppStorageUtils.getAppDirectory();
-  final file = File(p.join(appDirectory.path, '.radiance_env'));
-  final existed = await file.exists();
-  if (!existed) {
-    await file.create(recursive: true);
-  }
-  return _StagingMarker(file, createdByTest: !existed);
-}
-
 Future<void> _waitFor(
   WidgetTester tester,
   bool Function() condition, {
@@ -152,13 +137,6 @@ String _newUuid() {
   return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
       '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
       '${hex.substring(20)}';
-}
-
-class _StagingMarker {
-  final File file;
-  final bool createdByTest;
-
-  const _StagingMarker(this.file, {required this.createdByTest});
 }
 
 class _StripeCheckoutObserver implements AppWebViewObserver {

--- a/integration_test/payment/windows_stripe_checkout_smoke_test.dart
+++ b/integration_test/payment/windows_stripe_checkout_smoke_test.dart
@@ -1,0 +1,190 @@
+import 'dart:io';
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/utils/storage_utils.dart';
+import 'package:lantern/core/widgets/app_webview.dart';
+import 'package:lantern/features/plans/provider/plans_notifier.dart';
+import 'package:lantern/lantern_app.dart';
+import 'package:lantern/main.dart' as app;
+import 'package:path/path.dart' as p;
+
+const _stripeHost = 'checkout.stripe.com';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'staging Stripe Checkout renders in the Windows WebView',
+    (tester) async {
+      expect(Platform.isWindows, isTrue, reason: 'This smoke runs on Windows');
+
+      final stagingMarker = await _enableStaging();
+      addTearDown(() async {
+        if (stagingMarker.createdByTest && await stagingMarker.file.exists()) {
+          await stagingMarker.file.delete();
+        }
+      });
+
+      await app.main();
+      await _waitFor(
+        tester,
+        () => find.byType(LanternApp).evaluate().isNotEmpty,
+        timeout: const Duration(seconds: 30),
+        failure: () => 'Lantern did not render its Flutter UI',
+      );
+
+      final appElement = find.byType(LanternApp).evaluate().first;
+      final container = ProviderScope.containerOf(appElement, listen: false);
+      final plansSubscription = container.listen(plansProvider, (_, _) {});
+      addTearDown(plansSubscription.close);
+
+      final plans = await container
+          .read(plansProvider.future)
+          .timeout(const Duration(seconds: 60));
+      final stripe = plans.providers.desktop.where(
+        (provider) => provider.providers.name == 'stripe',
+      );
+      expect(stripe, isNotEmpty, reason: 'Staging did not return Stripe');
+      expect(
+        stripe.first.providers.supportSubscription,
+        isTrue,
+        reason: 'Staging Stripe must support subscriptions',
+      );
+      expect(plans.plans, isNotEmpty, reason: 'Staging returned no plans');
+
+      final selectedPlan = plans.plans.firstWhere(
+        (plan) => plan.bestValue,
+        orElse: () => plans.plans.first,
+      );
+      container.read(plansProvider.notifier).setSelectedPlan(selectedPlan);
+
+      final observer = _StripeCheckoutObserver();
+      await appRouter.replaceAll([
+        ChoosePaymentMethod(
+          email: 'e2e+${_newUuid()}@getlantern.org',
+          authFlow: AuthFlow.renewSubscription,
+          checkoutObserver: observer,
+        ),
+      ]);
+
+      final stripeProvider = find.byKey(const Key('payment.provider.stripe'));
+      await _waitFor(
+        tester,
+        () => stripeProvider.evaluate().isNotEmpty,
+        timeout: const Duration(seconds: 30),
+        failure: () => 'Stripe was not shown on the payment-method screen',
+      );
+
+      final checkoutButton = find.byKey(const Key('payment.checkout.stripe'));
+      if (checkoutButton.evaluate().isEmpty) {
+        await tester.tap(stripeProvider);
+        await tester.pump(const Duration(milliseconds: 300));
+      }
+      await _waitFor(
+        tester,
+        () => checkoutButton.evaluate().isNotEmpty,
+        timeout: const Duration(seconds: 10),
+        failure: () => 'Stripe checkout button was not available',
+      );
+
+      await tester.ensureVisible(checkoutButton);
+      await tester.tap(checkoutButton);
+
+      await _waitFor(
+        tester,
+        () => observer.finished,
+        timeout: const Duration(minutes: 3),
+        failure: () => observer.failureMessage,
+      );
+
+      if (observer.checkoutFailure != null) {
+        fail('Stripe Checkout failed to load: ${observer.checkoutFailure}');
+      }
+      expect(find.byKey(const ValueKey('app-webview')), findsOneWidget);
+      expect(observer.uri?.host, _stripeHost);
+      expect(observer.documentLength, greaterThan(0));
+      debugPrint(
+        'Stripe Checkout rendered from $_stripeHost '
+        '(${observer.documentLength} document characters)',
+      );
+    },
+    timeout: const Timeout(Duration(minutes: 5)),
+  );
+}
+
+Future<_StagingMarker> _enableStaging() async {
+  final appDirectory = await AppStorageUtils.getAppDirectory();
+  final file = File(p.join(appDirectory.path, '.radiance_env'));
+  final existed = await file.exists();
+  if (!existed) {
+    await file.create(recursive: true);
+  }
+  return _StagingMarker(file, createdByTest: !existed);
+}
+
+Future<void> _waitFor(
+  WidgetTester tester,
+  bool Function() condition, {
+  required Duration timeout,
+  required String Function() failure,
+}) async {
+  final deadline = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(deadline)) {
+    await tester.pump(const Duration(milliseconds: 200));
+    if (condition()) return;
+  }
+  fail(failure());
+}
+
+String _newUuid() {
+  final random = Random.secure();
+  final bytes = List<int>.generate(16, (_) => random.nextInt(256));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  final hex = bytes
+      .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+      .join();
+  return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
+      '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
+      '${hex.substring(20)}';
+}
+
+class _StagingMarker {
+  final File file;
+  final bool createdByTest;
+
+  const _StagingMarker(this.file, {required this.createdByTest});
+}
+
+class _StripeCheckoutObserver implements AppWebViewObserver {
+  Uri? uri;
+  int documentLength = 0;
+  String? lastFailure;
+  String? checkoutFailure;
+
+  bool get finished => uri?.host == _stripeHost || checkoutFailure != null;
+
+  String get failureMessage => lastFailure == null
+      ? 'Stripe Checkout did not load a non-empty document'
+      : 'Stripe Checkout did not load: $lastFailure';
+
+  @override
+  void onPageLoaded(Uri uri, {required int documentLength}) {
+    if (uri.host != _stripeHost) return;
+    this.uri = uri;
+    this.documentLength = documentLength;
+  }
+
+  @override
+  void onPageLoadFailed(Uri? uri, String reason) {
+    lastFailure = '${uri?.host ?? 'unknown host'}: $reason';
+    if (uri?.host == _stripeHost) {
+      checkoutFailure = reason;
+    }
+  }
+}

--- a/lib/core/common/common.dart
+++ b/lib/core/common/common.dart
@@ -1,5 +1,4 @@
 // Common file to export all common files
-import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/foundation.dart';
@@ -17,7 +16,6 @@ import 'package:lantern/core/router/router.dart';
 import 'package:lantern/core/services/logger_service.dart';
 import 'package:lantern/core/utils/country_code.dart';
 import 'package:lantern/core/utils/platform_utils.dart';
-import 'package:lantern/core/utils/storage_utils.dart';
 import 'package:share_plus/share_plus.dart';
 
 import '../../features/home/provider/home_notifier.dart';
@@ -241,10 +239,4 @@ ThemeMode resolveThemeMode(String raw) {
     default:
       return ThemeMode.system;
   }
-}
-
-Future<bool> isStageEnvironment() async {
-  final dir = await AppStorageUtils.getAppDirectory();
-  final envFile = File('${dir.path}/.radiance_env');
-  return envFile.existsSync();
 }

--- a/lib/core/router/router.gr.dart
+++ b/lib/core/router/router.gr.dart
@@ -155,10 +155,16 @@ class AppWebview extends _i44.PageRouteInfo<AppWebviewArgs> {
     _i45.Key? key,
     required String title,
     required String url,
+    _i3.AppWebViewObserver? observer,
     List<_i44.PageRouteInfo>? children,
   }) : super(
          AppWebview.name,
-         args: AppWebviewArgs(key: key, title: title, url: url),
+         args: AppWebviewArgs(
+           key: key,
+           title: title,
+           url: url,
+           observer: observer,
+         ),
          initialChildren: children,
        );
 
@@ -168,13 +174,23 @@ class AppWebview extends _i44.PageRouteInfo<AppWebviewArgs> {
     name,
     builder: (data) {
       final args = data.argsAs<AppWebviewArgs>();
-      return _i3.AppWebView(key: args.key, title: args.title, url: args.url);
+      return _i3.AppWebView(
+        key: args.key,
+        title: args.title,
+        url: args.url,
+        observer: args.observer,
+      );
     },
   );
 }
 
 class AppWebviewArgs {
-  const AppWebviewArgs({this.key, required this.title, required this.url});
+  const AppWebviewArgs({
+    this.key,
+    required this.title,
+    required this.url,
+    this.observer,
+  });
 
   final _i45.Key? key;
 
@@ -182,20 +198,26 @@ class AppWebviewArgs {
 
   final String url;
 
+  final _i3.AppWebViewObserver? observer;
+
   @override
   String toString() {
-    return 'AppWebviewArgs{key: $key, title: $title, url: $url}';
+    return 'AppWebviewArgs{key: $key, title: $title, url: $url, observer: $observer}';
   }
 
   @override
   bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! AppWebviewArgs) return false;
-    return key == other.key && title == other.title && url == other.url;
+    return key == other.key &&
+        title == other.title &&
+        url == other.url &&
+        observer == other.observer;
   }
 
   @override
-  int get hashCode => key.hashCode ^ title.hashCode ^ url.hashCode;
+  int get hashCode =>
+      key.hashCode ^ title.hashCode ^ url.hashCode ^ observer.hashCode;
 }
 
 /// generated route for
@@ -238,6 +260,7 @@ class ChoosePaymentMethod extends _i44.PageRouteInfo<ChoosePaymentMethodArgs> {
     required String email,
     String? code,
     required _i46.AuthFlow authFlow,
+    _i3.AppWebViewObserver? checkoutObserver,
     List<_i44.PageRouteInfo>? children,
   }) : super(
          ChoosePaymentMethod.name,
@@ -246,6 +269,7 @@ class ChoosePaymentMethod extends _i44.PageRouteInfo<ChoosePaymentMethodArgs> {
            email: email,
            code: code,
            authFlow: authFlow,
+           checkoutObserver: checkoutObserver,
          ),
          initialChildren: children,
        );
@@ -261,6 +285,7 @@ class ChoosePaymentMethod extends _i44.PageRouteInfo<ChoosePaymentMethodArgs> {
         email: args.email,
         code: args.code,
         authFlow: args.authFlow,
+        checkoutObserver: args.checkoutObserver,
       );
     },
   );
@@ -272,6 +297,7 @@ class ChoosePaymentMethodArgs {
     required this.email,
     this.code,
     required this.authFlow,
+    this.checkoutObserver,
   });
 
   final _i45.Key? key;
@@ -282,9 +308,11 @@ class ChoosePaymentMethodArgs {
 
   final _i46.AuthFlow authFlow;
 
+  final _i3.AppWebViewObserver? checkoutObserver;
+
   @override
   String toString() {
-    return 'ChoosePaymentMethodArgs{key: $key, email: $email, code: $code, authFlow: $authFlow}';
+    return 'ChoosePaymentMethodArgs{key: $key, email: $email, code: $code, authFlow: $authFlow, checkoutObserver: $checkoutObserver}';
   }
 
   @override
@@ -294,12 +322,17 @@ class ChoosePaymentMethodArgs {
     return key == other.key &&
         email == other.email &&
         code == other.code &&
-        authFlow == other.authFlow;
+        authFlow == other.authFlow &&
+        checkoutObserver == other.checkoutObserver;
   }
 
   @override
   int get hashCode =>
-      key.hashCode ^ email.hashCode ^ code.hashCode ^ authFlow.hashCode;
+      key.hashCode ^
+      email.hashCode ^
+      code.hashCode ^
+      authFlow.hashCode ^
+      checkoutObserver.hashCode;
 }
 
 /// generated route for

--- a/lib/core/utils/radiance_environment.dart
+++ b/lib/core/utils/radiance_environment.dart
@@ -1,0 +1,35 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:lantern/core/utils/storage_utils.dart';
+
+const _environmentOverride = String.fromEnvironment('RADIANCE_ENV');
+
+/// Returns the Radiance backend selected for this process.
+Future<String> radianceEnvironment() async {
+  if (_environmentOverride.isNotEmpty) {
+    return normalizeRadianceEnvironment(_environmentOverride);
+  }
+  if (kReleaseMode) {
+    return 'prod';
+  }
+  final directory = await AppStorageUtils.getAppDirectory();
+  final marker = File('${directory.path}/.radiance_env');
+  return await marker.exists() ? 'stage' : 'prod';
+}
+
+@visibleForTesting
+String normalizeRadianceEnvironment(String value) {
+  switch (value.trim().toLowerCase()) {
+    case 'prod':
+      return 'prod';
+    case 'staging':
+      return 'stage';
+    default:
+      throw ArgumentError.value(
+        value,
+        'RADIANCE_ENV',
+        'unsupported environment',
+      );
+  }
+}

--- a/lib/core/utils/url_utils.dart
+++ b/lib/core/utils/url_utils.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/widgets/app_webview.dart';
 import 'package:url_launcher/url_launcher.dart';
 
 class UrlUtils {
@@ -125,6 +126,7 @@ class UrlUtils {
     String url, {
     String? title,
     Function(T)? onWebviewResult,
+    AppWebViewObserver? observer,
   }) async {
     try {
       final normalizedUrl = normalizeWebviewUrl(url);
@@ -139,7 +141,11 @@ class UrlUtils {
         case 'macos':
         case 'windows':
           final result = await appRouter.push<T>(
-            AppWebview(title: title ?? '', url: normalizedUrl),
+            AppWebview(
+              title: title ?? '',
+              url: normalizedUrl,
+              observer: observer,
+            ),
           );
           if (result != null) {
             onWebviewResult?.call(result);

--- a/lib/core/widgets/app_webview.dart
+++ b/lib/core/widgets/app_webview.dart
@@ -9,6 +9,13 @@ final webViewLoadingProvider = NotifierProvider<WebViewLoading, bool>(
   WebViewLoading.new,
 );
 
+/// Receives main-frame load events from an in-app WebView.
+abstract interface class AppWebViewObserver {
+  void onPageLoaded(Uri uri, {required int documentLength});
+
+  void onPageLoadFailed(Uri? uri, String reason);
+}
+
 class WebViewLoading extends Notifier<bool> {
   @override
   bool build() => false;
@@ -22,8 +29,14 @@ class WebViewLoading extends Notifier<bool> {
 class AppWebView extends HookConsumerWidget {
   final String title;
   final String url;
+  final AppWebViewObserver? observer;
 
-  const AppWebView({super.key, required this.title, required this.url});
+  const AppWebView({
+    super.key,
+    required this.title,
+    required this.url,
+    this.observer,
+  });
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -48,7 +61,7 @@ class AppWebView extends HookConsumerWidget {
       ),
       body: Stack(
         children: [
-          _InnerWebView(url: url),
+          _InnerWebView(url: url, observer: observer),
           if (isLoading) Center(child: LoadingIndicator()),
         ],
       ),
@@ -58,8 +71,9 @@ class AppWebView extends HookConsumerWidget {
 
 class _InnerWebView extends StatefulHookConsumerWidget {
   final String url;
+  final AppWebViewObserver? observer;
 
-  const _InnerWebView({required this.url});
+  const _InnerWebView({required this.url, this.observer});
 
   @override
   ConsumerState<_InnerWebView> createState() => _InnerWebViewState();
@@ -94,7 +108,10 @@ class _InnerWebViewState extends ConsumerState<_InnerWebView> {
 
   @override
   Widget build(BuildContext context) {
-    appLogger.debug("Building _InnerWebView with URL: ${widget.url}");
+    final initialUri = Uri.tryParse(widget.url);
+    appLogger.debug(
+      'Building _InnerWebView for host: ${initialUri?.host ?? '<none>'}',
+    );
     return InAppWebView(
       key: const ValueKey('app-webview'),
       shouldOverrideUrlLoading: shouldOverrideUrlLoading,
@@ -125,22 +142,51 @@ class _InnerWebViewState extends ConsumerState<_InnerWebView> {
         loading.start();
       },
       onLoadStop: (controller, webUri) async {
-        // Handle load stop
         ref.read(webViewLoadingProvider.notifier).stop();
-        await _handleCompletionUrl(
-          webUri == null ? null : Uri.tryParse(webUri.toString()),
-        );
+        final uri = webUri == null ? null : Uri.tryParse(webUri.toString());
+        await _reportPageLoaded(controller, uri);
+        await _handleCompletionUrl(uri);
       },
       onReceivedError: (_, webResourceRequest, error) async {
-        // Handle received error
         appLogger.error("Received error: $error");
-        // Handle load stop
         ref.read(webViewLoadingProvider.notifier).stop();
-        await _handleCompletionUrl(
-          Uri.tryParse(webResourceRequest.url.toString()),
-        );
+        final uri = Uri.tryParse(webResourceRequest.url.toString());
+        if (webResourceRequest.isForMainFrame == true) {
+          widget.observer?.onPageLoadFailed(
+            uri,
+            '${error.type}: ${error.description}',
+          );
+        }
+        await _handleCompletionUrl(uri);
+      },
+      onReceivedHttpError: (_, request, response) {
+        if (request.isForMainFrame != true) return;
+        ref.read(webViewLoadingProvider.notifier).stop();
+        final uri = Uri.tryParse(request.url.toString());
+        widget.observer?.onPageLoadFailed(uri, 'HTTP ${response.statusCode}');
       },
     );
+  }
+
+  Future<void> _reportPageLoaded(
+    InAppWebViewController controller,
+    Uri? uri,
+  ) async {
+    final observer = widget.observer;
+    if (observer == null || uri == null) return;
+
+    try {
+      final value = await controller.evaluateJavascript(
+        source: 'document.documentElement?.outerHTML?.length ?? 0',
+      );
+      final documentLength = value is num
+          ? value.toInt()
+          : int.tryParse(value?.toString() ?? '') ?? 0;
+      observer.onPageLoaded(uri, documentLength: documentLength);
+    } catch (error, stackTrace) {
+      appLogger.error('Unable to inspect WebView document', error, stackTrace);
+      observer.onPageLoadFailed(uri, error.toString());
+    }
   }
 
   bool isLanternHost(String host) =>

--- a/lib/features/auth/choose_payment_method.dart
+++ b/lib/features/auth/choose_payment_method.dart
@@ -10,6 +10,7 @@ import 'package:lantern/core/models/plan_data.dart';
 import 'package:lantern/core/models/referral_attach_response.dart';
 import 'package:lantern/core/services/injection_container.dart';
 import 'package:lantern/core/services/stripe_service.dart';
+import 'package:lantern/core/widgets/app_webview.dart';
 import 'package:lantern/core/widgets/logs_path.dart';
 import 'package:lantern/features/plans/provider/payment_notifier.dart';
 import 'package:lantern/features/plans/provider/plans_notifier.dart';
@@ -20,12 +21,14 @@ class ChoosePaymentMethod extends HookConsumerWidget {
   final String email;
   final String? code;
   final AuthFlow authFlow;
+  final AppWebViewObserver? checkoutObserver;
 
   const ChoosePaymentMethod({
     super.key,
     required this.email,
     this.code,
     required this.authFlow,
+    this.checkoutObserver,
   });
 
   @override
@@ -295,6 +298,7 @@ class ChoosePaymentMethod extends HookConsumerWidget {
             final purchaseResult = await UrlUtils.openWebview<bool>(
               normalizedStripeUrl,
               title: 'stripe_payment'.i18n,
+              observer: checkoutObserver,
             );
             if (!context.mounted || purchaseResult == null) return;
             await onPurchaseResult(purchaseResult, context, ref);
@@ -479,6 +483,7 @@ class PaymentCheckoutMethods extends HookConsumerWidget {
         return Padding(
           padding: const EdgeInsets.only(bottom: 16),
           child: ExpansionTile(
+            key: Key('payment.provider.${method.providers.name}'),
             initiallyExpanded: index == 0,
             backgroundColor: context.bgElevated,
             collapsedBackgroundColor: context.bgElevated,
@@ -592,6 +597,7 @@ class PaymentCheckoutMethods extends HookConsumerWidget {
               ),
               SizedBox(height: defaultSize),
               PrimaryButton(
+                buttonKey: Key('payment.checkout.${method.providers.name}'),
                 label: method.providers.supportSubscription
                     ? 'subscribe'.i18n
                     : 'checkout'.i18n,

--- a/lib/features/auth/choose_payment_method.dart
+++ b/lib/features/auth/choose_payment_method.dart
@@ -10,6 +10,7 @@ import 'package:lantern/core/models/plan_data.dart';
 import 'package:lantern/core/models/referral_attach_response.dart';
 import 'package:lantern/core/services/injection_container.dart';
 import 'package:lantern/core/services/stripe_service.dart';
+import 'package:lantern/core/widgets/app_webview.dart';
 import 'package:lantern/core/widgets/logs_path.dart';
 import 'package:lantern/features/home/provider/home_notifier.dart';
 import 'package:lantern/features/plans/provider/payment_notifier.dart';
@@ -21,12 +22,14 @@ class ChoosePaymentMethod extends HookConsumerWidget {
   final String email;
   final String? code;
   final AuthFlow authFlow;
+  final AppWebViewObserver? checkoutObserver;
 
   const ChoosePaymentMethod({
     super.key,
     required this.email,
     this.code,
     required this.authFlow,
+    this.checkoutObserver,
   });
 
   @override
@@ -329,6 +332,7 @@ class ChoosePaymentMethod extends HookConsumerWidget {
             final purchaseResult = await UrlUtils.openWebview<bool>(
               normalizedStripeUrl,
               title: 'stripe_payment'.i18n,
+              observer: checkoutObserver,
             );
             if (!context.mounted || purchaseResult == null) return;
             await onPurchaseResult(purchaseResult, context, ref);
@@ -514,6 +518,7 @@ class PaymentCheckoutMethods extends HookConsumerWidget {
         return Padding(
           padding: const EdgeInsets.only(bottom: 16),
           child: ExpansionTile(
+            key: Key('payment.provider.${method.providers.name}'),
             initiallyExpanded: index == 0,
             backgroundColor: context.bgElevated,
             collapsedBackgroundColor: context.bgElevated,
@@ -627,6 +632,7 @@ class PaymentCheckoutMethods extends HookConsumerWidget {
               ),
               SizedBox(height: defaultSize),
               PrimaryButton(
+                buttonKey: Key('payment.checkout.${method.providers.name}'),
                 label: method.providers.supportSubscription
                     ? 'subscribe'.i18n
                     : 'checkout'.i18n,

--- a/lib/lantern/lantern_ffi_service.dart
+++ b/lib/lantern/lantern_ffi_service.dart
@@ -17,6 +17,7 @@ import 'package:lantern/core/models/private_server_status.dart';
 import 'package:lantern/core/services/app_purchase.dart';
 import 'package:lantern/core/models/restore_subscription_response.dart';
 import 'package:lantern/core/utils/app_data_utils.dart';
+import 'package:lantern/core/utils/radiance_environment.dart';
 import 'package:lantern/core/utils/storage_utils.dart';
 import 'package:lantern/features/report_issue/models/report_issue_attachment.dart';
 import 'package:lantern/lantern/lantern_core_service.dart';
@@ -163,21 +164,11 @@ class LanternFFIService implements LanternCoreService {
     }
   }
 
-  /// Determine the appropriate environment string for Radiance based on build mode and stage detection.
-  Future<String> _radianceEnv() async {
-    if (kReleaseMode) {
-      return "prod";
-    } else {
-      final isStageFound = await isStageEnvironment();
-      return isStageFound ? "stage" : "prod";
-    }
-  }
-
   Future<Either<String, Unit>> _setupRadiance() async {
     try {
       appLogger.debug('Setting up radiance');
       int consent = 0;
-      String env = await _radianceEnv();
+      final env = await radianceEnvironment();
       try {
         // Telemetry consent can be forwarded here when needed.
       } catch (_) {

--- a/lib/lantern/lantern_platform_service.dart
+++ b/lib/lantern/lantern_platform_service.dart
@@ -21,6 +21,7 @@ import 'package:lantern/core/services/app_purchase.dart';
 import 'package:lantern/core/services/injection_container.dart';
 import 'package:lantern/core/utils/app_data_utils.dart';
 import 'package:lantern/core/utils/enabled_apps.dart';
+import 'package:lantern/core/utils/radiance_environment.dart';
 import 'package:lantern/features/report_issue/models/report_issue_attachment.dart';
 import 'package:lantern/lantern/lantern_core_service.dart';
 import 'package:lantern/lantern/lantern_ffi_service.dart';
@@ -83,6 +84,10 @@ class LanternPlatformService implements LanternCoreService {
       _systemExtensionStatus = systemExtensionStatusChannel
           .receiveBroadcastStream()
           .map(MacOSExtensionState.fromEvent);
+      await _methodChannel.invokeMethod<void>(
+        'setupRadiance',
+        await radianceEnvironment(),
+      );
     }
     // _enabledApps starts as EnabledAppsSnapshot.empty() and is refreshed
     // lazily inside installedAppsStream / addSplitTunnelItem / etc.

--- a/macos/Runner/AppDelegate.swift
+++ b/macos/Runner/AppDelegate.swift
@@ -1,5 +1,4 @@
 import FlutterMacOS
-import Liblantern
 import OSLog
 import app_links
 
@@ -43,8 +42,6 @@ class AppDelegate: FlutterAppDelegate {
     }
 
     registerEventHandlers(controller: controller)
-
-    setupRadiance()
 
     // Setup native method channel
     setupMethodHandler(controller: controller)
@@ -104,30 +101,6 @@ class AppDelegate: FlutterAppDelegate {
       binaryMessenger: controller.engine.binaryMessenger
     )
     methodHandler = MethodHandler(channel: nativeChannel, vpnManager: vpnManager)
-  }
-
-  /// Calls API handler setup
-  private func setupRadiance() {
-    let startupTime = Date()
-    let opts = UtilsOpts()
-    opts.dataDir = FilePath.dataDirectory.relativePath
-    opts.logDir = FilePath.logsDirectory.relativePath
-    opts.deviceid = ""
-    opts.logLevel = "trace"
-    opts.telemetryConsent = FilePath.isTelemetryEnabled()
-    opts.env = FilePath.isRadianceEnv()
-    opts.locale = Locale.current.identifier
-    appLogger.info(
-      "logging to \(opts.logDir) dataDir: \(opts.dataDir) logLevel: \(opts.logLevel) telemetryConsent: \(opts.telemetryConsent) locale: \(opts.locale)"
-    )
-    var error: NSError?
-    MobileSetupRadiance(opts, FlutterEventListener.shared, &error)
-    // Handle any error returned by the setup
-    if let error {
-      appLogger.error("Error while setting up radiance: \(error)")
-    } else {
-      appLogger.info("Radiance setup took \(Date().timeIntervalSince(startupTime)) seconds")
-    }
   }
 
 }

--- a/macos/Runner/Handlers/MethodHandler.swift
+++ b/macos/Runner/Handlers/MethodHandler.swift
@@ -15,6 +15,7 @@ class MethodHandler {
 
   private var channel: FlutterMethodChannel
   private var vpnManager: VPNManager
+  private var isRadianceReady = false
 
   init(channel: FlutterMethodChannel, vpnManager: VPNManager = VPNManager.shared) {
     self.channel = channel
@@ -28,6 +29,15 @@ class MethodHandler {
       guard let self = self else { return }
 
       switch call.method {
+      case "setupRadiance":
+        guard
+          let environment: String = self.decodeValue(
+            from: call.arguments,
+            result: result
+          )
+        else { return }
+        self.setupRadiance(environment: environment, result: result)
+
       case "startVPN":
         self.startVPN(result: result)
 
@@ -381,6 +391,63 @@ class MethodHandler {
         result(FlutterMethodNotImplemented)
       }
     }
+  }
+
+  private func setupRadiance(environment: String, result: @escaping FlutterResult) {
+    guard environment == "prod" || environment == "stage" else {
+      result(
+        FlutterError(
+          code: "INVALID_ENVIRONMENT",
+          message: "Radiance environment must be prod or stage",
+          details: environment
+        )
+      )
+      return
+    }
+    guard !isRadianceReady else {
+      result(nil)
+      return
+    }
+
+    let startupTime = Date()
+    let opts = UtilsOpts()
+    opts.dataDir = FilePath.dataDirectory.relativePath
+    opts.logDir = FilePath.logsDirectory.relativePath
+    opts.deviceid = ""
+    opts.logLevel = "trace"
+    opts.telemetryConsent = FilePath.isTelemetryEnabled()
+    opts.env = environment
+    opts.locale = Locale.current.identifier
+    appLogger.info(
+      "Setting up Radiance in \(environment), logging to \(opts.logDir), dataDir: \(opts.dataDir), telemetryConsent: \(opts.telemetryConsent), locale: \(opts.locale)"
+    )
+
+    var error: NSError?
+    let success = MobileSetupRadiance(opts, FlutterEventListener.shared, &error)
+    if let error {
+      result(
+        FlutterError(
+          code: "RADIANCE_SETUP_FAILED",
+          message: error.localizedDescription,
+          details: error.debugDescription
+        )
+      )
+      return
+    }
+    guard success else {
+      result(
+        FlutterError(
+          code: "RADIANCE_SETUP_FAILED",
+          message: "Radiance setup did not complete",
+          details: nil
+        )
+      )
+      return
+    }
+
+    isRadianceReady = true
+    appLogger.info("Radiance setup took \(Date().timeIntervalSince(startupTime)) seconds")
+    result(nil)
   }
 
   private func startVPN(result: @escaping FlutterResult) {

--- a/macos/Shared/FilePath.swift
+++ b/macos/Shared/FilePath.swift
@@ -64,16 +64,6 @@ public enum FilePath {
     return FileManager.default.fileExists(atPath: marker.path)
   }
 
-  public static func isRadianceEnv() -> String {
-    let marker = appSupportDir()
-      .appendingPathComponent(".radiance_env")
-
-    if FileManager.default.fileExists(atPath: marker.path) {
-      return "stage"
-    }
-    return "prod"
-  }
-
 }
 
 extension FilePath {

--- a/test/core/utils/radiance_environment_test.dart
+++ b/test/core/utils/radiance_environment_test.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/utils/radiance_environment.dart';
+
+void main() {
+  test('normalizes supported Radiance environments', () {
+    expect(normalizeRadianceEnvironment('prod'), 'prod');
+    expect(normalizeRadianceEnvironment('staging'), 'stage');
+    expect(normalizeRadianceEnvironment(' STAGING '), 'stage');
+  });
+
+  test('rejects unsupported Radiance environments', () {
+    expect(() => normalizeRadianceEnvironment('stage'), throwsArgumentError);
+  });
+}


### PR DESCRIPTION
Resolves https://github.com/getlantern/engineering/issues/3723

Install and launch Lantern as a Windows user, verify per-user WebView2 storage, and confirm Stripe and Shepherd checkout pages render without navigation errors. Upload complete diagnostics on every run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Windows nightly “payment checkout smoke” support with workflow toggle, artifact publishing, and end-to-end bootstrapping via command-line arguments.
  * Added configurable smoke flow entry in the app that selects an eligible plan and routes directly to payment method.
* **Bug Fixes**
  * Improved Windows smoke automation element lookup and adjusted checkout document polling/error timing.
  * Enhanced webview smoke logging, document length capture, and main-frame error reporting with safer redaction.
  * Refined accessibility semantics for payment method and subscribe/checkout actions.
* **Tests**
  * Added unit tests covering payment checkout smoke argument parsing and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->