### PR TITLE
android: harden the two remaining crash candidates, and record why we died

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
@@ -333,8 +333,9 @@ class MainActivity : FlutterFragmentActivity() {
      * is the OS's record of what happened, and reading it on the next launch is
      * the only way that reason reaches an attached log bundle.
      *
-     * Runs after AppLogger.init() so the output lands in lantern.log rather than
-     * only logcat, which users cannot capture.
+     * Runs after AppLogger.init() so the output lands in
+     * .lantern/logs/lantern_android.log rather than only logcat, which users
+     * cannot capture.
      */
     private fun logPreviousExitReasons() {
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return

--- a/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/MainActivity.kt
@@ -1,6 +1,8 @@
 package org.getlantern.lantern
 
 import android.Manifest
+import android.app.ActivityManager
+import android.app.ApplicationExitInfo
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.VpnService
@@ -8,6 +10,7 @@ import android.os.Build
 import android.os.Handler
 import android.os.Looper
 import android.util.Log
+import androidx.annotation.RequiresApi
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import io.flutter.embedding.android.FlutterFragmentActivity
@@ -35,6 +38,10 @@ class MainActivity : FlutterFragmentActivity() {
         lateinit var instance: MainActivity
         const val VPN_PERMISSION_REQUEST_CODE = 7777
         const val NOTIFICATION_PERMISSION_REQUEST_CODE = 1010
+
+        // Tombstones and ANR traces run to hundreds of KB; enough to identify the
+        // faulting frame without displacing the rest of an attached log bundle.
+        private const val MAX_EXIT_TRACE_CHARS = 20_000
         var receiverRegistered: Boolean = false
         var pendingServiceStart: Boolean = false
         var isEngineConfigured: Boolean = false
@@ -69,6 +76,7 @@ class MainActivity : FlutterFragmentActivity() {
         Log.d(TAG, "Config directories set up")
         AppLogger.init()
         AppLogger.d(TAG, "AppLogger initialized")
+        logPreviousExitReasons()
         // Wire up Go-side logging before any Mobile.* call. Without this, every
         // lantern-core / radiance slog call that fires before LanternVpnService's
         // ACTION_START_RADIANCE coroutine reaches common.Init falls through to
@@ -315,5 +323,66 @@ class MainActivity : FlutterFragmentActivity() {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
     }
 
+    /**
+     * Logs how previous processes died, as reported by the OS.
+     *
+     * A process killed by the system — an uncaught exception on a thread with no
+     * handler, a foreground-service deadline, a native abort, low memory — leaves
+     * nothing behind in our own logs, so a bug report shows a truncated file that
+     * simply stops. [android.app.ActivityManager.getHistoricalProcessExitReasons]
+     * is the OS's record of what happened, and reading it on the next launch is
+     * the only way that reason reaches an attached log bundle.
+     *
+     * Runs after AppLogger.init() so the output lands in lantern.log rather than
+     * only logcat, which users cannot capture.
+     */
+    private fun logPreviousExitReasons() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return
+        try {
+            val am = getSystemService(ActivityManager::class.java) ?: return
+            val exits = am.getHistoricalProcessExitReasons(packageName, 0, 5)
+            if (exits.isEmpty()) {
+                AppLogger.d(TAG, "No previous process exits recorded")
+                return
+            }
+            for (info in exits) {
+                AppLogger.i(
+                    TAG,
+                    "Previous exit: reason=${exitReasonName(info.reason)}(${info.reason}) " +
+                        "status=${info.status} importance=${info.importance} " +
+                        "pss=${info.pss}kB rss=${info.rss}kB " +
+                        "timestamp=${info.timestamp} description=${info.description}",
+                )
+                // Present only for ANRs and native crashes, and the single most
+                // useful artifact when it is: the tombstone or ANR trace.
+                runCatching {
+                    info.traceInputStream?.use { stream ->
+                        val trace = stream.bufferedReader().readText().take(MAX_EXIT_TRACE_CHARS)
+                        if (trace.isNotBlank()) AppLogger.i(TAG, "Previous exit trace:\n$trace")
+                    }
+                }.onFailure { AppLogger.w(TAG, "Could not read previous exit trace", it) }
+            }
+        } catch (e: Throwable) {
+            // Diagnostics must never be the reason startup fails.
+            AppLogger.w(TAG, "Failed to read previous exit reasons", e)
+        }
+    }
 
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun exitReasonName(reason: Int): String = when (reason) {
+        ApplicationExitInfo.REASON_ANR -> "ANR"
+        ApplicationExitInfo.REASON_CRASH -> "CRASH"
+        ApplicationExitInfo.REASON_CRASH_NATIVE -> "CRASH_NATIVE"
+        ApplicationExitInfo.REASON_DEPENDENCY_DIED -> "DEPENDENCY_DIED"
+        ApplicationExitInfo.REASON_EXCESSIVE_RESOURCE_USAGE -> "EXCESSIVE_RESOURCE_USAGE"
+        ApplicationExitInfo.REASON_EXIT_SELF -> "EXIT_SELF"
+        ApplicationExitInfo.REASON_INITIALIZATION_FAILURE -> "INITIALIZATION_FAILURE"
+        ApplicationExitInfo.REASON_LOW_MEMORY -> "LOW_MEMORY"
+        ApplicationExitInfo.REASON_OTHER -> "OTHER"
+        ApplicationExitInfo.REASON_PERMISSION_CHANGE -> "PERMISSION_CHANGE"
+        ApplicationExitInfo.REASON_SIGNALED -> "SIGNALED"
+        ApplicationExitInfo.REASON_USER_REQUESTED -> "USER_REQUESTED"
+        ApplicationExitInfo.REASON_USER_STOPPED -> "USER_STOPPED"
+        else -> "UNKNOWN"
+    }
 }

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkListener.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkListener.kt
@@ -36,6 +36,7 @@ import kotlinx.coroutines.ObsoleteCoroutinesApi
 import kotlinx.coroutines.channels.actor
 import kotlinx.coroutines.runBlocking
 import org.getlantern.lantern.LanternApp
+import org.getlantern.lantern.utils.AppLogger
 
 object DefaultNetworkListener {
     private sealed class NetworkMessage {
@@ -56,43 +57,58 @@ object DefaultNetworkListener {
         val listeners = mutableMapOf<Any, (Network?) -> Unit>()
         var network: Network? = null
         val pendingRequests = arrayListOf<NetworkMessage.Get>()
-        for (message in channel) when (message) {
-            is NetworkMessage.Start -> {
-                if (listeners.isEmpty()) register()
-                listeners[message.key] = message.listener
-                if (network != null) message.listener(network)
-            }
+        // Handle each message under a guard. This actor runs on GlobalScope, which
+        // has no CoroutineExceptionHandler, so anything thrown here would reach the
+        // thread's default handler and kill the process — and take the channel with
+        // it, breaking every later network query. Several branches can throw: the
+        // check() below, register()'s ConnectivityManager calls, and the listener
+        // lambdas, which are caller-supplied. A failed Get is completed
+        // exceptionally so its caller sees the error at await() instead of hanging
+        // on a Deferred nothing will ever complete.
+        for (message in channel) try {
+            when (message) {
+                is NetworkMessage.Start -> {
+                    if (listeners.isEmpty()) register()
+                    listeners[message.key] = message.listener
+                    if (network != null) message.listener(network)
+                }
 
-            is NetworkMessage.Get -> {
-                check(listeners.isNotEmpty()) { "Getting network without any listeners is not supported" }
-                if (network == null) pendingRequests += message else message.response.complete(
-                    network
-                )
-            }
+                is NetworkMessage.Get -> {
+                    check(listeners.isNotEmpty()) { "Getting network without any listeners is not supported" }
+                    if (network == null) pendingRequests += message else message.response.complete(
+                        network
+                    )
+                }
 
-            is NetworkMessage.Stop -> if (listeners.isNotEmpty() && // was not empty
-                listeners.remove(message.key) != null && listeners.isEmpty()
-            ) {
-                network = null
-                unregister()
-            }
+                is NetworkMessage.Stop -> if (listeners.isNotEmpty() && // was not empty
+                    listeners.remove(message.key) != null && listeners.isEmpty()
+                ) {
+                    network = null
+                    unregister()
+                }
 
-            is NetworkMessage.Put -> {
-                network = message.network
-                pendingRequests.forEach { it.response.complete(message.network) }
-                pendingRequests.clear()
-                listeners.values.forEach { it(network) }
-            }
+                is NetworkMessage.Put -> {
+                    network = message.network
+                    pendingRequests.forEach { it.response.complete(message.network) }
+                    pendingRequests.clear()
+                    listeners.values.forEach { it(network) }
+                }
 
-            is NetworkMessage.Update -> if (network == message.network) listeners.values.forEach {
-                it(
-                    network
-                )
-            }
+                is NetworkMessage.Update -> if (network == message.network) listeners.values.forEach {
+                    it(
+                        network
+                    )
+                }
 
-            is NetworkMessage.Lost -> if (network == message.network) {
-                network = null
-                listeners.values.forEach { it(null) }
+                is NetworkMessage.Lost -> if (network == message.network) {
+                    network = null
+                    listeners.values.forEach { it(null) }
+                }
+            }
+        } catch (e: Throwable) {
+            AppLogger.e("DefaultNetworkListener", "Failed handling ${message.javaClass.simpleName}", e)
+            if (message is NetworkMessage.Get && message.response.isActive) {
+                message.response.completeExceptionally(e)
             }
         }
     }

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkListener.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/DefaultNetworkListener.kt
@@ -70,7 +70,7 @@ object DefaultNetworkListener {
                 is NetworkMessage.Start -> {
                     if (listeners.isEmpty()) register()
                     listeners[message.key] = message.listener
-                    if (network != null) message.listener(network)
+                    if (network != null) notify(message.listener, network)
                 }
 
                 is NetworkMessage.Get -> {
@@ -91,18 +91,16 @@ object DefaultNetworkListener {
                     network = message.network
                     pendingRequests.forEach { it.response.complete(message.network) }
                     pendingRequests.clear()
-                    listeners.values.forEach { it(network) }
+                    listeners.values.forEach { notify(it, network) }
                 }
 
-                is NetworkMessage.Update -> if (network == message.network) listeners.values.forEach {
-                    it(
-                        network
-                    )
+                is NetworkMessage.Update -> if (network == message.network) {
+                    listeners.values.forEach { notify(it, network) }
                 }
 
                 is NetworkMessage.Lost -> if (network == message.network) {
                     network = null
-                    listeners.values.forEach { it(null) }
+                    listeners.values.forEach { notify(it, null) }
                 }
             }
         } catch (e: Throwable) {
@@ -110,6 +108,18 @@ object DefaultNetworkListener {
             if (message is NetworkMessage.Get && message.response.isActive) {
                 message.response.completeExceptionally(e)
             }
+        }
+    }
+
+    // Invokes one listener in isolation. Listeners are caller-supplied, and the
+    // fan-outs above iterate every registered one: letting a throw escape would
+    // abort the loop, so a single bad listener would silently deprive all the
+    // others of the event — and stay registered to do it again on the next one.
+    private fun notify(listener: (Network?) -> Unit, network: Network?) {
+        try {
+            listener(network)
+        } catch (e: Throwable) {
+            AppLogger.e("DefaultNetworkListener", "Network listener threw; continuing", e)
         }
     }
 

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
@@ -184,17 +184,29 @@ interface PlatformInterfaceWrapper : PlatformInterface {
     override fun clearDNSCache() {
     }
 
+    // Returns null rather than throwing on any failure. Go calls this through
+    // gomobile and the interface method has no error return, so a Kotlin throw
+    // leaves a pending JNI exception the Go side cannot observe or clear, which
+    // aborts the process (SIGABRT) instead of surfacing an error. WifiManager is a
+    // realistic source of one: connectionInfo raises SecurityException without
+    // location permission on some vendor builds, and returns entries whose ssid or
+    // bssid is null. Null is already this method's "no WiFi state" answer.
     override fun readWIFIState(): WIFIState? {
-        @Suppress("DEPRECATION") val wifiInfo =
-            LanternApp.wifiManager.connectionInfo ?: return null
-        var ssid = wifiInfo.ssid
-        if (ssid == "<unknown ssid>") {
-            return WIFIState("", "")
+        return try {
+            @Suppress("DEPRECATION") val wifiInfo =
+                LanternApp.wifiManager.connectionInfo ?: return null
+            var ssid = wifiInfo.ssid ?: return null
+            if (ssid == "<unknown ssid>") {
+                return WIFIState("", "")
+            }
+            if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
+                ssid = ssid.substring(1, ssid.length - 1)
+            }
+            WIFIState(ssid, wifiInfo.bssid ?: "")
+        } catch (e: Throwable) {
+            AppLogger.e("PlatformInterface", "readWIFIState() failed", e)
+            null
         }
-        if (ssid.startsWith("\"") && ssid.endsWith("\"")) {
-            ssid = ssid.substring(1, ssid.length - 1)
-        }
-        return WIFIState(ssid, wifiInfo.bssid)
     }
 
     private class InterfaceArray(private val iterator: Iterator<lantern.io.libbox.NetworkInterface>) :

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/PlatformInterfaceWrapper.kt
@@ -189,8 +189,12 @@ interface PlatformInterfaceWrapper : PlatformInterface {
     // leaves a pending JNI exception the Go side cannot observe or clear, which
     // aborts the process (SIGABRT) instead of surfacing an error. WifiManager is a
     // realistic source of one: connectionInfo raises SecurityException without
-    // location permission on some vendor builds, and returns entries whose ssid or
-    // bssid is null. Null is already this method's "no WiFi state" answer.
+    // location permission on some vendor builds, and can report a null ssid.
+    //
+    // Null means "no WiFi state", and is returned when there is no connection
+    // info, no ssid, or anything throws. A missing bssid does not invalidate the
+    // answer, so it degrades to an empty string — the same shape the existing
+    // "<unknown ssid>" case returns.
     override fun readWIFIState(): WIFIState? {
         return try {
             @Suppress("DEPRECATION") val wifiInfo =


### PR DESCRIPTION
Follow-up to #8947. [engineering#3761](https://github.com/getlantern/engineering/issues/3761)'s diagnosis named three ways the process could die a second after Connect; #8947 fixed the first. This handles the other two — and adds the instrumentation that says which one actually fires.

## 1. `readWIFIState()` — unguarded across a JNI boundary

`PlatformInterfaceWrapper.readWIFIState()` is called from Go through gomobile, and the interface method has **no error return**. A Kotlin throw therefore leaves a pending JNI exception the Go side can neither observe nor clear, and the process aborts (SIGABRT) rather than surfacing an error.

`WifiManager` is a realistic source of one: `connectionInfo` raises `SecurityException` without location permission on some vendor builds, and returns entries whose `ssid` or `bssid` is null — and the old code called `.startsWith(...)` on that `ssid` directly.

It now returns `null` on failure, which is already this method's "no WiFi state" answer. That matches its guarded siblings in the same file: `findConnectionOwner`, `uidByPackageName`, `getInterfaces`. It was the only unguarded one.

## 2. `DefaultNetworkListener` — a throw inside an unsupervised actor

The actor runs on `GlobalScope.actor(Dispatchers.Unconfined)` with no `CoroutineExceptionHandler`, so anything thrown reaches the thread's default handler and kills the process — **and takes the channel with it**, breaking every later network query even if the process survived.

Three branches can throw:

- `check(listeners.isNotEmpty())` on a `Get` with no listeners
- `register()`'s `ConnectivityManager` calls (`SecurityException`, `TooManyRequestsException`)
- the listener lambdas, which are caller-supplied

Each message is now handled under a guard. A failed `Get` is completed **exceptionally**, so its caller sees the error at `response.await()` instead of hanging forever on a `CompletableDeferred` nothing will ever complete — which is what happens today, on top of the crash.

Note `unregister()` was already wrapped in `runCatching`; `register()` wasn't. Same asymmetry as the `startForeground` bug in #8947.

## 3. Record why the process died

None of the above tells us which candidate killed *this* user's app. The OS already knows, so ask it: `getHistoricalProcessExitReasons` reports `reason`, `status`, `importance`, memory, and — for ANRs and native crashes — the tombstone trace.

Logged right after `AppLogger.init()` so it lands in `lantern.log` and arrives in an attached bug report. Placement matters: `AppLogger.init()` runs in `MainActivity`, not `Application.onCreate()`, so logging from the latter would never reach the file users actually attach.

This is the falsification step the diagnosis asked for, made automatic. It discriminates the three candidates and rules out `REASON_LOW_MEMORY` — and it addresses the root problem in #3761, which is that a system-killed process leaves a log that simply **stops**, with no reason recorded anywhere we can see.

Guarded so diagnostics can never be the reason startup fails; API-30-gated with `@RequiresApi` (minSdk here is 24); trace capped at 20k chars so a tombstone can't displace the rest of a bundle.

## Verification

Not compile-checked locally — the gomobile AAR isn't present in a fresh worktree. `android-compile-check.yml` builds the debug APK on any `*.kt` change and covers exactly this.

Checked by hand: brace balance across all three files, `AppLogger.w(tag, msg, throwable)` and `AppLogger.i(tag, msg)` signatures against `LanternLogger.kt`, `ApplicationExitInfo` constant names, and that `PlatformInterfaceWrapper` logs with a `"PlatformInterface"` string literal rather than a `TAG` constant (it has none).

## Scope

Defense in depth. Only the `ApplicationExitInfo` capture produces new evidence; the other two make failures reportable instead of fatal. If the reporter's crash turns out to be one of these rather than `startForeground`, they'll now get a logged error and a recorded exit reason instead of a vanished process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved network service reliability so individual processing errors do not interrupt subsequent requests.
  * Network information checks now fail safely when Wi‑Fi details are unavailable or incomplete.
  * Failed requests now report errors promptly instead of remaining pending.
  * Listener errors are isolated so one failing callback does not prevent others from receiving updates.

* **Diagnostics**
  * Added Android process-exit diagnostics to capture details about recent app terminations, crashes, and related system conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->