### PR TITLE
fix: promoting radiance version without quic reject rule

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb
+	github.com/getlantern/radiance v0.0.0-20260730165907-b8630814fc55
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -261,6 +261,8 @@ github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmI
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
 github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb h1:1VhnolDkNBFI7LmG6IAHgabJKrR7/B8LOYLFEne5wuo=
 github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb/go.mod h1:BUKzQxV+sKuRySBLPTVHDt1XkPqoIdx/G+pB9euO4LQ=
+github.com/getlantern/radiance v0.0.0-20260730165907-b8630814fc55 h1:yHcB5/Z9KHAKxxnshRQKzNWdWZMFvaFwmcxq+AG9P3g=
+github.com/getlantern/radiance v0.0.0-20260730165907-b8630814fc55/go.mod h1:BUKzQxV+sKuRySBLPTVHDt1XkPqoIdx/G+pB9euO4LQ=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->