### PR TITLE
models: correct the lantern-box version in user_failures comments

### DIFF
--- a/lib/core/models/available_servers.dart
+++ b/lib/core/models/available_servers.dart
@@ -268,7 +268,7 @@ class SelectionHistory {
       );
 
   /// Timestamp of one `user_failures` entry, or null if it has none we can
-  /// read. lantern-box v0.0.104 changed each entry from a bare RFC3339 string
+  /// read. lantern-box v0.0.101 changed each entry from a bare RFC3339 string
   /// to a `{"at": ..., "kind": ...}` object; both are accepted so this parses
   /// against either version, matching Go's `UserFailure.UnmarshalJSON`.
   /// Unreadable entries are dropped rather than thrown on: one entry in the
@@ -285,7 +285,7 @@ class SelectionHistory {
     if (lastOutcomeAt != null)
       "last_outcome_at": lastOutcomeAt!.toIso8601String(),
     "consecutive_failures": consecutiveFailures,
-    // Bare timestamps, i.e. the pre-v0.0.104 shape, which Go still accepts.
+    // Bare timestamps, i.e. the pre-v0.0.101 shape, which Go still accepts.
     // Nothing sends this back to Go today; emitting the object form would mean
     // inventing a `kind` we never parsed.
     if (userFailures.isNotEmpty)

--- a/test/core/models/available_servers_test.dart
+++ b/test/core/models/available_servers_test.dart
@@ -263,10 +263,10 @@ void main() {
   });
 
   group('user_failures deserialization', () {
-    // lantern-box v0.0.104 changed each entry from a bare RFC3339 timestamp to
+    // lantern-box v0.0.101 changed each entry from a bare RFC3339 timestamp to
     // a {"at": ..., "kind": ...} object. Both have to parse: the object form is
     // what current lantern-box sends, the string form is what a client paired
-    // with a pre-v0.0.104 one would see.
+    // with a pre-v0.0.101 one would see.
     test('parses the object form', () {
       final history = SelectionHistory.fromJson({
         'last_success_delay_ms': 2556,


### PR DESCRIPTION
Follow-up to #8929. Comments only — no behavior change.

The comments I added in #8929 name **v0.0.104** as the lantern-box release that changed each `user_failures` entry from a bare RFC3339 string to a `{"at", "kind"}` object. Wrong: v0.0.104 was just the edge of the module cache I sampled. Verified against the actual tags:

| lantern-box | `TagHistory.UserFailures` |
|---|---|
| v0.0.99, v0.0.100 | `[]time.Time` |
| **v0.0.101** … v0.0.106 | `[]UserFailure` |

```
$ for v in v0.0.99 v0.0.100 v0.0.101 v0.0.104 v0.0.106; do
    printf '%-10s ' "$v"; git show "${v}:adapter/autoselect_history.go" | grep -E 'UserFailures\s+\[\]'
  done
v0.0.99     UserFailures []time.Time   `json:"user_failures,omitempty"`
v0.0.100    UserFailures []time.Time   `json:"user_failures,omitempty"`
v0.0.101    UserFailures []UserFailure `json:"user_failures,omitempty"`
v0.0.104    UserFailures []UserFailure `json:"user_failures,omitempty"`
v0.0.106    UserFailures []UserFailure `json:"user_failures,omitempty"`
```

The change is lantern-box [#286](https://github.com/getlantern/lantern-box/pull/286) (`b2c28bb`, 2026-07-09), first tagged **v0.0.101**.

The whole job of these comments is to send a future reader to the version where the shape changed, so an off-by-three defeats their only purpose. #8929's description was corrected before merge; the comments and its commit message weren't. The commit message is immutable now — this fixes the code.

Four occurrences, all in comments:

- `lib/core/models/available_servers.dart` — the `_userFailureAt` doc comment, and the `toJson` note about the pre-change shape
- `test/core/models/available_servers_test.dart` — the `user_failures deserialization` group preamble (2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected version references for supported `user_failures` timestamp formats.
  - Clarified that both bare RFC3339 timestamps and object-form timestamps remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->