### PR TITLE
fix(ios,macos): tear down tunnel on failed NE restart

### DIFF
--- a/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
@@ -374,8 +374,8 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
   }
 
   public func restartService() throws {
-    runBlocking { [self] in
-      tunnel.restartService()
+    try runBlocking { [self] in
+      try tunnel.restartService()
     }
   }
 

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -125,7 +125,7 @@ class ExtensionProvider: NEPacketTunnelProvider {
     postServiceClose()
   }
 
-  func restartService() {
+  func restartService() throws {
     appLogger.log("(lantern-tunnel) restarting service")
     reasserting = true
     defer {
@@ -133,12 +133,15 @@ class ExtensionProvider: NEPacketTunnelProvider {
     }
     stopService()
 
-    // Don't cancelTunnelWithError on failure; this extension hosts the IPC server.
     var error: NSError?
     MobileStartVPN(&error)
     if let error {
-      appLogger.log("(lantern-tunnel) restart failed: \(error.localizedDescription)")
-      return
+      appLogger.error("(lantern-tunnel) restart failed: \(error.localizedDescription)")
+      // A failed (re)start must tear the tunnel down so on-demand/the app can recover
+      // rather than leaving a dead-but-"connected" tunnel; the throw propagates the
+      // failure to radiance's Restart so it reports ErrorStatus instead of success.
+      cancelTunnelWithError(error)
+      throw error
     }
     appLogger.log("(lantern-tunnel) tunnel restarted successfully")
   }

--- a/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
@@ -460,8 +460,8 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
   }
 
   public func restartService() throws {
-    runBlocking { [self] in
-      tunnel.restartService()
+    try runBlocking { [self] in
+      try tunnel.restartService()
     }
   }
 

--- a/macos/PacketTunnel/SingBox/ExtensionProvider.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionProvider.swift
@@ -124,7 +124,7 @@ public class ExtensionProvider: NEPacketTunnelProvider {
     postServiceClose()
   }
 
-  func restartService() {
+  func restartService() throws {
     appLogger.log("(lantern-tunnel) restarting service")
     reasserting = true
     defer {
@@ -132,12 +132,15 @@ public class ExtensionProvider: NEPacketTunnelProvider {
     }
     stopService()
 
-    // Don't cancelTunnelWithError on failure; this extension hosts the IPC server.
     var error: NSError?
     MobileStartVPN(&error)
     if let error {
       appLogger.error("(lantern-tunnel) restart failed: \(error.localizedDescription)")
-      return
+      // A failed (re)start must tear the tunnel down so on-demand/the app can recover
+      // rather than leaving a dead-but-"connected" tunnel; the throw propagates the
+      // failure to radiance's Restart so it reports ErrorStatus instead of success.
+      cancelTunnelWithError(error)
+      throw error
     }
     appLogger.log("(lantern-tunnel) tunnel restarted successfully")
   }


### PR DESCRIPTION
## What

On a failed VPN tunnel *restart*, the network extension's `restartService()` swallowed the `MobileStartVPN` error and returned, leaving the extension alive with a dead tunnel the system still reported as connected. radiance's `Restart` then saw a nil error and treated the restart as successful, so the client neither recovered nor surfaced the failure — the "dead but connected" state.

## Change

- `restartService()` now `throws` on failure, calls `cancelTunnelWithError` (matching the initial-connect paths `startVPN`/`connectToServer`), and propagates the error.
- The platform-interface wrapper rethrows through the throwing `runBlocking` overload, so radiance's `RestartService()` returns the error and the VPN client transitions to `ErrorStatus` instead of "restarted successfully."
- Applied to both the iOS and macOS extensions.

related to getlantern/engineering#3700.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN service restart error handling on iOS and macOS.
  * Restart failures are now correctly reported instead of being silently ignored.
  * Failed restarts now safely terminate the affected tunnel, helping prevent unstable or partially active VPN connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->