### PR TITLE
models: parse both shapes of user_failures

### DIFF
--- a/lib/core/models/available_servers.dart
+++ b/lib/core/models/available_servers.dart
@@ -258,7 +258,8 @@ class SelectionHistory {
         consecutiveFailures: json["consecutive_failures"] ?? 0,
         userFailures:
             (json["user_failures"] as List<dynamic>?)
-                ?.map((e) => DateTime.parse(e as String))
+                ?.map(_userFailureAt)
+                .whereType<DateTime>()
                 .toList() ??
             const [],
         updatedAt: json["updated_at"] == null
@@ -266,11 +267,27 @@ class SelectionHistory {
             : DateTime.parse(json["updated_at"]),
       );
 
+  /// Timestamp of one `user_failures` entry, or null if it has none we can
+  /// read. lantern-box v0.0.104 changed each entry from a bare RFC3339 string
+  /// to a `{"at": ..., "kind": ...}` object; both are accepted so this parses
+  /// against either version, matching Go's `UserFailure.UnmarshalJSON`.
+  /// Unreadable entries are dropped rather than thrown on: one entry in the
+  /// shape this side didn't expect used to fail `Server.fromJson`, and since
+  /// `AvailableServers.fromJson` maps over the whole list, that cost the client
+  /// every server it had. `kind` is dropped too — nothing here reads it.
+  static DateTime? _userFailureAt(dynamic entry) {
+    final at = entry is Map ? entry["at"] : entry;
+    return at is String ? DateTime.tryParse(at) : null;
+  }
+
   Map<String, dynamic> toJson() => {
     "last_success_delay_ms": lastSuccessDelayMs,
     if (lastOutcomeAt != null)
       "last_outcome_at": lastOutcomeAt!.toIso8601String(),
     "consecutive_failures": consecutiveFailures,
+    // Bare timestamps, i.e. the pre-v0.0.104 shape, which Go still accepts.
+    // Nothing sends this back to Go today; emitting the object form would mean
+    // inventing a `kind` we never parsed.
     if (userFailures.isNotEmpty)
       "user_failures": userFailures.map((e) => e.toIso8601String()).toList(),
     if (updatedAt != null) "updated_at": updatedAt!.toIso8601String(),

--- a/test/core/models/available_servers_test.dart
+++ b/test/core/models/available_servers_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lantern/core/models/available_servers.dart';
 
@@ -259,7 +261,143 @@ void main() {
       expect(s.shouldWarnBeforeManualSelection, isFalse);
     });
   });
