### PR TITLE
Fix staging issue on android.

### DIFF
--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -223,7 +223,7 @@ func (lc *LanternCore) initialize(opts *utils.Opts, eventEmitter utils.FlutterEv
 	}
 	slog.Debug("Starting LanternCore initialization")
 
-	if opts.Env == "stage" || opts.Env == "staging" {
+	if opts.IsStaging() {
 		slog.Debug("Setting staging environment")
 		env.SetStagingEnv()
 	}

--- a/lantern-core/mobile/mobile.go
+++ b/lantern-core/mobile/mobile.go
@@ -16,6 +16,7 @@ import (
 	"github.com/getlantern/radiance/account"
 	"github.com/getlantern/radiance/backend"
 	"github.com/getlantern/radiance/common"
+	"github.com/getlantern/radiance/common/env"
 	"github.com/getlantern/radiance/common/settings"
 	"github.com/getlantern/radiance/ipc"
 
@@ -287,6 +288,13 @@ func StartIPCServer(platform utils.PlatformInterface, opts *utils.Opts) error {
 		defer ipcMu.Unlock()
 		if ipcServer != nil {
 			return struct{}{}, nil
+		}
+		// The backend's config fetcher captures common.GetBaseURL() at
+		// construction, so the environment must be set before
+		// NewLocalBackend — SetupRadiance's SetStagingEnv runs too late on
+		// Android, where StartIPCServer is called first.
+		if opts.IsStaging() {
+			env.SetStagingEnv()
 		}
 		bopts := backend.Options{
 			DataDir:           opts.DataDir,

--- a/lantern-core/utils/common.go
+++ b/lantern-core/utils/common.go
@@ -15,6 +15,13 @@ type Opts struct {
 	Platform         PlatformInterface
 }
 
+// IsStaging reports whether Env selects the staging environment. Both
+// spellings are accepted; keep every env check on this method so the
+// vocabulary can't drift between call sites.
+func (o *Opts) IsStaging() bool {
+	return o.Env == "stage" || o.Env == "staging"
+}
+
 type PrivateServerEventListener interface {
 	OpenBrowser(url string) error
 	OnPrivateServerEvent(event string)


### PR DESCRIPTION
This pull request improves and standardizes how the staging environment is detected and set in the codebase, reducing the risk of inconsistent environment checks and ensuring the correct environment is configured before backend initialization. The main changes are as follows:

**Environment detection and configuration:**

* Added the `IsStaging()` method to the `Opts` struct in `utils/common.go` to centralize and standardize staging environment checks. This method ensures that all checks for staging use a single source of truth and accept both `"stage"` and `"staging"` as valid values.
* Updated `LanternCore.initialize` in `core.go` to use the new `opts.IsStaging()` method instead of directly comparing the `Env` string, improving maintainability and consistency.
* In `mobile/mobile.go`, before backend initialization in `StartIPCServer`, added a call to `env.SetStagingEnv()` if `opts.IsStaging()` is true. This ensures the environment is set early enough, especially on Android where initialization order previously caused issues.
* Imported the `env` package in `mobile/mobile.go` to support the new environment setup logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved staging environment detection across core and mobile components.
  * Ensured staging settings are applied before starting the local backend.
  * Added support for both `stage` and `staging` environment labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->