### PR TITLE
android: guard startForeground and give serviceScope a handler

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -8,6 +8,7 @@ import android.net.VpnService
 import android.os.Build
 import android.os.ParcelFileDescriptor
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -135,8 +136,24 @@ class LanternVpnService :
     }
 
     // Create a CoroutineScope tied to the service's lifecycle.
-    // SupervisorJob ensures that failure in one child doesn't cancel the whole scope.
-    private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
+    //
+    // SupervisorJob keeps one child's failure from cancelling its siblings, but it does
+    // not handle the exception: without a CoroutineExceptionHandler an uncaught throw in
+    // any launch{} below reaches the thread's default handler and takes the process down
+    // with no Kotlin log and no Go crash file, which reads as a silent death. The handler
+    // makes that case diagnosable and reports it to the UI like any other VPN error.
+    private val serviceScope =
+        CoroutineScope(
+            Dispatchers.IO + SupervisorJob() +
+                CoroutineExceptionHandler { _, e ->
+                    AppLogger.e(TAG, "Uncaught exception in service coroutine", e)
+                    VpnStatusManager.postVPNError(
+                        errorCode = "service_coroutine_uncaught",
+                        errorMessage = "Unexpected VPN service error",
+                        error = e,
+                    )
+                },
+        )
 
     override fun onStartCommand(
         intent: Intent?,
@@ -386,10 +403,15 @@ class LanternVpnService :
             VpnStatusManager.postVPNStatus(VPNStatus.MissingPermission)
             return@withContext
         }
-        // Show foreground notification immediately — required by the OS as soon as
-        // VPN service starts, replaced by connected notification on success.
-        notificationHelper.showStartingVPNConnectedNotification(this@LanternVpnService)
         runCatching {
+            // Show foreground notification immediately — required by the OS as soon as
+            // VPN service starts, replaced by the connected notification on success.
+            // This is startForeground() underneath, which the OS can refuse over
+            // foreground-service type, permission, or vendor policy. Guarded so a
+            // refusal surfaces through onFailure like every other step here; outside
+            // the block it escapes into serviceScope, which has no handler, and kills
+            // the process with nothing logged.
+            notificationHelper.showStartingVPNConnectedNotification(this@LanternVpnService)
             // Radiance is pre-warmed via ACTION_START_RADIANCE, but as a background
             // service it may have been killed by the OS before setup completed.
             // Re-run setup here under the foreground notification so it is guaranteed

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -407,10 +407,11 @@ class LanternVpnService :
             // Show foreground notification immediately — required by the OS as soon as
             // VPN service starts, replaced by the connected notification on success.
             // This is startForeground() underneath, which the OS can refuse over
-            // foreground-service type, permission, or vendor policy. Guarded so a
-            // refusal surfaces through onFailure like every other step here; outside
-            // the block it escapes into serviceScope, which has no handler, and kills
-            // the process with nothing logged.
+            // foreground-service type, permission, or vendor policy. Inside the block
+            // so a refusal takes this operation's own failure path — errorCode-tagged
+            // reporting, network-monitor teardown, and serviceCleanUp when the caller
+            // asked for it — rather than the service-wide handler, which only logs and
+            // posts a generic error.
             notificationHelper.showStartingVPNConnectedNotification(this@LanternVpnService)
             // Radiance is pre-warmed via ACTION_START_RADIANCE, but as a background
             // service it may have been killed by the OS before setup completed.


### PR DESCRIPTION
Fixes the silent crash-on-connect in [engineering#3761](https://github.com/getlantern/engineering/issues/3761) / [ticket 180909](https://lantern.freshdesk.com/a/tickets/180909).

## The bug

`launchVPN` guards every risky step in a `runCatching` block — `setupRadiance()`, `DefaultNetworkMonitor.start()`, `Mobile.startVPN()`, `showVPNConnectedNotification()`. All except one:

```kotlin
notificationHelper.showStartingVPNConnectedNotification(this@LanternVpnService)   // ← outside
runCatching {                                                                     // ← guard opens here
```

That call is `startForeground(37, ...)` underneath (`NotificationManager.kt:175`), which the OS can refuse over foreground-service type, permission, or vendor policy. Sitting outside the block, a refusal escapes into `serviceScope`:

```kotlin
private val serviceScope = CoroutineScope(Dispatchers.IO + SupervisorJob())
```

`SupervisorJob` stops one child's failure from cancelling its siblings, but it does **not** handle the exception — the comment above it implied otherwise. With no `CoroutineExceptionHandler` the throw reaches the thread's default handler and kills the process: no Kotlin log, no Go crash file (`lantern-crash.log` is 0 bytes in the user's capture), nothing. It reads as the app vanishing about a second after pressing Connect.

## The fix

1. Move the call inside `runCatching`, as its first statement so the notification still goes up before any long work. A refusal now takes the same `onFailure` path as everything else — `AppLogger.e` + `VPNStatus.Error` — which makes it visible in logs and in the UI instead of fatal.
2. Give `serviceScope` a `CoroutineExceptionHandler`. Anything else escaping a `launch{}` in this service had the same silent-kill behavior; now it is logged and surfaced.

## Not a regression

Reported against 9.1.18, but the unguarded call is byte-identical in **9.1.13, 9.1.16, 9.1.17 and 9.1.18** (it only moved from `:349` to `:391`) and dates to `b2c0a7c9f`, 2026-02-18 — about six months. That matches the issue's own evidence of process deaths across both 9.1.13 and 9.1.18. Rolling back will not help affected users.

## Correction to the issue

#3761 states the `FOREGROUND_SERVICE_SYSTEM_EXEMPTED` permission "appears to be missing," making it a guaranteed `SecurityException` on Android 14+ and potentially affecting a much larger population. **It is declared** — `AndroidManifest.xml:9`. That escalation is a false alarm; the API-33/34 `foregroundServiceType` mismatch may still be worth a look, but not on those grounds.

## Verification

Not compile-checked locally — building this module needs the gomobile AAR, which isn't present in a fresh worktree. `android-compile-check.yml` builds the debug APK on any `*.kt` change, so CI covers exactly that.

The structural claims were each verified against `v9.1.18-beta` rather than the working tree: the unguarded call at `:391`, the guarded analog at `:449`, the handler-free scope at `:139`, the null-intent early return at `:147`, and the manifest permission at `:9`.

## What this does not prove

The root cause rests on 3 of 10 observed deaths ending at the log line emitted immediately *before* `startForeground` and nothing after. Strong, but circumstantial. The falsification step from the issue is still worth running: capture `ApplicationExitInfo.getReason()` / `getDescription()` / `getTraceInputStream()` for the previous process on next launch, which discriminates the three candidate causes and rules out `REASON_LOW_MEMORY`.

Regardless of which of the three is the trigger, both changes here are correct — the asymmetry with `:449` is a bug on its own terms, and a scope that silently kills the process is not diagnosable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN error handling when startup operations fail.
  * Added clearer reporting for unexpected service failures.
  * Prevented VPN startup errors from escaping without being handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->