+
+  group('user_failures deserialization', () {
+    // lantern-box v0.0.104 changed each entry from a bare RFC3339 timestamp to
+    // a {"at": ..., "kind": ...} object. Both have to parse: the object form is
+    // what current lantern-box sends, the string form is what a client paired
+    // with a pre-v0.0.104 one would see.
+    test('parses the object form', () {
+      final history = SelectionHistory.fromJson({
+        'last_success_delay_ms': 2556,
+        'consecutive_failures': 2,
+        'user_failures': [
+          {'at': '2026-07-23T19:23:18.956396324+08:00', 'kind': 'unknown'},
+          {'at': '2026-07-23T19:24:11.696763492+08:00', 'kind': 'stall'},
+        ],
+        'updated_at': '2026-07-23T19:26:52.297493639+08:00',
+      });
+
+      expect(history.userFailures, [
+        DateTime.parse('2026-07-23T19:23:18.956396324+08:00'),
+        DateTime.parse('2026-07-23T19:24:11.696763492+08:00'),
+      ]);
+    });
+
+    test('parses an object form with no kind', () {
+      final history = SelectionHistory.fromJson({
+        'user_failures': [
+          {'at': '2026-07-06T12:00:00Z'},
+        ],
+      });
+
+      expect(history.userFailures, [DateTime.parse('2026-07-06T12:00:00Z')]);
+    });
+
+    test('parses the legacy bare-timestamp form', () {
+      final history = SelectionHistory.fromJson({
+        'user_failures': ['2026-07-06T12:00:00Z', '2026-07-06T12:01:00Z'],
+      });
+
+      expect(history.userFailures, [
+        DateTime.parse('2026-07-06T12:00:00Z'),
+        DateTime.parse('2026-07-06T12:01:00Z'),
+      ]);
+    });
+
+    test('parses a window holding both forms at once', () {
+      final history = SelectionHistory.fromJson({
+        'user_failures': [
+          '2026-07-06T12:00:00Z',
+          {'at': '2026-07-06T12:01:00Z', 'kind': 'reset'},
+        ],
+      });
+
+      expect(history.userFailures, [
+        DateTime.parse('2026-07-06T12:00:00Z'),
+        DateTime.parse('2026-07-06T12:01:00Z'),
+      ]);
+    });
+
+    test('an absent window parses as empty', () {
+      expect(SelectionHistory.fromJson({}).userFailures, isEmpty);
+    });
+
+    // A window this side can't read must cost us the entries, not the server.
+    test('drops entries with no readable timestamp', () {
+      final history = SelectionHistory.fromJson({
+        'user_failures': [
+          {'kind': 'stall'},
+          {'at': null},
+          {'at': 1752580800},
+          'the beginning of time',
+          42,
+          null,
+          {'at': '2026-07-06T12:00:00Z', 'kind': 'stall'},
+        ],
+      });
+
+      expect(history.userFailures, [DateTime.parse('2026-07-06T12:00:00Z')]);
+    });
+
+    // Freshdesk #180591: a single server carrying the object form threw during
+    // Server.fromJson, and because AvailableServers.fromJson maps over the
+    // whole list, that one entry took down all 55 servers — leaving the client
+    // with no server list at all.
+    test('parses a list where only one server carries user_failures', () {
+      final servers = AvailableServers.fromJson(
+        _payload([
+          _serverJson(tag: 'no-failures'),
+          _serverJson(
+            tag: 'has-failures',
+            userFailures: [
+              {'at': '2026-07-23T19:23:18.956396324+08:00', 'kind': 'unknown'},
+            ],
+          ),
+        ]),
+      );
+
+      expect(servers.servers.map((s) => s.tag), [
+        'no-failures',
+        'has-failures',
+      ]);
+      expect(
+        servers.serverByTag('has-failures')!.selectionHistory!.userFailures,
+        hasLength(1),
+      );
+    });
+  });
 }
