### PR TITLE
fix(ios): send empty device ID from network extension

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260727212115-149f0d726208
+	github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260727212115-149f0d726208 h1:4kKNcKIHSTbDI0m+DnaSq2n5TyafW/BPkDbUMeUJWcU=
-github.com/getlantern/radiance v0.0.0-20260727212115-149f0d726208/go.mod h1:BUKzQxV+sKuRySBLPTVHDt1XkPqoIdx/G+pB9euO4LQ=
+github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb h1:1VhnolDkNBFI7LmG6IAHgabJKrR7/B8LOYLFEne5wuo=
+github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb/go.mod h1:BUKzQxV+sKuRySBLPTVHDt1XkPqoIdx/G+pB9euO4LQ=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -109,9 +109,9 @@ class ExtensionProvider: NEPacketTunnelProvider {
     let opts = UtilsOpts()
     opts.dataDir = FilePath.dataDirectory.relativePath
     opts.logDir = FilePath.logsDirectory.relativePath
-    // Intentionally left empty. Keychain items aren't shared across processes,
-    // so a per-process ID here would diverge from the main app's. Radiance
-    // resolves the device ID from the shared app-group settings the app persists.
+    // Intentionally left empty. The app and extension don't share a keychain access
+    // group so `DeviceIdentifier.getUDID` would diverge. Radiance resolves the device 
+    // ID from the shared app-group settings the app persists.
     opts.deviceid = ""
     opts.logLevel = "trace"
     opts.locale = Locale.current.identifier

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -109,7 +109,10 @@ class ExtensionProvider: NEPacketTunnelProvider {
     let opts = UtilsOpts()
     opts.dataDir = FilePath.dataDirectory.relativePath
     opts.logDir = FilePath.logsDirectory.relativePath
-    opts.deviceid = DeviceIdentifier.getUDID()
+    // Intentionally left empty. Keychain items aren't shared across processes,
+    // so a per-process ID here would diverge from the main app's. Radiance
+    // resolves the device ID from the shared app-group settings the app persists.
+    opts.deviceid = ""
     opts.logLevel = "trace"
     opts.locale = Locale.current.identifier
     return opts

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -110,8 +110,7 @@ class ExtensionProvider: NEPacketTunnelProvider {
     opts.dataDir = FilePath.dataDirectory.relativePath
     opts.logDir = FilePath.logsDirectory.relativePath
     // Intentionally left empty. The app and extension don't share a keychain access
-    // group so `DeviceIdentifier.getUDID` would diverge. Radiance resolves the device 
-    // ID from the shared app-group settings the app persists.
+    // Radiance resolves the device ID from the main app process. 
     opts.deviceid = ""
     opts.logLevel = "trace"
     opts.locale = Locale.current.identifier


### PR DESCRIPTION
## Summary

The iOS main app and network extension run as separate processes. Keychain items are not shared across processes without a shared `keychain-access-groups` entitlement — so the extension's `DeviceIdentifier.getUDID()` produced a per-process device ID that diverged from the main app's, and each sent a different ID in config and telemetry requests.

The extension is not authoritative for the device ID, so it now sends an empty `opts.deviceid`. Radiance resolves the shared ID from the app-group settings the main app persisted, so both processes use the same ID.

## Companion PR

Requires getlantern/radiance#583, which adds the radiance-side resolution (caller → persisted settings). The two must merge together.

closes getlantern/engineering/issues/3701

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device identification handling for the iOS tunnel extension by using shared, app-provisioned settings instead of direct device ID retrieval.
  * Prevented inconsistent device ID access between the main app and its extension.
* **Chores**
  * Updated an internal library dependency to a newer version for continued stability and improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->