### PR TITLE
referral: await the reward dialog before marking referrals seen

### DIFF
--- a/lib/features/setting/referral_reward_dialog.dart
+++ b/lib/features/setting/referral_reward_dialog.dart
@@ -41,7 +41,7 @@ Future<void> checkAndShowReferralReward(
   if (!context.mounted) return;
   _rewardDialogVisible = true;
   try {
-    _showReferralRewardDialog(
+    await _showReferralRewardDialog(
       context: context,
       newMonths: newMonths,
       totalMonths: totalMonths,

--- a/test/features/setting/referral_reward_dialog_test.dart
+++ b/test/features/setting/referral_reward_dialog_test.dart
@@ -27,12 +27,15 @@ class _RecordingStorage implements LocalStorageService {
 void main() {
   late _RecordingStorage storage;
 
-  setUp(() {
+  setUp(() async {
+    await sl.reset();
     storage = _RecordingStorage();
     sl.registerSingleton<LocalStorageService>(storage);
   });
 
-  tearDown(() => sl.reset());
+  tearDown(() async {
+    await sl.reset();
+  });
 
   final user = UserResponseModel.fromJson({
     'legacyID': 1,

--- a/test/features/setting/referral_reward_dialog_test.dart
+++ b/test/features/setting/referral_reward_dialog_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/common/app_theme.dart';
+import 'package:lantern/core/models/user.dart';
+import 'package:lantern/core/services/injection_container.dart';
+import 'package:lantern/core/services/local_storage_service.dart';
+import 'package:lantern/features/setting/referral_reward_dialog.dart';
+
+class _RecordingStorage implements LocalStorageService {
+  List<String> seen = const <String>[];
+  int saves = 0;
+
+  @override
+  List<String> getSeenConvertedReferrals() => seen;
+
+  @override
+  Future<void> saveSeenConvertedReferrals(List<String> userIds) async {
+    saves++;
+    seen = userIds;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+void main() {
+  late _RecordingStorage storage;
+
+  setUp(() {
+    storage = _RecordingStorage();
+    sl.registerSingleton<LocalStorageService>(storage);
+  });
+
+  tearDown(() => sl.reset());
+
+  final user = UserResponseModel.fromJson({
+    'legacyID': 1,
+    'legacyToken': 'token',
+    'emailConfirmed': true,
+    'success': true,
+    'legacyUserData': {
+      'referral': 'abc123',
+      'referrals': [
+        {'userId': 'friend', 'converted': true, 'bonusDaysEarned': 30},
+      ],
+    },
+  });
+
+  testWidgets('marks referrals seen only once the dialog is dismissed', (
+    tester,
+  ) async {
+    final navigatorKey = GlobalKey<NavigatorState>();
+    late BuildContext context;
+
+    await tester.pumpWidget(
+      ScreenUtilInit(
+        designSize: const Size(390, 844),
+        child: MaterialApp(
+          navigatorKey: navigatorKey,
+          theme: AppTheme.appTheme(),
+          home: Builder(
+            builder: (ctx) {
+              context = ctx;
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+
+    final pending = checkAndShowReferralReward(context, user);
+    await tester.pumpAndSettle();
+
+    expect(find.byIcon(Icons.redeem), findsOneWidget);
+    expect(
+      storage.saves,
+      0,
+      reason:
+          'persisting before dismissal loses the notification if the '
+          'dialog never reaches the user',
+    );
+
+    navigatorKey.currentState!.pop();
+    await tester.pumpAndSettle();
+    await pending;
+
+    expect(storage.saves, 1);
+    expect(storage.seen, <String>['friend']);
+  });
+}


### PR DESCRIPTION
## The bug

`checkAndShowReferralReward` calls `_showReferralRewardDialog` without `await`ing it.

`AppDialog.customDialog` returns `showDialog<void>(...)` (`lib/core/common/app_dialog.dart:181`), whose future completes **only when the route is popped**. Without the `await`, `checkAndShowReferralReward` fell straight through to the persist call — which sits directly under a comment claiming the opposite:

```dart
// referral_reward_dialog.dart:51-55  (before this PR)
// Persist only after the user dismisses the dialog. If the route cannot be
// shown or the app exits first, the notification is retried next time.
await storage.saveSeenConvertedReferrals(...);
```

The comment describes the intended contract. The code did not implement it.

```mermaid
sequenceDiagram
    autonumber
    participant Caller as checkAndShowReferralReward<br/>referral_reward_dialog.dart
    participant Dialog as _showReferralRewardDialog<br/>referral_reward_dialog.dart
    participant Nav as showDialog / Navigator<br/>app_dialog.dart
    participant Store as LocalStorageService<br/>local_storage_service.dart

    Caller->>Dialog: referral_reward_dialog.dart:44<br/>call (no await) 🐛
    Dialog->>Nav: app_dialog.dart:181<br/>showDialog(barrierDismissible: false)
    Nav-->>Dialog: Future — pending until the route is popped
    Dialog-->>Caller: Future — dropped on the floor
    rect rgba(255, 200, 200, 0.3)
        Caller->>Store: referral_reward_dialog.dart:53<br/>saveSeenConvertedReferrals — runs immediately ⚠️
        Note over Caller: referral_reward_dialog.dart:57<br/>finally clears _rewardDialogVisible<br/>while the dialog is still on screen ⚠️
    end
    Note over Nav: user finally taps Done →<br/>appRouter.pop() — nobody is listening
```

## Why it matters

- **The notification can be lost.** The dialog is deliberately once-per-referral: every converted referral is added to `seen_converted_referrals` and never shown again. Recording it before the user could have read it means a failed route push, or the app being killed while the dialog is up, silently burns the congratulation. The retry the comment promises never happens.
- **The re-entrancy guard is defeated.** `finally { _rewardDialogVisible = false; }` ran while the dialog was still visible, so a second `checkAndShowReferralReward` arriving in that window would stack another dialog on top.

## The fix

Add the `await`. One word.

Awaiting is safe here — it can't hang:

- Both dialog actions pop the route (`referral_reward_dialog.dart:96`, `:102`).
- `showProAccountFlowDialog` (`lib/core/utils/pro_utils.dart:44-48`) already awaits `AppDialog.customDialog` with the same `appRouter`-pop button pattern, so this is a proven combination in shipped code.

## Test

`test/features/setting/referral_reward_dialog_test.dart` pumps the dialog, asserts **nothing** was persisted while it is still on screen, then pops the route and asserts the referral is recorded exactly once.

Verified it's a real regression guard — reverting just the `await` fails it:

```
Expected: <0>
  Actual: <1>
persisting before dismissal loses the notification if the dialog never reaches the user
```

Full suite green: `flutter test` → `115 tests passed`. `dart format` and `flutter analyze` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Referral reward status is now saved only after the reward dialog is dismissed, preventing referrals from being marked as seen prematurely.
  * If the dialog flow does not complete, the referral can be shown again as expected.

* **Tests**
  * Added coverage verifying the timing and accuracy of referral reward status persistence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->