+
+/// Round-trips through JSON so element types match what the platform channel
+/// hands us — `List<dynamic>` of `Map<String, dynamic>`, nested maps likewise —
+/// rather than the sharper literal types the analyzer infers here.
+List<dynamic> _payload(List<Map<String, dynamic>> servers) =>
+    jsonDecode(jsonEncode(servers)) as List<dynamic>;
+
+/// One server as it looks after `jsonDecode` of the payload radiance sends.
+Map<String, dynamic> _serverJson({
+  required String tag,
+  List<Map<String, dynamic>>? userFailures,
+}) => {
+  'tag': tag,
+  'type': 'samizdat',
+  'isLantern': true,
+  'outbound': {'type': 'samizdat', 'tag': tag, 'server': '203.0.113.7'},
+  'location': {
+    'country': 'U.S.A.',
+    'city': 'Chicago',
+    'country_code': 'US',
+    'latitude': 41.8781,
+    'longitude': -87.6298,
+  },
+  'selection_history': {
+    'last_success_delay_ms': 1264,
+    'last_outcome_at': '2026-07-23T19:26:51.648896087+08:00',
+    'user_failures': ?userFailures,
+    'updated_at': '2026-07-23T19:26:51.648896087+08:00',
+  },
+};
 
 Server _server({
   required String tag,


### PR DESCRIPTION
## What's wrong

lantern-box [#286](https://github.com/getlantern/lantern-box/pull/286) (`b2c28bb`, 2026-07-09, first tagged **v0.0.101**) changed `TagHistory.UserFailures` from `[]time.Time` to `[]UserFailure`:

```go
// v0.0.100 — adapter/autoselect_history.go:31
UserFailures []time.Time    `json:"user_failures,omitempty"`
// v0.0.101 — adapter/autoselect_history.go:81
UserFailures []UserFailure  `json:"user_failures,omitempty"`   // {"at": ..., "kind": ...}
```

So `user_failures` went from `["2026-07-06T12:00:00Z"]` to `[{"at":"2026-07-06T12:00:00Z","kind":"stall"}]`. Go got back-compat for its own reads (`UserFailure.UnmarshalJSON` accepts both forms) — the Dart consumer didn't, and nothing tests the cross-language contract. `available_servers.dart:261` still did `DateTime.parse(e as String)`.

`AvailableServers.fromJson` maps over the whole list with no per-entry isolation, so **one** server carrying a recorded user failure throws out of the entire parse and the client is left with no server list at all.

## How it reached users

The Dart cast came first and was correct when written — `fc84cbe45` (#8833, 2026-06-18) added `user_failures` parsing three weeks before the Go side changed shape.

What broke it was the dep bump: **`6d2c05c8b` ([#8912](https://github.com/getlantern/lantern/pull/8912), 2026-07-17)** moved lantern-box v0.0.100 → v0.0.103, crossing the v0.0.101 boundary. It touched `go.mod` and `go.sum` and nothing else — zero Dart files — which is exactly why nobody noticed: the breaking change is invisible in the diff, and no test covers the Go↔Dart contract.

| release | lantern-box | parses? |
|---|---|---|
| v9.1.15-beta2 (07-13) | v0.0.100 | ✅ |
| v9.1.16-beta (07-17) | v0.0.104 | ❌ |
| v9.1.17-beta (07-22) | v0.0.104 | ❌ |

So **9.1.16 is affected too**, not just 9.1.17. The ticket only shows 9.1.17 because that user's upgrade history goes 9.1.15 → 9.1.17 — they skipped 9.1.16 entirely.

```mermaid
sequenceDiagram
    autonumber
    participant UI as VPN screen<br/>available_servers_notifier.dart
    participant Svc as platform service<br/>lantern_platform_service.dart
    participant LB as lantern-box v0.0.104<br/>adapter/autoselect_history.go
    participant Model as model<br/>available_servers.dart

    Note over LB: autoselect_history.go:81 ⚠️<br/>UserFailures is []UserFailure<br/>(was []time.Time in v0.0.100)
    UI->>Svc: available_servers_notifier.dart:37<br/>getLanternAvailableServers()
    Svc->>LB: lantern_platform_service.dart:1436<br/>MethodChannel getLanternAvailableServers
    LB-->>Svc: JSON string — user_failures entries<br/>are now objects (at + kind)
    Svc->>Model: lantern_platform_service.dart:1439<br/>AvailableServers.fromJson(jsonDecode(result))
    Model->>Model: available_servers.dart:6<br/>map over all 55 servers, no per-entry isolation
    Model->>Model: available_servers.dart:138<br/>SelectionHistory.fromJson(selection_history)
    rect rgba(255, 200, 200, 0.3)
        Note over Model: available_servers.dart:261 🐛<br/>DateTime.parse(e as String)<br/>the entry is a Map, not a String
    end
    Model-->>Svc: throws — _Map is not a subtype of String in type cast
    Svc-->>UI: lantern_platform_service.dart:1446<br/>Left(Failure) — all 55 servers lost
    Note over UI: available_servers_notifier.dart:46<br/>logs and returns, so state stays stale<br/>(build() at :25 throws outright)
```

## Evidence

[Freshdesk #180591](https://lantern.freshdesk.com/a/tickets/180591) — China, Android, 9.1.17. From that user's `flutter.log`:

- 9.1.17 first appears at `11:28:11.225`; the first parse failure is at `11:29:43.937` — **92 seconds later**, as soon as radiance recorded its first user-traffic failure.
- 339 occurrences of `type '_Map<String, dynamic>' is not a subtype of type 'String' in type cast`, from `11:29:43` through `16:35:40`, with the stack trace naming `available_servers.dart:261`.
- 2329 `Servers JSON: [` lines, all well-formed — the payload was fine, only the parse wasn't.

Downstream: 130 `updateServerLocation: type=auto`, 58 "falling back to auto", ~23 churned tags. The UI can't learn which servers exist, so it keeps re-resolving against a stale list.

**Why this escaped testing:** `user_failures` is `omitempty`, so a fresh upgrade parses fine; and `defaultUserFailureWindow` is 5 minutes, so the window empties again after five failure-free minutes. On a clean network the bug is invisible. In China it never clears.

## Reproduction

The model has no imports beyond `dart:core`, so it runs standalone against the payload the ticket's log captured verbatim (55 servers, 2 carrying `user_failures`):

```
A  v0.0.104 shape (as shipped in 9.1.17)
    THREW — type '_Map<String, dynamic>' is not a subtype of type 'String' in type cast
B  v0.0.100 shape (list of timestamp strings)
    OK — parsed 55 servers, 33 locations
C  no user_failures recorded yet
    OK — parsed 55 servers, 33 locations
```

Mutating only `user_failures` flips the outcome, which is what makes the dependency bump causal rather than correlated. One poisoned server out of 55 is enough.

## The fix

Accept both shapes, and drop entries we can't read instead of throwing:

```dart
static DateTime? _userFailureAt(dynamic entry) {
  final at = entry is Map ? entry["at"] : entry;
  return at is String ? DateTime.tryParse(at) : null;
}
```

`entry is Map` rather than `Map<String, dynamic>` on purpose — this has to hold if the payload ever arrives via `StandardMessageCodec` rather than `jsonDecode`, which yields `Map<Object?, Object?>`.

Dropping rather than throwing is the load-bearing half. `userFailures` has **no readers** anywhere in `lib/` — it is parsed, defaulted, and re-serialized, nothing else. A field nobody consumes should not be able to cost the client its server list, whatever shape a future lantern-box gives it.

## Tests

This model had **zero** `fromJson` coverage before now. Seven new tests; **five fail without the fix**:

| test | fails pre-fix |
|---|---|
| parses the object form | ✅ |
| parses an object form with no kind | ✅ |
| parses a window holding both forms at once | ✅ |
| drops entries with no readable timestamp | ✅ |
| parses a list where only one server carries user_failures | ✅ |
| parses the legacy bare-timestamp form | — (guards against over-correcting) |
| an absent window parses as empty | — (guards the `omitempty` path) |

The list-level test round-trips its fixture through `jsonEncode`/`jsonDecode` so element types match the platform channel's, and pre-fix it reproduces the ticket's error string exactly: `type '_Map<String, dynamic>' is not a subtype of type 'String' in type cast`.

## Deliberately out of scope

- **Per-entry isolation in `AvailableServers.fromJson:6`.** One bad server still takes down the list for any *other* parse failure. Worth fixing, but it's a behavior change (partial lists) that deserves its own review.
- **`last_outcome_at` / `updated_at` are never null.** Go's `omitempty` doesn't apply to structs, so a zero `time.Time` marshals as `0001-01-01T00:00:00Z`. The `json[...] == null ? null : ...` guards are dead code and `toJson`'s `if (lastOutcomeAt != null)` never trips.
- **A test that actually pins the Go↔Dart contract.** Nothing here catches the next shape change on the Go side; that needs a fixture generated from lantern-box.

## Note

`test/widget_test.dart` ("Counter increments smoke test") fails on `origin/main` as well — verified by stashing these two files and re-running. Pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
