### PR TITLE
Refresh account state before AddEmail signup

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -718,6 +718,9 @@ msgstr "Error"
 msgid "signup_error_user_exists"
 msgstr "It looks like something went wrong with the sign-up. Please try again or sign in if you already have an account"
 
+msgid "use_a_different_account"
+msgstr "Use a different account"
+
 msgid "user_not_found"
 msgstr "User not recognized. Please check your credentials and try again. If you continue to experience issues, please reach out to our support team for assistance."
 
@@ -1718,4 +1721,3 @@ msgstr "Order Total"
 
 msgid "smart_routing_mode_description"
 msgstr "Smart Location picks the fastest server and switches automatically as it finds better routes."
-

--- a/integration_test/auth/auth_smoke_harness.dart
+++ b/integration_test/auth/auth_smoke_harness.dart
@@ -86,6 +86,11 @@ class _AuthSmokeFakeLanternService implements LanternService {
   bool forceLoginFailure = false;
   int deleteAccountCalls = 0;
 
+  @override
+  Future<Either<Failure, UserResponseModel>> fetchUserData() async {
+    return right(_emptyUser(success: true));
+  }
+
   void seedUser({
     required String email,
     required String password,

--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -243,7 +243,6 @@ func (lc *LanternCore) initialize(opts *utils.Opts, eventEmitter utils.FlutterEv
 	go lc.listenAutoSelectedEvents()
 	go lc.listenConfigEvents()
 	go lc.listenDataCapEvents()
-	go lc.fetchUserDataIfNeeded()
 
 	slog.Debug("LanternCore initialized successfully")
 	return nil
@@ -260,40 +259,6 @@ func (lc *LanternCore) notifyFlutter(event EventType, message string) {
 		Type:    string(event),
 		Message: message,
 	})
-}
-
-// fetchUserDataIfNeeded pulls fresh user data from the server at startup
-func (lc *LanternCore) fetchUserDataIfNeeded() {
-	raw := lc.settings()[settings.UserIDKey]
-	userID := userIDAsInt64(raw)
-	if userID == 0 {
-		slog.Debug("Skipping startup user-data fetch: no user ID set", "raw", raw)
-		return
-	}
-	if _, err := lc.client.FetchUserData(lc.ctx); err != nil {
-		slog.Error("Startup user-data fetch failed", "error", err)
-		return
-	}
-	slog.Debug("Startup user-data fetch succeeded", "userID", userID)
-}
-
-// userIDAsInt64 normalizes the radiance UserIDKey value across the storage
-// types it can have: int64 (in-process), float64 (after JSON IPC round-trip),
-// int (defensive), or a decimal string (mobile.go purchase flow). Returns 0
-// for any unrecognized type so the caller treats the user as anonymous.
-func userIDAsInt64(v any) int64 {
-	switch x := v.(type) {
-	case int64:
-		return x
-	case float64:
-		return int64(x)
-	case int:
-		return int64(x)
-	case string:
-		n, _ := strconv.ParseInt(x, 10, 64)
-		return n
-	}
-	return 0
 }
 
 // listenAutoSelectedEvents listens for auto-selected server changes from the IPC client and forwards

--- a/lib/core/keys/auth_keys.dart
+++ b/lib/core/keys/auth_keys.dart
@@ -23,6 +23,12 @@ class AuthKeys {
   static const signUpContinueWithoutEmailButton = ValueKey<String>(
     'auth.sign_up.email.continue_without_email_button',
   );
+  static const signUpUseDifferentAccountButton = ValueKey<String>(
+    'auth.sign_up.email.use_different_account_button',
+  );
+  static const signUpAccountRefreshRetryButton = ValueKey<String>(
+    'auth.sign_up.email.account_refresh_retry_button',
+  );
 
   static const confirmEmailCodeField = ValueKey<String>(
     'auth.confirm_email.code.field',

--- a/lib/features/auth/add_email.dart
+++ b/lib/features/auth/add_email.dart
@@ -10,6 +10,7 @@ import 'package:lantern/core/keys/app_keys.dart';
 import 'package:lantern/features/auth/provider/auth_notifier.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
+import 'package:loader_overlay/loader_overlay.dart';
 
 import 'package:lantern/features/home/provider/home_notifier.dart';
 
@@ -32,6 +33,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
   late final TextEditingController _emailController;
   bool _accountRefreshInProgress = true;
   Failure? _accountRefreshFailure;
+  VoidCallback? _hideActiveLoadingOverlay;
   TextTheme? textTheme;
 
   @override
@@ -43,10 +45,23 @@ class _AddEmailState extends ConsumerState<AddEmail> {
 
   @override
   void dispose() {
+    _hideLoadingDialog();
     _emailController
       ..removeListener(_onEmailChanged)
       ..dispose();
     super.dispose();
+  }
+
+  void _showLoadingDialog() {
+    final overlay = context.loaderOverlay;
+    overlay.show();
+    _hideActiveLoadingOverlay = overlay.hide;
+  }
+
+  void _hideLoadingDialog() {
+    final hide = _hideActiveLoadingOverlay;
+    _hideActiveLoadingOverlay = null;
+    hide?.call();
   }
 
   void _onEmailChanged() {
@@ -358,18 +373,18 @@ class _AddEmailState extends ConsumerState<AddEmail> {
       if (!_formKey.currentState!.validate()) {
         return;
       }
-      context.showLoadingDialog();
+      _showLoadingDialog();
       final refreshResult = await _refreshAccountState();
       if (!mounted) return;
 
       UserResponseModel? authoritativeUser;
       refreshResult.fold((_) {}, (user) => authoritativeUser = user);
       if (authoritativeUser == null) {
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         return;
       }
       final userData = authoritativeUser!.legacyUserData;
-      context.hideLoadingDialog();
+      _hideLoadingDialog();
 
       if (widget.authFlow == AuthFlow.changeEmail) {
         appLogger.debug('Starting change email flow');
@@ -394,7 +409,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
       appLogger.debug('Starting signup flow');
       await signupFlow(email);
     } catch (e) {
-      if (mounted) context.hideLoadingDialog();
+      _hideLoadingDialog();
       appLogger.error('Error in _handleContinue: $e');
       if (mounted) context.showSnackBar('an_error_occurred'.i18n);
     }
@@ -421,7 +436,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
   }
 
   Future<void> signupFlow(String email) async {
-    context.showLoadingDialog();
+    _showLoadingDialog();
     final tempPassword = generatePassword();
     final result = await ref
         .read(authProvider.notifier)
@@ -431,7 +446,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
     Failure? signupFailure;
     result.fold((failure) => signupFailure = failure, (_) {});
     if (signupFailure == null) {
-      context.hideLoadingDialog();
+      _hideLoadingDialog();
       await startForgotPasswordFlow(email, tempPassword);
       return;
     }
@@ -444,7 +459,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
       UserResponseModel? authoritativeUser;
       refreshResult.fold((_) {}, (user) => authoritativeUser = user);
       if (authoritativeUser == null) {
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         return;
       }
 
@@ -452,7 +467,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
       if (userData.unpassRegistered && userData.email.trim().isNotEmpty) {
         final backendEmail = userData.email.trim();
         _setEmail(backendEmail);
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         appLogger.info(
           'Signup conflicted after account registration; rerouting to password recovery',
         );
@@ -460,12 +475,12 @@ class _AddEmailState extends ConsumerState<AddEmail> {
         return;
       }
 
-      context.hideLoadingDialog();
+      _hideLoadingDialog();
       _showSignupConflictDialog(failure);
       return;
     }
 
-    context.hideLoadingDialog();
+    _hideLoadingDialog();
     AppDialog.errorDialog(
       context: context,
       title: 'error'.i18n,
@@ -514,26 +529,26 @@ class _AddEmailState extends ConsumerState<AddEmail> {
   }
 
   Future<void> _useDifferentAccount() async {
-    context.showLoadingDialog();
+    _showLoadingDialog();
     final refreshResult = await _refreshAccountState();
     if (!mounted) return;
 
     UserResponseModel? authoritativeUser;
     refreshResult.fold((_) {}, (user) => authoritativeUser = user);
     if (authoritativeUser == null) {
-      context.hideLoadingDialog();
+      _hideLoadingDialog();
       return;
     }
 
     final userData = authoritativeUser!.legacyUserData;
     if (!userData.unpassRegistered) {
-      context.hideLoadingDialog();
+      _hideLoadingDialog();
       _emailController.clear();
       return;
     }
     final backendEmail = userData.email.trim();
     if (backendEmail.isEmpty) {
-      context.hideLoadingDialog();
+      _hideLoadingDialog();
       _showInvalidRegisteredAccount();
       return;
     }
@@ -542,7 +557,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
     if (!mounted) return;
     result.fold(
       (failure) {
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         appLogger.error('Different-account rollover failed: ${failure.error}');
         context.showSnackBar(failure.localizedErrorMessage);
       },
@@ -550,7 +565,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
         ref.read(homeProvider.notifier).clearLogoutData();
         ref.read(homeProvider.notifier).updateUserData(newUser);
         _emailController.clear();
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         appLogger.info('Switched to a fresh anonymous account');
       },
     );
@@ -567,17 +582,17 @@ class _AddEmailState extends ConsumerState<AddEmail> {
     String email, [
     String? tempPassword,
   ]) async {
-    context.showLoadingDialog();
+    _showLoadingDialog();
     final result = await ref
         .read(authProvider.notifier)
         .startRecoveryByEmail(email);
     result.fold(
       (failure) {
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         context.showSnackBar(failure.localizedErrorMessage);
       },
       (_) {
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         navigateRoute(SignUpMethodType.email, email, tempPassword);
       },
     );
@@ -589,17 +604,17 @@ class _AddEmailState extends ConsumerState<AddEmail> {
   ) async {
     final token = result['token'];
     if (token != null) {
-      context.showLoadingDialog();
+      _showLoadingDialog();
       final result = await ref
           .read(authProvider.notifier)
           .oAuthLoginCallback(token);
       result.fold(
         (failure) {
-          context.hideLoadingDialog();
+          _hideLoadingDialog();
           context.showSnackBar(failure.localizedErrorMessage);
         },
         (response) {
-          context.hideLoadingDialog();
+          _hideLoadingDialog();
           ref.read(homeProvider.notifier).updateUserData(response);
           appLogger.debug(
             'OAuth login successful, for user email  ${response.legacyUserData.email}, userD ${response.legacyID}, updating app settings with token and provider: ${type.name}',
@@ -616,14 +631,14 @@ class _AddEmailState extends ConsumerState<AddEmail> {
 
   //Change Email flow
   Future<void> startChangeEmailFlow(String email) async {
-    context.showLoadingDialog();
+    _showLoadingDialog();
     final result = await ref
         .read(authProvider.notifier)
         .startChangeEmail(email, widget.password!);
 
     result.fold(
       (failure) {
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         AppDialog.errorDialog(
           context: context,
           title: 'error'.i18n,
@@ -631,7 +646,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
         );
       },
       (newEmail) {
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         appLogger.debug('Change email started successfully: $newEmail');
         navigateRoute(SignUpMethodType.email, email);
       },
@@ -682,10 +697,10 @@ class _AddEmailState extends ConsumerState<AddEmail> {
   void continueWithoutEmail() {
     showEmailDialog(() async {
       try {
-        context.showLoadingDialog();
+        _showLoadingDialog();
         await checkUserAccountStatus(ref, context);
         if (!mounted) return;
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         AppDialog.showLanternProDialog(
           context: context,
           onPressed: () {
@@ -694,7 +709,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
         );
       } catch (e) {
         if (!mounted) return;
-        context.hideLoadingDialog();
+        _hideLoadingDialog();
         appLogger.error('Error while continuing without email: $e');
         context.showSnackBar('error_occurred'.i18n);
       }

--- a/lib/features/auth/add_email.dart
+++ b/lib/features/auth/add_email.dart
@@ -1,18 +1,20 @@
 import 'package:auto_route/auto_route.dart';
 import 'package:auto_size_text/auto_size_text.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:fpdart/fpdart.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/models/user.dart';
 import 'package:lantern/core/widgets/oauth_login.dart';
 import 'package:lantern/core/keys/app_keys.dart';
 import 'package:lantern/features/auth/provider/auth_notifier.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
 
 import 'package:lantern/features/home/provider/home_notifier.dart';
 
 @RoutePage(name: 'AddEmail')
-class AddEmail extends StatefulHookConsumerWidget {
+class AddEmail extends ConsumerStatefulWidget {
   final AuthFlow authFlow;
 
   ///password will be used for change email flow
@@ -27,156 +29,285 @@ class AddEmail extends StatefulHookConsumerWidget {
 
 class _AddEmailState extends ConsumerState<AddEmail> {
   final _formKey = GlobalKey<FormState>();
+  late final TextEditingController _emailController;
+  bool _accountRefreshInProgress = true;
+  Failure? _accountRefreshFailure;
   TextTheme? textTheme;
 
   @override
+  void initState() {
+    super.initState();
+    _emailController = TextEditingController()..addListener(_onEmailChanged);
+    WidgetsBinding.instance.addPostFrameCallback((_) => _refreshOnEntry());
+  }
+
+  @override
+  void dispose() {
+    _emailController
+      ..removeListener(_onEmailChanged)
+      ..dispose();
+    super.dispose();
+  }
+
+  void _onEmailChanged() {
+    if (mounted) setState(() {});
+  }
+
+  void _setEmail(String email) {
+    if (_emailController.text == email) return;
+    _emailController.value = TextEditingValue(
+      text: email,
+      selection: TextSelection.collapsed(offset: email.length),
+    );
+  }
+
+  Future<void> _refreshOnEntry() async {
+    if (!mounted) return;
+    setState(() {
+      _accountRefreshInProgress = true;
+      _accountRefreshFailure = null;
+    });
+
+    // Do not race the provider's asynchronous cached-data build: a late build
+    // completion would otherwise overwrite the authoritative server result.
+    try {
+      await ref.read(homeProvider.future);
+    } catch (e) {
+      appLogger.warning(
+        'Cached account state was unavailable before server refresh: $e',
+      );
+    }
+    if (!mounted) return;
+    final cachedWasRegistered =
+        ref.read(homeProvider).value?.legacyUserData.unpassRegistered ?? false;
+
+    final result = await ref.read(homeProvider.notifier).fetchUserData();
+    if (!mounted) return;
+
+    result.fold(
+      (failure) {
+        setState(() {
+          _accountRefreshInProgress = false;
+          _accountRefreshFailure = failure;
+        });
+      },
+      (user) {
+        final userData = user.legacyUserData;
+        if (widget.authFlow != AuthFlow.changeEmail) {
+          if (userData.unpassRegistered && userData.email.isNotEmpty) {
+            _setEmail(userData.email);
+          } else if (cachedWasRegistered) {
+            _emailController.clear();
+          }
+        }
+        setState(() {
+          _accountRefreshInProgress = false;
+          _accountRefreshFailure = null;
+        });
+      },
+    );
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final emailController = useTextEditingController();
-    useListenable(emailController);
     final user = ref.watch(homeProvider).value;
     final isUserRegistered = user?.legacyUserData.unpassRegistered ?? false;
     final currentEmail = user?.legacyUserData.email ?? '';
     final isChangeEmailFlow = widget.authFlow == AuthFlow.changeEmail;
 
-    useEffect(() {
-      if (isUserRegistered && !isChangeEmailFlow) {
-        emailController.text = currentEmail;
-      }
-      return null;
-    }, [isUserRegistered, isChangeEmailFlow, currentEmail]);
+    if (isUserRegistered &&
+        !isChangeEmailFlow &&
+        currentEmail.isNotEmpty &&
+        _emailController.text != currentEmail) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (mounted) _setEmail(currentEmail);
+      });
+    }
 
     textTheme = Theme.of(context).textTheme;
+    final accountStateReady =
+        !_accountRefreshInProgress && _accountRefreshFailure == null;
     return EnterKeyShortcut(
       onEnter: () {
-        if (_canSubmitEmail(emailController.text, currentEmail)) {
-          onContinuePressed(
-            SignUpMethodType.email,
-            emailController.text,
-            isUserRegistered,
-            currentEmail,
-          );
+        if (accountStateReady &&
+            _canSubmitEmail(_emailController.text, currentEmail)) {
+          onContinuePressed(SignUpMethodType.email, currentEmail);
         }
       },
       child: BaseScreen(
         title: isChangeEmailFlow
             ? 'enter_new_email'.i18n
             : 'add_your_email'.i18n,
-        body: Form(
-          key: _formKey,
-          child: SingleChildScrollView(
-            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                AppTextField(
-                  fieldKey: AuthKeys.signUpEmailField,
-                  enable: !isUserRegistered || isChangeEmailFlow,
-                  controller: emailController,
-                  label: 'email'.i18n,
-                  keyboardType: TextInputType.emailAddress,
-                  textInputAction: TextInputAction.done,
-                  autofillHints: const [
-                    AutofillHints.email,
-                    AutofillHints.username,
+        body: Column(
+          children: [
+            if (_accountRefreshInProgress)
+              const LinearProgressIndicator()
+            else if (_accountRefreshFailure case final failure?)
+              Padding(
+                padding: EdgeInsets.only(bottom: defaultSize),
+                child: Column(
+                  children: [
+                    Text(
+                      failure.localizedErrorMessage,
+                      style: textTheme!.bodyMedium!.copyWith(
+                        color: context.textSecondary,
+                      ),
+                      textAlign: TextAlign.center,
+                    ),
+                    AppTextButton(
+                      key: AuthKeys.signUpAccountRefreshRetryButton,
+                      label: 'retry'.i18n,
+                      onPressed: _refreshOnEntry,
+                    ),
                   ],
-                  prefixIcon: AppImagePaths.email,
-                  hintText: 'example@gmail.com',
-                  validator: (value) {
-                    final email = value?.trim() ?? '';
-                    if (email.isEmpty) {
-                      return null;
-                    }
-                    if (!email.isValidEmail()) {
-                      return 'invalid_email'.i18n;
-                    }
-                    if (isChangeEmailFlow &&
-                        _isSameEmail(email, currentEmail)) {
-                      return 'email_must_be_different'.i18n;
-                    }
-                    return null;
-                  },
                 ),
-                SizedBox(height: 4),
-                if (isUserRegistered &&
-                    widget.authFlow == AuthFlow.lanternProLicense) ...{
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: defaultSize),
-                    child: Text(
-                      'lantern_pro_license_applied'.i18n,
-                      style: textTheme!.bodyMedium!.copyWith(
-                        color: context.textDisabled,
-                        fontSize: 12,
-                      ),
+              ),
+            Expanded(
+              child: IgnorePointer(
+                ignoring: !accountStateReady,
+                child: Form(
+                  key: _formKey,
+                  child: SingleChildScrollView(
+                    keyboardDismissBehavior:
+                        ScrollViewKeyboardDismissBehavior.onDrag,
+                    child: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        AppTextField(
+                          fieldKey: AuthKeys.signUpEmailField,
+                          enable: !isUserRegistered || isChangeEmailFlow,
+                          controller: _emailController,
+                          label: 'email'.i18n,
+                          keyboardType: TextInputType.emailAddress,
+                          textInputAction: TextInputAction.done,
+                          autofillHints: const [
+                            AutofillHints.email,
+                            AutofillHints.username,
+                          ],
+                          prefixIcon: AppImagePaths.email,
+                          hintText: 'example@gmail.com',
+                          validator: (value) {
+                            final email = value?.trim() ?? '';
+                            if (email.isEmpty) {
+                              return null;
+                            }
+                            if (!email.isValidEmail()) {
+                              return 'invalid_email'.i18n;
+                            }
+                            if (isChangeEmailFlow &&
+                                _isSameEmail(email, currentEmail)) {
+                              return 'email_must_be_different'.i18n;
+                            }
+                            return null;
+                          },
+                        ),
+                        SizedBox(height: 4),
+                        if (isUserRegistered &&
+                            widget.authFlow == AuthFlow.lanternProLicense) ...{
+                          Padding(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: defaultSize,
+                            ),
+                            child: Text(
+                              'lantern_pro_license_applied'.i18n,
+                              style: textTheme!.bodyMedium!.copyWith(
+                                color: context.textDisabled,
+                                fontSize: 12,
+                              ),
+                            ),
+                          ),
+                          SizedBox(height: defaultSize),
+                        },
+                        if (widget.authFlow == AuthFlow.changeEmail)
+                          Padding(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: defaultSize,
+                            ),
+                            child: Text(
+                              'change_email_message'.i18n,
+                              style: textTheme!.bodyMedium!.copyWith(
+                                color: context.textDisabled,
+                              ),
+                            ),
+                          )
+                        else
+                          Padding(
+                            padding: EdgeInsets.symmetric(
+                              horizontal: defaultSize,
+                            ),
+                            child: Text(
+                              'add_your_email_message'.i18n,
+                              style: textTheme!.bodyMedium!.copyWith(
+                                color: context.textDisabled,
+                              ),
+                            ),
+                          ),
+                        SizedBox(height: 32),
+                        PrimaryButton(
+                          key: AuthKeys.signUpContinueButton,
+                          label: 'continue'.i18n,
+                          enabled:
+                              accountStateReady &&
+                              _canSubmitEmail(
+                                _emailController.text,
+                                currentEmail,
+                              ),
+                          isTaller: true,
+                          onPressed: () => onContinuePressed(
+                            SignUpMethodType.email,
+                            currentEmail,
+                          ),
+                        ),
+                        if (isUserRegistered && !isChangeEmailFlow) ...[
+                          SizedBox(height: defaultSize),
+                          Center(
+                            child: AppTextButton(
+                              key: AuthKeys.signUpUseDifferentAccountButton,
+                              label: 'use_a_different_account'.i18n,
+                              onPressed: _useDifferentAccount,
+                            ),
+                          ),
+                        ],
+                        if (!isUserRegistered) ...{
+                          SizedBox(height: defaultSize),
+                          DividerSpace(),
+                          SizedBox(height: defaultSize),
+                          OAuthLogin(
+                            methodType: SignUpMethodType.google,
+                            onResult: (token) =>
+                                onOAuthResult(token, SignUpMethodType.google),
+                          ),
+                          SizedBox(height: defaultSize),
+                          OAuthLogin(
+                            methodType: SignUpMethodType.apple,
+                            foregroundColor: context.textPrimary,
+                            onResult: (token) =>
+                                onOAuthResult(token, SignUpMethodType.apple),
+                          ),
+                          SizedBox(height: defaultSize),
+                          DividerSpace(),
+                          SizedBox(height: defaultSize),
+                          if (isStoreVersion() &&
+                              widget.authFlow == AuthFlow.signUp)
+                            Center(
+                              child: AppTextButton(
+                                key: AuthKeys.signUpContinueWithoutEmailButton,
+                                label: 'continue_without_email'.i18n,
+                                textColor: AppColors.gray9,
+                                onPressed: () => navigateRoute(
+                                  SignUpMethodType.withoutEmail,
+                                  "",
+                                ),
+                              ),
+                            ),
+                        },
+                      ],
                     ),
-                  ),
-                  SizedBox(height: defaultSize),
-                },
-                if (widget.authFlow == AuthFlow.changeEmail)
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: defaultSize),
-                    child: Text(
-                      'change_email_message'.i18n,
-                      style: textTheme!.bodyMedium!.copyWith(
-                        color: context.textDisabled,
-                      ),
-                    ),
-                  )
-                else
-                  Padding(
-                    padding: EdgeInsets.symmetric(horizontal: defaultSize),
-                    child: Text(
-                      'add_your_email_message'.i18n,
-                      style: textTheme!.bodyMedium!.copyWith(
-                        color: context.textDisabled,
-                      ),
-                    ),
-                  ),
-                SizedBox(height: 32),
-                PrimaryButton(
-                  key: AuthKeys.signUpContinueButton,
-                  label: 'continue'.i18n,
-                  enabled: _canSubmitEmail(emailController.text, currentEmail),
-                  isTaller: true,
-                  onPressed: () => onContinuePressed(
-                    SignUpMethodType.email,
-                    emailController.text,
-                    isUserRegistered,
-                    currentEmail,
                   ),
                 ),
-                if (!isUserRegistered) ...{
-                  SizedBox(height: defaultSize),
-                  DividerSpace(),
-                  SizedBox(height: defaultSize),
-                  OAuthLogin(
-                    methodType: SignUpMethodType.google,
-                    onResult: (token) =>
-                        onOAuthResult(token, SignUpMethodType.google),
-                  ),
-                  SizedBox(height: defaultSize),
-                  OAuthLogin(
-                    methodType: SignUpMethodType.apple,
-                    foregroundColor: context.textPrimary,
-                    onResult: (token) =>
-                        onOAuthResult(token, SignUpMethodType.apple),
-                  ),
-                  SizedBox(height: defaultSize),
-                  DividerSpace(),
-                  SizedBox(height: defaultSize),
-                  if (isStoreVersion() && widget.authFlow == AuthFlow.signUp)
-                    Center(
-                      child: AppTextButton(
-                        key: AuthKeys.signUpContinueWithoutEmailButton,
-                        label: 'continue_without_email'.i18n,
-                        textColor: AppColors.gray9,
-                        onPressed: () =>
-                            navigateRoute(SignUpMethodType.withoutEmail, ""),
-                      ),
-                    ),
-                },
-              ],
+              ),
             ),
-          ),
+          ],
         ),
       ),
     );
@@ -205,60 +336,88 @@ class _AddEmailState extends ConsumerState<AddEmail> {
         email.trim().toLowerCase() == currentEmail.trim().toLowerCase();
   }
 
-  void onContinuePressed(
-    SignUpMethodType type,
-    String email,
-    bool isUserRegistered,
-    String currentEmail,
-  ) {
-    email = email.trim();
+  void onContinuePressed(SignUpMethodType type, String currentEmail) {
+    final email = _emailController.text.trim();
     if (!_canSubmitEmail(email, currentEmail)) {
       _formKey.currentState!.validate();
       return;
     }
     if (!_formKey.currentState!.validate()) return;
 
-    if (_isProblematicEmail(email) && !isUserRegistered) {
-      _showEmailDeliverabilityNotice(
-        () => _handleContinue(type, email, isUserRegistered),
-      );
+    final cachedUserIsRegistered =
+        ref.read(homeProvider).value?.legacyUserData.unpassRegistered ?? false;
+    if (_isProblematicEmail(email) && !cachedUserIsRegistered) {
+      _showEmailDeliverabilityNotice(() => _handleContinue(type, email));
       return;
     }
-    _handleContinue(type, email, isUserRegistered);
+    _handleContinue(type, email);
   }
 
-  Future<void> _handleContinue(
-    SignUpMethodType type,
-    String email,
-    bool isUserRegistered,
-  ) async {
+  Future<void> _handleContinue(SignUpMethodType type, String email) async {
     try {
       if (!_formKey.currentState!.validate()) {
         return;
       }
+      context.showLoadingDialog();
+      final refreshResult = await _refreshAccountState();
+      if (!mounted) return;
+
+      UserResponseModel? authoritativeUser;
+      refreshResult.fold((_) {}, (user) => authoritativeUser = user);
+      if (authoritativeUser == null) {
+        context.hideLoadingDialog();
+        return;
+      }
+      final userData = authoritativeUser!.legacyUserData;
+      context.hideLoadingDialog();
+
       if (widget.authFlow == AuthFlow.changeEmail) {
-        //Change email flow
         appLogger.debug('Starting change email flow');
-        startChangeEmailFlow(email);
-      } else {
-        if (isUserRegistered) {
-          ///This mean user is already registered
-          /// plan is expired or user are creating new account with same email
-          /// by pass signup flow and start forgot password flow
-          startForgotPasswordFlow(email);
-          appLogger.info(
-            "User already registered, starting forgot password flow",
-          );
-        } else {
-          appLogger.debug('Starting signup flow');
-          await signupFlow(email);
+        await startChangeEmailFlow(email);
+        return;
+      }
+
+      if (userData.unpassRegistered) {
+        final backendEmail = userData.email.trim();
+        if (backendEmail.isEmpty) {
+          _showInvalidRegisteredAccount();
           return;
         }
+        _setEmail(backendEmail);
+        appLogger.info(
+          'Server reports an existing registered account; starting password recovery',
+        );
+        await startForgotPasswordFlow(backendEmail);
+        return;
       }
+
+      appLogger.debug('Starting signup flow');
+      await signupFlow(email);
     } catch (e) {
+      if (mounted) context.hideLoadingDialog();
       appLogger.error('Error in _handleContinue: $e');
-      context.showSnackBar('error_occurred'.i18n);
+      if (mounted) context.showSnackBar('an_error_occurred'.i18n);
     }
+  }
+
+  Future<Either<Failure, UserResponseModel>> _refreshAccountState() async {
+    final result = await ref.read(homeProvider.notifier).fetchUserData();
+    if (!mounted) return result;
+
+    result.fold(
+      (failure) {
+        setState(() => _accountRefreshFailure = failure);
+        appLogger.error(
+          'Authoritative account refresh failed: ${failure.error}',
+        );
+      },
+      (_) {
+        if (_accountRefreshFailure != null) {
+          setState(() => _accountRefreshFailure = null);
+        }
+      },
+    );
+    return result;
   }
 
   Future<void> signupFlow(String email) async {
@@ -267,60 +426,141 @@ class _AddEmailState extends ConsumerState<AddEmail> {
     final result = await ref
         .read(authProvider.notifier)
         .signUpWithEmail(email, tempPassword);
+    if (!mounted) return;
 
+    Failure? signupFailure;
+    result.fold((failure) => signupFailure = failure, (_) {});
+    if (signupFailure == null) {
+      context.hideLoadingDialog();
+      await startForgotPasswordFlow(email, tempPassword);
+      return;
+    }
+
+    final failure = signupFailure!;
+    if (_isSignupConflict(failure)) {
+      final refreshResult = await _refreshAccountState();
+      if (!mounted) return;
+
+      UserResponseModel? authoritativeUser;
+      refreshResult.fold((_) {}, (user) => authoritativeUser = user);
+      if (authoritativeUser == null) {
+        context.hideLoadingDialog();
+        return;
+      }
+
+      final userData = authoritativeUser!.legacyUserData;
+      if (userData.unpassRegistered && userData.email.trim().isNotEmpty) {
+        final backendEmail = userData.email.trim();
+        _setEmail(backendEmail);
+        context.hideLoadingDialog();
+        appLogger.info(
+          'Signup conflicted after account registration; rerouting to password recovery',
+        );
+        await startForgotPasswordFlow(backendEmail);
+        return;
+      }
+
+      context.hideLoadingDialog();
+      _showSignupConflictDialog(failure);
+      return;
+    }
+
+    context.hideLoadingDialog();
+    AppDialog.errorDialog(
+      context: context,
+      title: 'error'.i18n,
+      content: failure.localizedErrorMessage,
+    );
+  }
+
+  bool _isSignupConflict(Failure failure) {
+    final details = '${failure.error} ${failure.localizedErrorMessage}'
+        .toLowerCase();
+    return failure.localizedErrorMessage == 'signup_error_user_exists'.i18n ||
+        details.contains('signup_user_exists') ||
+        details.contains('user already exists') ||
+        details.contains('legacy user id already exists');
+  }
+
+  void _showSignupConflictDialog(Failure failure) {
+    AppDialog.customDialog(
+      context: context,
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          SizedBox(height: 24),
+          Text('create_account_error'.i18n, style: textTheme!.headlineMedium),
+          SizedBox(height: defaultSize),
+          Text(failure.localizedErrorMessage, style: textTheme!.bodyMedium),
+        ],
+      ),
+      action: [
+        AppTextButton(
+          label: 'sign_in'.i18n,
+          onPressed: () {
+            appRouter.maybePop();
+            appRouter.push(SignInEmail());
+          },
+        ),
+        AppTextButton(
+          label: 'ok'.i18n,
+          textColor: AppColors.gray6,
+          onPressed: () {
+            appRouter.maybePop();
+          },
+        ),
+      ],
+    );
+  }
+
+  Future<void> _useDifferentAccount() async {
+    context.showLoadingDialog();
+    final refreshResult = await _refreshAccountState();
+    if (!mounted) return;
+
+    UserResponseModel? authoritativeUser;
+    refreshResult.fold((_) {}, (user) => authoritativeUser = user);
+    if (authoritativeUser == null) {
+      context.hideLoadingDialog();
+      return;
+    }
+
+    final userData = authoritativeUser!.legacyUserData;
+    if (!userData.unpassRegistered) {
+      context.hideLoadingDialog();
+      _emailController.clear();
+      return;
+    }
+    final backendEmail = userData.email.trim();
+    if (backendEmail.isEmpty) {
+      context.hideLoadingDialog();
+      _showInvalidRegisteredAccount();
+      return;
+    }
+
+    final result = await ref.read(lanternServiceProvider).logout(backendEmail);
+    if (!mounted) return;
     result.fold(
       (failure) {
         context.hideLoadingDialog();
-        if (failure.localizedErrorMessage == 'signup_error_user_exists'.i18n) {
-          AppDialog.customDialog(
-            context: context,
-            content: Column(
-              mainAxisSize: MainAxisSize.min,
-              children: <Widget>[
-                SizedBox(height: 24),
-                Text(
-                  'create_account_error'.i18n,
-                  style: textTheme!.headlineMedium,
-                ),
-                SizedBox(height: defaultSize),
-                Text(
-                  failure.localizedErrorMessage,
-                  style: textTheme!.bodyMedium,
-                ),
-              ],
-            ),
-            action: [
-              AppTextButton(
-                label: 'sign_in'.i18n,
-                onPressed: () {
-                  appRouter.maybePop();
-                  appRouter.push(SignInEmail());
-                },
-              ),
-              AppTextButton(
-                label: 'ok'.i18n,
-                textColor: AppColors.gray6,
-                onPressed: () {
-                  appRouter.maybePop();
-                },
-              ),
-            ],
-          );
-          return;
-        }
-        AppDialog.errorDialog(
-          context: context,
-          title: 'error'.i18n,
-          content: failure.localizedErrorMessage,
-        );
+        appLogger.error('Different-account rollover failed: ${failure.error}');
+        context.showSnackBar(failure.localizedErrorMessage);
       },
-      (response) {
-        //sign up successful
-        //start forgot password flow
+      (newUser) {
+        ref.read(homeProvider.notifier).clearLogoutData();
+        ref.read(homeProvider.notifier).updateUserData(newUser);
+        _emailController.clear();
         context.hideLoadingDialog();
-        startForgotPasswordFlow(email, tempPassword);
+        appLogger.info('Switched to a fresh anonymous account');
       },
     );
+  }
+
+  void _showInvalidRegisteredAccount() {
+    appLogger.error(
+      'Server returned unpassRegistered=true without a usable email',
+    );
+    context.showSnackBar('an_error_occurred'.i18n);
   }
 
   Future<void> startForgotPasswordFlow(
@@ -375,7 +615,7 @@ class _AddEmailState extends ConsumerState<AddEmail> {
   }
 
   //Change Email flow
-  void startChangeEmailFlow(String email) async {
+  Future<void> startChangeEmailFlow(String email) async {
     context.showLoadingDialog();
     final result = await ref
         .read(authProvider.notifier)

--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -22,9 +22,7 @@ class HomeNotifier extends _$HomeNotifier {
     final result = await service.getUserData();
     return result.fold(
       (failure) {
-        appLogger.error(
-          'Error getting user data: ${failure.error}',
-        );
+        appLogger.error('Error getting user data: ${failure.error}');
         throw Exception('Failed to get user data');
       },
       (userData) {
@@ -36,19 +34,18 @@ class HomeNotifier extends _$HomeNotifier {
   }
 
   /// Fetches the latest user data from the server
-  Future<void> fetchUserData() async {
+  Future<Either<Failure, UserResponseModel>> fetchUserData() async {
     final result = await ref.read(lanternServiceProvider).fetchUserData();
     result.fold(
       (failure) {
-        appLogger.error(
-          'Error fetching user data: ${failure.error}',
-        );
+        appLogger.error('Error fetching user data: ${failure.error}');
       },
       (userData) {
         appLogger.debug('Fetched user data form server: $userData');
         _applyUserData(userData);
       },
     );
+    return result;
   }
 
   /// Force refresh from Go
@@ -58,9 +55,7 @@ class HomeNotifier extends _$HomeNotifier {
     final result = await ref.read(lanternServiceProvider).getUserData();
     result.fold(
       (failure) {
-        appLogger.error(
-          'Error refreshing user data: ${failure.error}',
-        );
+        appLogger.error('Error refreshing user data: ${failure.error}');
         state = AsyncValue.error(failure, StackTrace.current);
       },
       (userData) {
@@ -103,13 +98,6 @@ class HomeNotifier extends _$HomeNotifier {
           .read(serverLocationProvider.notifier)
           .updateServerLocation(initialServerLocation());
     }
-  }
-
-  /// Fetches the latest user data from the server if not cached locally.
-  Future<void> fetchUserDataIfNeeded() async {
-    appLogger.info("Checking if user data fetch is needed...");
-    appLogger.info("Fetching from Go (source-of-truth)...");
-    await refreshUser();
   }
 
   /// Checks if the user is a Pro user and if the current device is added

--- a/lib/features/home/provider/home_notifier.dart
+++ b/lib/features/home/provider/home_notifier.dart
@@ -41,7 +41,7 @@ class HomeNotifier extends _$HomeNotifier {
         appLogger.error('Error fetching user data: ${failure.error}');
       },
       (userData) {
-        appLogger.debug('Fetched user data form server: $userData');
+        appLogger.debug('Fetched user data from server: $userData');
         _applyUserData(userData);
       },
     );

--- a/test/features/auth/add_email_test.dart
+++ b/test/features/auth/add_email_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -71,6 +73,7 @@ class _FakeLanternService implements LanternService {
   int logoutCalls = 0;
   String? recoveryEmail;
   String? logoutEmail;
+  Completer<Either<Failure, UserResponseModel>>? nextFetch;
 
   @override
   Future<void> waitForRadiance() async {}
@@ -83,6 +86,11 @@ class _FakeLanternService implements LanternService {
   @override
   Future<Either<Failure, UserResponseModel>> fetchUserData() async {
     fetchCalls += 1;
+    final pendingFetch = nextFetch;
+    if (pendingFetch != null) {
+      nextFetch = null;
+      return pendingFetch.future;
+    }
     if (_fetchResults.isEmpty) {
       return right(cachedUser);
     }
@@ -205,6 +213,37 @@ void main() {
       find.byKey(AuthKeys.signUpAccountRefreshRetryButton),
       findsOneWidget,
     );
+  });
+
+  testWidgets('hides the loading overlay when disposed during refresh', (
+    tester,
+  ) async {
+    final service = _FakeLanternService(
+      cachedUser: _anonymousUser,
+      fetchResults: [right(_anonymousUser)],
+    );
+    final container = await _pumpAddEmail(tester, service);
+    addTearDown(container.dispose);
+
+    final pendingFetch = Completer<Either<Failure, UserResponseModel>>();
+    service.nextFetch = pendingFetch;
+    final overlay = tester.element(find.byType(AddEmail)).loaderOverlay;
+
+    await tester.enterText(
+      find.byKey(AuthKeys.signUpEmailField),
+      'new@example.com',
+    );
+    await tester.pump();
+    await tester.tap(_continueButton());
+    await tester.pump();
+    expect(service.fetchCalls, 2);
+    expect(overlay.visible, isTrue);
+
+    await tester.pumpWidget(const SizedBox());
+    expect(overlay.visible, isFalse);
+
+    pendingFetch.complete(right(_anonymousUser));
+    await tester.pump();
   });
 
   testWidgets('explicit different-account action performs logout rollover', (

--- a/test/features/auth/add_email_test.dart
+++ b/test/features/auth/add_email_test.dart
@@ -1,0 +1,265 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/common/app_eum.dart';
+import 'package:lantern/core/common/app_theme.dart';
+import 'package:lantern/core/keys/app_keys.dart';
+import 'package:lantern/core/models/app_setting.dart';
+import 'package:lantern/core/models/user.dart';
+import 'package:lantern/core/utils/failure.dart';
+import 'package:lantern/features/auth/add_email.dart';
+import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/features/home/provider/home_notifier.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
+import 'package:loader_overlay/loader_overlay.dart';
+
+const _anonymousUser = UserResponseModel(
+  legacyID: 1,
+  legacyToken: 'anonymous-token',
+  emailConfirmed: false,
+  success: true,
+  legacyUserData: UserDataModel(userLevel: 'pro'),
+);
+
+const _registeredUser = UserResponseModel(
+  legacyID: 1,
+  legacyToken: 'registered-token',
+  emailConfirmed: true,
+  success: true,
+  legacyUserData: UserDataModel(
+    email: 'backend@example.com',
+    userLevel: 'pro',
+    unpassRegistered: true,
+  ),
+);
+
+final _refreshFailure = Failure(
+  error: 'network unavailable',
+  localizedErrorMessage: 'Unable to refresh account',
+);
+
+final _recoveryFailure = Failure(
+  error: 'stop after recording recovery',
+  localizedErrorMessage: 'Recovery stopped for test',
+);
+
+class _InMemoryAppSettingNotifier extends AppSettingNotifier {
+  @override
+  AppSetting build() => const AppSetting();
+
+  @override
+  Future<void> update(AppSetting updated) async {
+    state = updated;
+  }
+}
+
+class _FakeLanternService implements LanternService {
+  _FakeLanternService({
+    required this.cachedUser,
+    required List<Either<Failure, UserResponseModel>> fetchResults,
+  }) : _fetchResults = fetchResults;
+
+  final UserResponseModel cachedUser;
+  final List<Either<Failure, UserResponseModel>> _fetchResults;
+  Either<Failure, Unit> signUpResult = right(unit);
+  Either<Failure, UserResponseModel> logoutResult = right(_anonymousUser);
+  int fetchCalls = 0;
+  int signUpCalls = 0;
+  int logoutCalls = 0;
+  String? recoveryEmail;
+  String? logoutEmail;
+
+  @override
+  Future<void> waitForRadiance() async {}
+
+  @override
+  Future<Either<Failure, UserResponseModel>> getUserData() async {
+    return right(cachedUser);
+  }
+
+  @override
+  Future<Either<Failure, UserResponseModel>> fetchUserData() async {
+    fetchCalls += 1;
+    if (_fetchResults.isEmpty) {
+      return right(cachedUser);
+    }
+    return _fetchResults.removeAt(0);
+  }
+
+  @override
+  Future<Either<Failure, Unit>> signUp({
+    required String email,
+    required String password,
+  }) async {
+    signUpCalls += 1;
+    return signUpResult;
+  }
+
+  @override
+  Future<Either<Failure, Unit>> startRecoveryByEmail(String email) async {
+    recoveryEmail = email;
+    return left(_recoveryFailure);
+  }
+
+  @override
+  Future<Either<Failure, UserResponseModel>> logout(String email) async {
+    logoutCalls += 1;
+    logoutEmail = email;
+    return logoutResult;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+Future<ProviderContainer> _pumpAddEmail(
+  WidgetTester tester,
+  _FakeLanternService service,
+) async {
+  final container = ProviderContainer(
+    overrides: [
+      lanternServiceProvider.overrideWithValue(service),
+      appSettingProvider.overrideWith(_InMemoryAppSettingNotifier.new),
+    ],
+  );
+  await tester.pumpWidget(
+    UncontrolledProviderScope(
+      container: container,
+      child: ScreenUtilInit(
+        designSize: const Size(390, 844),
+        child: GlobalLoaderOverlay(
+          child: MaterialApp(
+            theme: AppTheme.appTheme(),
+            home: const AddEmail(authFlow: AuthFlow.signUp),
+          ),
+        ),
+      ),
+    ),
+  );
+  await tester.pumpAndSettle();
+  return container;
+}
+
+TextFormField _emailField(WidgetTester tester) {
+  return tester.widget<TextFormField>(find.byKey(AuthKeys.signUpEmailField));
+}
+
+Finder _continueButton() => find.descendant(
+  of: find.byKey(AuthKeys.signUpContinueButton),
+  matching: find.byType(ElevatedButton),
+);
+
+void main() {
+  testWidgets(
+    'refreshes on entry and routes a registered user with the backend email',
+    (tester) async {
+      final service = _FakeLanternService(
+        cachedUser: _anonymousUser,
+        fetchResults: [right(_registeredUser), right(_registeredUser)],
+      );
+      final container = await _pumpAddEmail(tester, service);
+      addTearDown(container.dispose);
+
+      expect(service.fetchCalls, 1);
+      expect(_emailField(tester).controller!.text, 'backend@example.com');
+      expect(_emailField(tester).enabled, isFalse);
+
+      await tester.tap(_continueButton());
+      await tester.pumpAndSettle();
+
+      expect(service.fetchCalls, 2);
+      expect(service.recoveryEmail, 'backend@example.com');
+      expect(service.signUpCalls, 0);
+    },
+  );
+
+  testWidgets('blocks signup when the submit-time refresh fails', (
+    tester,
+  ) async {
+    final service = _FakeLanternService(
+      cachedUser: _anonymousUser,
+      fetchResults: [right(_anonymousUser), left(_refreshFailure)],
+    );
+    final container = await _pumpAddEmail(tester, service);
+    addTearDown(container.dispose);
+
+    await tester.enterText(
+      find.byKey(AuthKeys.signUpEmailField),
+      'new@example.com',
+    );
+    await tester.pump();
+    expect(
+      tester.widget<ElevatedButton>(_continueButton()).onPressed,
+      isNotNull,
+    );
+    await tester.tap(_continueButton());
+    await tester.pumpAndSettle();
+
+    expect(service.fetchCalls, 2);
+    expect(service.signUpCalls, 0);
+    expect(_emailField(tester).controller!.text, 'new@example.com');
+    expect(
+      find.byKey(AuthKeys.signUpAccountRefreshRetryButton),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('explicit different-account action performs logout rollover', (
+    tester,
+  ) async {
+    final service = _FakeLanternService(
+      cachedUser: _registeredUser,
+      fetchResults: [right(_registeredUser), right(_registeredUser)],
+    );
+    final container = await _pumpAddEmail(tester, service);
+    addTearDown(container.dispose);
+
+    await tester.tap(find.byKey(AuthKeys.signUpUseDifferentAccountButton));
+    await tester.pumpAndSettle();
+
+    expect(service.logoutCalls, 1);
+    expect(service.logoutEmail, 'backend@example.com');
+    expect(container.read(homeProvider).value, _anonymousUser);
+    expect(_emailField(tester).controller!.text, isEmpty);
+    expect(find.byKey(AuthKeys.signUpUseDifferentAccountButton), findsNothing);
+  });
+
+  testWidgets('refreshes and reroutes after a signup conflict race', (
+    tester,
+  ) async {
+    final conflict = Failure(
+      error: 'user with this legacy user ID already exists',
+      localizedErrorMessage: 'signup_error_user_exists',
+    );
+    final service = _FakeLanternService(
+      cachedUser: _anonymousUser,
+      fetchResults: [
+        right(_anonymousUser),
+        right(_anonymousUser),
+        right(_registeredUser),
+      ],
+    )..signUpResult = left(conflict);
+    final container = await _pumpAddEmail(tester, service);
+    addTearDown(container.dispose);
+
+    await tester.enterText(
+      find.byKey(AuthKeys.signUpEmailField),
+      'attempted@example.com',
+    );
+    await tester.pump();
+    expect(
+      tester.widget<ElevatedButton>(_continueButton()).onPressed,
+      isNotNull,
+    );
+    await tester.tap(_continueButton());
+    await tester.pumpAndSettle();
+
+    expect(service.fetchCalls, 3);
+    expect(service.signUpCalls, 1);
+    expect(service.recoveryEmail, 'backend@example.com');
+    expect(_emailField(tester).controller!.text, 'backend@example.com');
+  });
+}

--- a/test/features/home/provider/home_notifier_test.dart
+++ b/test/features/home/provider/home_notifier_test.dart
@@ -24,6 +24,8 @@ class _FakeLanternService implements LanternService {
   final waitStarted = Completer<void>();
   int waitForRadianceCalls = 0;
   int getUserDataCalls = 0;
+  int fetchUserDataCalls = 0;
+  Either<Failure, UserResponseModel> fetchUserDataResult = right(_user);
 
   @override
   Future<void> waitForRadiance() {
@@ -36,6 +38,12 @@ class _FakeLanternService implements LanternService {
   Future<Either<Failure, UserResponseModel>> getUserData() async {
     getUserDataCalls += 1;
     return right(_user);
+  }
+
+  @override
+  Future<Either<Failure, UserResponseModel>> fetchUserData() async {
+    fetchUserDataCalls += 1;
+    return fetchUserDataResult;
   }
 
   @override
@@ -65,5 +73,58 @@ void main() {
 
     expect(await user, _user);
     expect(service.getUserDataCalls, 1);
+  });
+
+  test('returns and applies server-fetched user data', () async {
+    const fetchedUser = UserResponseModel(
+      legacyID: 2,
+      legacyToken: 'new-token',
+      emailConfirmed: true,
+      success: true,
+      legacyUserData: UserDataModel(
+        email: 'registered@example.com',
+        userLevel: 'pro',
+        unpassRegistered: true,
+      ),
+    );
+    final service = _FakeLanternService()
+      ..fetchUserDataResult = right(fetchedUser);
+    service.ready.complete();
+    final container = ProviderContainer(
+      overrides: [
+        lanternServiceProvider.overrideWithValue(service),
+        appSettingProvider.overrideWithValue(const AppSetting()),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(homeProvider.future);
+
+    final result = await container.read(homeProvider.notifier).fetchUserData();
+
+    expect(service.fetchUserDataCalls, 1);
+    expect(result.isRight(), isTrue);
+    expect(container.read(homeProvider).value, fetchedUser);
+  });
+
+  test('returns refresh failure without replacing cached user data', () async {
+    final failure = Failure(
+      error: 'network unavailable',
+      localizedErrorMessage: 'Unable to refresh',
+    );
+    final service = _FakeLanternService()..fetchUserDataResult = left(failure);
+    service.ready.complete();
+    final container = ProviderContainer(
+      overrides: [
+        lanternServiceProvider.overrideWithValue(service),
+        appSettingProvider.overrideWithValue(const AppSetting()),
+      ],
+    );
+    addTearDown(container.dispose);
+    await container.read(homeProvider.future);
+
+    final result = await container.read(homeProvider.notifier).fetchUserData();
+
+    expect(result.isLeft(), isTrue);
+    expect(container.read(homeProvider).value, _user);
   });
 }


### PR DESCRIPTION
Fetch user data when AddEmail opens and before submission, routing migrated registered users to password recovery instead of duplicate signup. Also adds an explicit "Use a different account" rollover, handles signup races, and removes the unobserved background refresh. Includes provider and widget regression tests

Partially resolves https://github.com/getlantern/engineering/issues/3734

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added “Use a different account” and “account refresh retry” actions during sign-up.
* **Updates**
  * Sign-up now refreshes authoritative account info on entry and before continuing, with loading/progress and retry feedback on failure.
  * Updated English copy for Smart Location and added the new account-switch prompt text.
* **Bug Fixes**
  * Improved handling of registered-account conflicts and refresh failures by preserving existing cached user data and reconciling state after retries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->