### PR TITLE
deps: bump radiance for the client-info stall fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260722205654-838849783d37
+	github.com/getlantern/radiance v0.0.0-20260724234937-eea72f0e9ce8
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -171,12 +171,12 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04 // indirect
-	github.com/getlantern/lantern-box v0.0.104 // indirect
+	github.com/getlantern/lantern-box v0.0.106 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b // indirect
-	github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf // indirect
+	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 // indirect
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb // indirect
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04 h1:YaN1rTKlpkREh9GQIJ8sLnZDt2brzzAhpd+nqmr2Iss=
 github.com/getlantern/kindling v0.0.0-20260722205227-8563bcdd9b04/go.mod h1:Mej4MXda67EuL+kM6k4xcgxysWarkYjR5XPcNr8oYUI=
-github.com/getlantern/lantern-box v0.0.104 h1:ASLpYelmYUnY/bgDXH+UKiIex1Pme/Zg9YtDY6qQThk=
-github.com/getlantern/lantern-box v0.0.104/go.mod h1:xrH8ZziXLy1pYN94cfHenczjVwUVcuuUzJWb9lY8duw=
+github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
+github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
@@ -259,10 +259,10 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260722205654-838849783d37 h1:Fzn1UupMGhx2lLJCYjLQ0/eOP7z62EpYV/XfLPNpF88=
-github.com/getlantern/radiance v0.0.0-20260722205654-838849783d37/go.mod h1:3ioylshJuvd1dJEUydJvIWjSXllphapzDk8HQgiyPnc=
-github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf h1:KxiMF+oG0rTtuBi7GiIaHfccYOf69rLJ/VnO5myoYc4=
-github.com/getlantern/samizdat v0.0.3-0.20260529191731-5ea8ae61ddbf/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
+github.com/getlantern/radiance v0.0.0-20260724234937-eea72f0e9ce8 h1:QRmw4IAlJrEtssjG71LJokHNxJ8ulcafWQd2XjS9aLM=
+github.com/getlantern/radiance v0.0.0-20260724234937-eea72f0e9ce8/go.mod h1:cPGmIwXSIwbWlgIV0SZUCcsefEY+sB0J8jQ1QMkLi1k=
+github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
+github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
Final hop of the client-info-stall fix propagation. Bumps `github.com/getlantern/radiance` → `eea72f0`, cascading `lantern-box` `v0.0.104`→`v0.0.106` and `samizdat` → `a5ee9ab` (both indirect).

## The full chain (now complete to the client)

- **[getlantern/samizdat#14](https://github.com/getlantern/samizdat/pull/14)** — `streamConn`'s read deadline now actually interrupts a blocked HTTP/2 stream read.
- **[getlantern/lantern-box#291](https://github.com/getlantern/lantern-box/pull/291)** — bounds the post-handshake client-info `OK` exchange with a read deadline; fixes the TCP short-read / UDP short-buffer teardowns.
- **[getlantern/radiance#578](https://github.com/getlantern/radiance/pull/578)** — bumped lantern-box to v0.0.106.
- **this PR** — brings it into the client.

## Why it matters

A proxy that completes the handshake and then goes silent — the Rostelecom / DPI-throttling failure mode in Russia (Freshdesk #180563, engineering#3726) — previously held the flow and its slot in the healthy-outbound pool for 10+ minutes. It now fails in ~10s, so `MutableAutoSelect` moves to the next candidate an order of magnitude faster.

## Verification

- `go.mod`/`go.sum` only; `go mod tidy` clean; `sing-box-minimal` replace unchanged.
- **Resolved versions confirmed via `go list -m`**: `lantern-box v0.0.106`, `samizdat a5ee9ab` — matching `go.mod`, with **no stale older entries left in `go.sum`** (the trap that silently compiled old lantern-box into the April release binary).
- `go mod verify` passes; `go build ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependency versions for improved compatibility and maintenance.
  * No user-facing features or behavior changes were introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->