### PR TITLE
Update deferred Stripe renewal and retry handling

### DIFF
--- a/lib/core/services/stripe_service.dart
+++ b/lib/core/services/stripe_service.dart
@@ -127,10 +127,12 @@ class StripeService {
             },
             // The SDK confirms the intent itself with the payment method it
             // collected, so neither callback argument is needed here.
-            confirmHandler: (_, _) => _createSubscriptionAndConfirm(
-              createSubscriptionOnce,
-              intentMode,
-            ),
+            confirmHandler: (_, _) async {
+              await _createSubscriptionAndConfirm(
+                createSubscriptionOnce,
+                intentMode,
+              );
+            },
           ),
           merchantDisplayName: 'Lantern Pro',
           allowsDelayedPaymentMethods: true,

--- a/lib/core/services/stripe_service.dart
+++ b/lib/core/services/stripe_service.dart
@@ -1,26 +1,45 @@
-import 'dart:async';
-
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
 import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/models/user.dart';
+
+enum StripeIntentMode { payment, setup }
+
+/// Mirrors the backend's active one-time-purchase branch closely enough to
+/// choose the deferred PaymentSheet intent type before the backend creates the
+/// subscription. The backend returns a SetupIntent only for this case.
+StripeIntentMode stripeIntentModeForRenewal(
+  UserDataModel? userData, {
+  int? currentTimeSeconds,
+}) {
+  if (userData == null) return StripeIntentMode.payment;
+
+  final now =
+      currentTimeSeconds ?? DateTime.now().millisecondsSinceEpoch ~/ 1000;
+  final purchases = userData.purchases.trim();
+  final hasPurchaseHistory = purchases.isNotEmpty && purchases != '[]';
+  final hasActiveOneTimePurchase =
+      userData.isPro &&
+      userData.expiration > now &&
+      !userData.subscriptionData.autoRenew &&
+      userData.subscriptionData.subscriptionID.isEmpty &&
+      hasPurchaseHistory;
+
+  return hasActiveOneTimePurchase
+      ? StripeIntentMode.setup
+      : StripeIntentMode.payment;
+}
 
 class StripeService {
   /// Adopts the publishable key advertised by the plans response so the SDK
   /// always confirms intents against the same Stripe account/environment the
   /// backend creates them in (prod → live key, staging → test key). The SDK
-  /// no-ops on an unchanged key; applySettings pushes a changed one to the
-  /// native SDK right away so it's already applied by the time the payment
-  /// sheet initializes.
+  /// no-ops on an unchanged key. PaymentSheet applies and awaits changed
+  /// settings before it initializes.
   void updatePublishableKey(String? pubKey) {
     if (pubKey == null || pubKey.isEmpty) return;
     Stripe.publishableKey = pubKey;
-    unawaited(
-      Stripe.instance.applySettings().catchError((Object e) {
-        // Non-fatal: initPaymentSheet re-applies pending settings itself.
-        appLogger.error('Stripe applySettings failed', e);
-      }),
-    );
   }
 
   /// Presents the payment sheet using Stripe's deferred-intent flow: no
@@ -38,6 +57,7 @@ class StripeService {
     required BuildContext context,
     required int amount,
     required String email,
+    required StripeIntentMode intentMode,
     required Future<StripeOptions> Function() onCreateSubscription,
     required OnPressed onSuccess,
     required Function(dynamic error) onError,
@@ -65,23 +85,52 @@ class StripeService {
         placeholderText: context.textDisabled,
       );
 
+      // PaymentSheet can invoke its confirmation callback again when the user
+      // retries. Reuse the subscription that was already created so a retry
+      // cannot create another incomplete subscription. A failed request is
+      // cleared so a transient backend failure remains retryable.
+      Future<StripeOptions>? subscriptionFuture;
+      Future<StripeOptions> createSubscriptionOnce() async {
+        final existing = subscriptionFuture;
+        if (existing != null) return existing;
+
+        final pending = onCreateSubscription();
+        subscriptionFuture = pending;
+        try {
+          return await pending;
+        } catch (_) {
+          if (identical(subscriptionFuture, pending)) {
+            subscriptionFuture = null;
+          }
+          rethrow;
+        }
+      }
+
       // initPaymentSheet applies any pending settings (including the
       // publishable key) to the native SDK itself. If plans never provided
       // a key, this throws StripeConfigException into the catch below.
       await Stripe.instance.initPaymentSheet(
         paymentSheetParameters: SetupPaymentSheetParameters(
           intentConfiguration: IntentConfiguration(
-            mode: IntentMode.paymentMode(
-              currencyCode: 'USD',
-              amount: amount,
-              // The subscription charges this payment method on renewal, so
-              // it must be saved for off-session reuse.
-              setupFutureUsage: IntentFutureUsage.OffSession,
-            ),
+            mode: switch (intentMode) {
+              StripeIntentMode.payment => IntentMode.paymentMode(
+                currencyCode: 'USD',
+                amount: amount,
+                // The subscription charges this payment method on renewal, so
+                // it must be saved for off-session reuse.
+                setupFutureUsage: IntentFutureUsage.OffSession,
+              ),
+              StripeIntentMode.setup => const IntentMode.setupMode(
+                currencyCode: 'USD',
+                setupFutureUsage: IntentFutureUsage.OffSession,
+              ),
+            },
             // The SDK confirms the intent itself with the payment method it
             // collected, so neither callback argument is needed here.
-            confirmHandler: (_, _) =>
-                _createSubscriptionAndConfirm(onCreateSubscription),
+            confirmHandler: (_, _) => _createSubscriptionAndConfirm(
+              createSubscriptionOnce,
+              intentMode,
+            ),
           ),
           merchantDisplayName: 'Lantern Pro',
           allowsDelayedPaymentMethods: true,
@@ -122,6 +171,7 @@ class StripeService {
   /// lets the user retry, instead of crashing the flow.
   Future<void> _createSubscriptionAndConfirm(
     Future<StripeOptions> Function() onCreateSubscription,
+    StripeIntentMode intentMode,
   ) async {
     try {
       appLogger.info('Stripe: user tapped Pay, creating subscription');
@@ -131,12 +181,14 @@ class StripeService {
         '(subscriptionId: ${options.subscriptionId}, '
         'secret type: ${options.clientSecret.isNotEmpty ? 'payment' : 'setup'})',
       );
-      // The sheet was initialized with IntentMode.paymentMode, so it can only
-      // confirm a PaymentIntent secret. The trial path (user still has an
-      // unexpired one-time purchase) returns a SetupIntent secret instead,
-      // which this sheet can't confirm — fail with a retryable message rather
-      // than hand the SDK a mismatched intent type.
-      final secret = options.clientSecret;
+      // The client must return the same kind of intent used to initialize the
+      // deferred sheet. Active one-time purchases start with a free trial and
+      // therefore return a SetupIntent; ordinary purchases return a
+      // PaymentIntent.
+      final secret = switch (intentMode) {
+        StripeIntentMode.payment => options.clientSecret,
+        StripeIntentMode.setup => options.setupIntentClientSecret,
+      };
 
       if (secret.isEmpty) {
         throw Exception(
@@ -171,22 +223,20 @@ class StripeService {
 }
 
 extension StripeErrorMessage on StripeException {
-  /// API/integration error types hidden from the user: their messages carry
-  /// developer text (e.g. "Expired API Key provided: pk_live_…", which is
-  /// type api_error) rather than anything the user can act on. Everything
-  /// else (card declines, bad CVC, ...) shows Stripe's own localized message.
-  static const _hiddenErrorTypes = {
-    'api_error',
-    'authentication_error',
-    'invalid_request_error',
-  };
+  /// Stripe types whose localized messages are intended for customers. An
+  /// allowlist keeps new API/integration error types from accidentally
+  /// exposing developer details or publishable keys in the UI.
+  static const _userFacingErrorTypes = {'card_error', 'validation_error'};
 
   /// A message safe to show the user for this Stripe failure.
   String get userFacingMessage {
-    if (_hiddenErrorTypes.contains(error.type)) {
-      return 'an_error_occurred'.i18n;
+    if (_userFacingErrorTypes.contains(error.type) ||
+        error.declineCode != null) {
+      return error.localizedMessage ??
+          error.message ??
+          'an_error_occurred'.i18n;
     }
-    return error.localizedMessage ?? error.message ?? 'an_error_occurred'.i18n;
+    return 'an_error_occurred'.i18n;
   }
 }
 

--- a/lib/features/auth/choose_payment_method.dart
+++ b/lib/features/auth/choose_payment_method.dart
@@ -11,6 +11,7 @@ import 'package:lantern/core/models/referral_attach_response.dart';
 import 'package:lantern/core/services/injection_container.dart';
 import 'package:lantern/core/services/stripe_service.dart';
 import 'package:lantern/core/widgets/logs_path.dart';
+import 'package:lantern/features/home/provider/home_notifier.dart';
 import 'package:lantern/features/plans/provider/payment_notifier.dart';
 import 'package:lantern/features/plans/provider/plans_notifier.dart';
 import 'package:lantern/features/plans/provider/referral_notifier.dart';
@@ -200,9 +201,10 @@ class ChoosePaymentMethod extends HookConsumerWidget {
     // usdPrice is the backend's plan price in USD cents — always USD,
     // unlike the currency-keyed `price` map (local currency on CNY plans).
     final amount = userPlan.usdPrice;
+    final intentMode = _stripeIntentMode(ref);
     appLogger.info(
       'Stripe subscription flow started (plan: ${userPlan.id}, '
-      'amount: $amount cents)',
+      'amount: $amount cents, intent: ${intentMode.name})',
     );
 
     /// Deferred-intent flow: the sheet opens right away and the backend
@@ -214,6 +216,7 @@ class ChoosePaymentMethod extends HookConsumerWidget {
       context: context,
       amount: amount,
       email: email,
+      intentMode: intentMode,
       onCreateSubscription: () async {
         // paymentProvider is autoDispose, so it must be read here at Pay-tap
         // time — a notifier captured when the sheet opened is disposed by the
@@ -253,6 +256,17 @@ class ChoosePaymentMethod extends HookConsumerWidget {
         context.showSnackBar((error as Object).localizedDescription);
       },
     );
+  }
+
+  /// The Stripe backend gives users with an active one-time purchase a trial
+  /// subscription backed by a SetupIntent. Everyone else gets a PaymentIntent.
+  StripeIntentMode _stripeIntentMode(WidgetRef ref) {
+    if (authFlow != AuthFlow.renewSubscription) {
+      return StripeIntentMode.payment;
+    }
+
+    final userData = ref.read(homeProvider).value?.legacyUserData;
+    return stripeIntentModeForRenewal(userData);
   }
 
   Future<void> desktopStripePurchaseFlow(

--- a/lib/lantern_app.dart
+++ b/lib/lantern_app.dart
@@ -244,12 +244,13 @@ class _LanternAppState extends ConsumerState<LanternApp>
                 locale: locale.toLocale,
                 debugShowCheckedModeBanner: false,
                 builder: (context, child) {
-                  if (!isStaging) return child!;
+                  final router = child ?? const SizedBox.shrink();
+                  if (!isStaging) return router;
                   return Banner(
                     message: 'STAGING',
                     location: BannerLocation.topEnd,
                     color: AppColors.red6,
-                    child: child!,
+                    child: router,
                   );
                 },
                 theme: AppTheme.appTheme(),

--- a/test/core/services/stripe_service_test.dart
+++ b/test/core/services/stripe_service_test.dart
@@ -9,10 +9,16 @@ import 'package:lantern/core/services/stripe_service.dart';
 
 void main() {
   late _FakeStripePlatform platform;
+  late StripePlatform originalPlatform;
 
   setUpAll(() {
+    originalPlatform = StripePlatform.instance;
     platform = _FakeStripePlatform();
     StripePlatform.instance = platform;
+  });
+
+  tearDownAll(() {
+    StripePlatform.instance = originalPlatform;
   });
 
   setUp(() {
@@ -337,7 +343,13 @@ class _FakeStripePlatform extends StripePlatform {
     events.add('payment-sheet:present');
     for (var i = 0; i < confirmationsToRun; i++) {
       _intentCallbackCompleter = Completer<void>();
-      _confirmHandler!.call(_paymentMethod, false);
+      final confirmation = Function.apply(_confirmHandler!, [
+        _paymentMethod,
+        false,
+      ]);
+      if (confirmation is Future<void>) {
+        await confirmation;
+      }
       await _intentCallbackCompleter!.future;
     }
     return null;

--- a/test/core/services/stripe_service_test.dart
+++ b/test/core/services/stripe_service_test.dart
@@ -1,0 +1,371 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart' hide Card;
+import 'package:flutter_stripe/flutter_stripe.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/common/app_theme.dart';
+import 'package:lantern/core/models/user.dart';
+import 'package:lantern/core/services/stripe_service.dart';
+
+void main() {
+  late _FakeStripePlatform platform;
+
+  setUpAll(() {
+    platform = _FakeStripePlatform();
+    StripePlatform.instance = platform;
+  });
+
+  setUp(() {
+    platform.reset();
+  });
+
+  Future<BuildContext> pumpContext(WidgetTester tester) async {
+    late BuildContext result;
+    await tester.pumpWidget(
+      MaterialApp(
+        theme: AppTheme.appTheme(),
+        home: Builder(
+          builder: (context) {
+            result = context;
+            return const SizedBox.shrink();
+          },
+        ),
+      ),
+    );
+    return result;
+  }
+
+  testWidgets('publishable key is applied before PaymentSheet initializes', (
+    tester,
+  ) async {
+    final service = StripeService();
+    final context = await pumpContext(tester);
+
+    service.updatePublishableKey('pk_test_deferred_settings');
+    expect(platform.events, isEmpty);
+
+    await tester.runAsync(
+      () => service.startStripeSDK(
+        context: context,
+        amount: 1200,
+        email: '',
+        intentMode: StripeIntentMode.payment,
+        onCreateSubscription: () => throw StateError('should not be called'),
+        onSuccess: () {},
+        onError: (dynamic error) =>
+            throw TestFailure('Unexpected Stripe error: $error'),
+      ),
+    );
+
+    expect(platform.events, [
+      'initialise:start',
+      'initialise:end',
+      'payment-sheet:init',
+      'payment-sheet:present',
+    ]);
+  });
+
+  testWidgets('payment retries reuse the created subscription', (tester) async {
+    final service = StripeService();
+    final context = await pumpContext(tester);
+    var creationCount = 0;
+    platform.confirmationsToRun = 2;
+
+    await tester.runAsync(
+      () => service.startStripeSDK(
+        context: context,
+        amount: 1200,
+        email: 'user@example.com',
+        intentMode: StripeIntentMode.payment,
+        onCreateSubscription: () async {
+          creationCount++;
+          return StripeOptions(
+            clientSecret: 'pi_secret',
+            setupIntentClientSecret: '',
+            subscriptionId: 'sub_123',
+          );
+        },
+        onSuccess: () {},
+        onError: (dynamic error) =>
+            throw TestFailure('Unexpected Stripe error: $error'),
+      ),
+    );
+
+    expect(creationCount, 1);
+    expect(platform.intentCallbacks, hasLength(2));
+    expect(
+      platform.intentCallbacks.map((callback) => callback.clientSecret),
+      everyElement('pi_secret'),
+    );
+    expect(
+      platform.paymentSheetParameters!.intentConfiguration!.mode.toJson(),
+      containsPair('runtimeType', 'paymentMode'),
+    );
+  });
+
+  testWidgets('a failed subscription request can be retried', (tester) async {
+    final service = StripeService();
+    final context = await pumpContext(tester);
+    var creationCount = 0;
+    platform.confirmationsToRun = 2;
+
+    await tester.runAsync(
+      () => service.startStripeSDK(
+        context: context,
+        amount: 1200,
+        email: 'user@example.com',
+        intentMode: StripeIntentMode.payment,
+        onCreateSubscription: () async {
+          creationCount++;
+          if (creationCount == 1) throw Exception('Temporary failure');
+          return StripeOptions(
+            clientSecret: 'pi_retry_secret',
+            setupIntentClientSecret: '',
+            subscriptionId: 'sub_retry',
+          );
+        },
+        onSuccess: () {},
+        onError: (dynamic error) =>
+            throw TestFailure('Unexpected Stripe error: $error'),
+      ),
+    );
+
+    expect(creationCount, 2);
+    expect(platform.intentCallbacks.first.error, isNotNull);
+    expect(platform.intentCallbacks.last.clientSecret, 'pi_retry_secret');
+  });
+
+  testWidgets('setup mode confirms the backend SetupIntent', (tester) async {
+    final service = StripeService();
+    final context = await pumpContext(tester);
+    platform.confirmationsToRun = 1;
+
+    await tester.runAsync(
+      () => service.startStripeSDK(
+        context: context,
+        amount: 1200,
+        email: 'user@example.com',
+        intentMode: StripeIntentMode.setup,
+        onCreateSubscription: () async => StripeOptions(
+          clientSecret: '',
+          setupIntentClientSecret: 'seti_secret',
+          subscriptionId: 'sub_trial',
+        ),
+        onSuccess: () {},
+        onError: (dynamic error) =>
+            throw TestFailure('Unexpected Stripe error: $error'),
+      ),
+    );
+
+    expect(platform.intentCallbacks.single.clientSecret, 'seti_secret');
+    expect(
+      platform.paymentSheetParameters!.intentConfiguration!.mode.toJson(),
+      containsPair('runtimeType', 'setupMode'),
+    );
+  });
+
+  group('StripeErrorMessage', () {
+    StripeException stripeError({
+      required String type,
+      String? localizedMessage,
+      String? declineCode,
+    }) => StripeException(
+      error: LocalizedErrorMessage(
+        code: FailureCode.Failed,
+        type: type,
+        localizedMessage: localizedMessage,
+        declineCode: declineCode,
+      ),
+    );
+
+    test('shows card and validation errors', () {
+      expect(
+        stripeError(
+          type: 'card_error',
+          localizedMessage: 'Your card was declined.',
+        ).userFacingMessage,
+        'Your card was declined.',
+      );
+      expect(
+        stripeError(
+          type: 'validation_error',
+          localizedMessage: 'Check the card number.',
+        ).userFacingMessage,
+        'Check the card number.',
+      );
+    });
+
+    test('shows decline messages even when Stripe omits the type', () {
+      expect(
+        stripeError(
+          type: '',
+          localizedMessage: 'Insufficient funds.',
+          declineCode: 'insufficient_funds',
+        ).userFacingMessage,
+        'Insufficient funds.',
+      );
+    });
+
+    test('hides known and unknown integration errors', () {
+      final apiMessage = stripeError(
+        type: 'api_error',
+        localizedMessage: 'Expired API Key: pk_live_sensitive',
+      ).userFacingMessage;
+      final unknownMessage = stripeError(
+        type: 'future_internal_error',
+        localizedMessage: 'Internal Stripe detail',
+      ).userFacingMessage;
+
+      expect(apiMessage, isNot(contains('pk_live_sensitive')));
+      expect(unknownMessage, apiMessage);
+    });
+  });
+
+  test(
+    'StripeOptions keeps PaymentIntent and SetupIntent secrets separate',
+    () {
+      final options = StripeOptions.fromJson({
+        'clientSecret': 'pi_secret',
+        'pending_secret': 'seti_secret',
+        'subscriptionId': 'sub_123',
+      });
+
+      expect(options.clientSecret, 'pi_secret');
+      expect(options.setupIntentClientSecret, 'seti_secret');
+      expect(options.subscriptionId, 'sub_123');
+    },
+  );
+
+  group('stripeIntentModeForRenewal', () {
+    test('uses setup mode for an unexpired one-time purchaser', () {
+      const user = UserDataModel(
+        userLevel: 'pro',
+        expiration: 2000,
+        purchases: '[{plan: yearly}]',
+      );
+
+      expect(
+        stripeIntentModeForRenewal(user, currentTimeSeconds: 1000),
+        StripeIntentMode.setup,
+      );
+    });
+
+    test('uses payment mode without an active one-time purchase', () {
+      const expiredPurchase = UserDataModel(
+        userLevel: 'pro',
+        expiration: 500,
+        purchases: '[{plan: yearly}]',
+      );
+      const activeSubscription = UserDataModel(
+        userLevel: 'pro',
+        expiration: 2000,
+        purchases: '[{plan: yearly}]',
+        subscriptionData: SubscriptionDataModel(
+          subscriptionID: 'sub_existing',
+          autoRenew: true,
+        ),
+      );
+      const noPurchase = UserDataModel(
+        userLevel: 'pro',
+        expiration: 2000,
+        purchases: '[]',
+      );
+
+      expect(
+        stripeIntentModeForRenewal(expiredPurchase, currentTimeSeconds: 1000),
+        StripeIntentMode.payment,
+      );
+      expect(
+        stripeIntentModeForRenewal(
+          activeSubscription,
+          currentTimeSeconds: 1000,
+        ),
+        StripeIntentMode.payment,
+      );
+      expect(
+        stripeIntentModeForRenewal(noPurchase, currentTimeSeconds: 1000),
+        StripeIntentMode.payment,
+      );
+    });
+  });
+}
+
+class _FakeStripePlatform extends StripePlatform {
+  final events = <String>[];
+  final intentCallbacks = <IntentCreationCallbackParams>[];
+  SetupPaymentSheetParameters? paymentSheetParameters;
+  ConfirmHandler? _confirmHandler;
+  Completer<void>? _intentCallbackCompleter;
+  int confirmationsToRun = 0;
+
+  void reset() {
+    events.clear();
+    intentCallbacks.clear();
+    paymentSheetParameters = null;
+    _confirmHandler = null;
+    _intentCallbackCompleter = null;
+    confirmationsToRun = 0;
+  }
+
+  @override
+  Future<void> initialise({
+    required String publishableKey,
+    String? stripeAccountId,
+    ThreeDSecureConfigurationParams? threeDSecureParams,
+    String? merchantIdentifier,
+    String? urlScheme,
+    bool? setReturnUrlSchemeOnAndroid,
+  }) async {
+    events.add('initialise:start');
+    events.add('initialise:end');
+  }
+
+  @override
+  Future<PaymentSheetPaymentOption?> initPaymentSheet(
+    SetupPaymentSheetParameters params,
+  ) async {
+    events.add('payment-sheet:init');
+    paymentSheetParameters = params;
+    _confirmHandler = params.intentConfiguration?.confirmHandler;
+    return null;
+  }
+
+  @override
+  Future<PaymentSheetPaymentOption?> presentPaymentSheet({
+    PaymentSheetPresentOptions? options,
+  }) async {
+    events.add('payment-sheet:present');
+    for (var i = 0; i < confirmationsToRun; i++) {
+      _intentCallbackCompleter = Completer<void>();
+      _confirmHandler!.call(_paymentMethod, false);
+      await _intentCallbackCompleter!.future;
+    }
+    return null;
+  }
+
+  @override
+  Future<void> intentCreationCallback(
+    IntentCreationCallbackParams params,
+  ) async {
+    intentCallbacks.add(params);
+    _intentCallbackCompleter?.complete();
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+const _paymentMethod = PaymentMethod(
+  id: 'pm_test',
+  livemode: false,
+  paymentMethodType: 'card',
+  billingDetails: BillingDetails(),
+  card: Card(),
+  sepaDebit: SepaDebit(),
+  bacsDebit: BacsDebit(),
+  auBecsDebit: AuBecsDebit(),
+  ideal: Ideal(),
+  fpx: Fpx(),
+  upi: Upi(),
+  usBankAccount: UsBankAccount(),
+);


### PR DESCRIPTION
- Handle both PaymentIntent and SetupIntent subscription flows
- Prevent PaymentSheet retries from creating duplicate subscriptions
- Adds Stripe tests covering both intent modes, retries, initialization, and error filtering