### PR TITLE
deps: bump radiance for build stamping + jsDelivr config mirror

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,7 +80,10 @@ BUILD_TIME := $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "[D
 else
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 endif
-GIT_REVISION := $(shell git rev-parse --short=7 HEAD)
+## Fall back to a sentinel so common.Commit is never empty (e.g. a build from a
+## source tree with no .git); an empty -X value would drop the build-identity
+## signal from logs.
+GIT_REVISION := $(or $(strip $(shell git rev-parse --short=7 HEAD)),unknown)
 EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)' -X '$(RADIANCE_REPO)/common.BuildTime=$(BUILD_TIME)' -X '$(RADIANCE_REPO)/common.Commit=$(GIT_REVISION)'
 STEALTH_GO_IMPORT_PATH := github.com/getlantern/lantern/lantern-core
 STEALTH_GO_LOG_LEVEL ?= warn

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,12 @@ APP_VERSION_PUBSPEC := $(firstword $(subst +, ,$(APP_VERSION)))
 ifeq ($(strip $(APP_VERSION_PUBSPEC)),)
 $(error APP_VERSION_PUBSPEC is empty; export APP_VERSION (e.g. "9.0.25+459") or ensure pubspec.yaml contains a `version:` line)
 endif
-EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)'
+## Stamp build time + commit (radiance logs them at startup in every build, so a
+## shipped binary is self-describing). `:=` so one make invocation stamps one
+## consistent value across all artifacts it builds.
+BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+GIT_REVISION := $(shell git rev-parse --short HEAD)
+EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)' -X '$(RADIANCE_REPO)/common.BuildTime=$(BUILD_TIME)' -X '$(RADIANCE_REPO)/common.Commit=$(GIT_REVISION)'
 STEALTH_GO_IMPORT_PATH := github.com/getlantern/lantern/lantern-core
 STEALTH_GO_LOG_LEVEL ?= warn
 # Stealth can be activated via a stealth BUILD_TYPE or via STEALTH_MODE/STEALTH_PROFILE

--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,12 @@ endif
 ## Stamp build time + commit (radiance logs them at startup in every build, so a
 ## shipped binary is self-describing). `:=` so one make invocation stamps one
 ## consistent value across all artifacts it builds.
+ifeq ($(OS),Windows_NT)
+BUILD_TIME := $(shell powershell -NoProfile -ExecutionPolicy Bypass -Command "[DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')")
+else
 BUILD_TIME := $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
-GIT_REVISION := $(shell git rev-parse --short HEAD)
+endif
+GIT_REVISION := $(shell git rev-parse --short=7 HEAD)
 EXTRA_LDFLAGS ?= -X '$(RADIANCE_REPO)/common.Version=$(APP_VERSION_PUBSPEC)' -X '$(RADIANCE_REPO)/common.BuildTime=$(BUILD_TIME)' -X '$(RADIANCE_REPO)/common.Commit=$(GIT_REVISION)'
 STEALTH_GO_IMPORT_PATH := github.com/getlantern/lantern/lantern-core
 STEALTH_GO_LOG_LEVEL ?= warn

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260724234937-eea72f0e9ce8
+	github.com/getlantern/radiance v0.0.0-20260725142156-584a0568abac
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260724234937-eea72f0e9ce8 h1:QRmw4IAlJrEtssjG71LJokHNxJ8ulcafWQd2XjS9aLM=
-github.com/getlantern/radiance v0.0.0-20260724234937-eea72f0e9ce8/go.mod h1:cPGmIwXSIwbWlgIV0SZUCcsefEY+sB0J8jQ1QMkLi1k=
+github.com/getlantern/radiance v0.0.0-20260725142156-584a0568abac h1:bDCAYj1LF8pYWn6WRKEKFlfcElhXZe/D0zHKupiBfK8=
+github.com/getlantern/radiance v0.0.0-20260725142156-584a0568abac/go.mod h1:cPGmIwXSIwbWlgIV0SZUCcsefEY+sB0J8jQ1QMkLi1k=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## What
- Bump radiance `eea72f0` → `584a056` (latest main), picking up:
  - **radiance#556** — stamp build time + commit; log build identity and the linked versions of every `getlantern/*` dep (plus sing-box) at Info in every build, with `replace` directives surfaced. A shipped binary is now self-describing in logs.
  - **radiance#575** — race a jsDelivr mirror for `fronted.yaml.gz`; `raw.githubusercontent.com` is blocked in China, and jsDelivr is served from a non-getlantern mirror account since jsDelivr bans the getlantern org.
- Makefile: inject the new `common.BuildTime` (UTC RFC3339) and `common.Commit` (short rev) ldflags — the lantern-side half of radiance#556. Verified the resolved flags:
  ```
  -X '...common.Version=9.1.18-13f9212-20260725T142515Z' -X '...common.BuildTime=2026-07-25T14:25:15Z' -X '...common.Commit=13f92127f'
  ```

## Why
A 9.1.14 iOS TestFlight build shipped a pre-fix keepcurrent despite go.mod declaring the fixed version, and nothing in the logs revealed it. With this bump every build logs what was actually linked, so a stale-cache build is visible in the first lines of any user log instead of silent.

`go mod tidy` run; go.mod and go.sum committed together.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Build artifacts now include build timestamp and source revision metadata alongside the application version, improving release traceability.
  * Updated the Radiance library dependency to a newer revision.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->