### PR TITLE
bump radiance to pick up the client-info fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260730165907-b8630814fc55
+	github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -171,7 +171,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 // indirect
-	github.com/getlantern/lantern-box v0.0.106 // indirect
+	github.com/getlantern/lantern-box v0.0.107 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.106 h1:5czWMqdgrhCslLcE+ttt+us+d0dmCutpjxqmCOZnqKw=
-github.com/getlantern/lantern-box v0.0.106/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
+github.com/getlantern/lantern-box v0.0.107 h1:uTRoj5BKijO6Q2a9JZWunFL7Z29WDg8WzEuoliJ+kJg=
+github.com/getlantern/lantern-box v0.0.107/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
@@ -259,10 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb h1:1VhnolDkNBFI7LmG6IAHgabJKrR7/B8LOYLFEne5wuo=
-github.com/getlantern/radiance v0.0.0-20260730161730-76fcac0ceebb/go.mod h1:BUKzQxV+sKuRySBLPTVHDt1XkPqoIdx/G+pB9euO4LQ=
-github.com/getlantern/radiance v0.0.0-20260730165907-b8630814fc55 h1:yHcB5/Z9KHAKxxnshRQKzNWdWZMFvaFwmcxq+AG9P3g=
-github.com/getlantern/radiance v0.0.0-20260730165907-b8630814fc55/go.mod h1:BUKzQxV+sKuRySBLPTVHDt1XkPqoIdx/G+pB9euO4LQ=
+github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89 h1:ZgdE/qPjx7ptpv0msnu4NSReL9neFlXQzC7kDVYty6g=
+github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89/go.mod h1:ZfvjwdgV6HbffcH7ZAkLsmt5Vs3TTd4AbWJMajOeyww=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Final step of the chain from getlantern/lantern-box#294 → getlantern/radiance#586/#587 → here. Tracked as getlantern/engineering#3773.

| | from | to |
|---|---|---|
| radiance | `20260730165907-b8630814fc55` | `20260805182705-0aebcab87c89` |
| lantern-box (indirect) | v0.0.106 | **v0.0.107** |

## What this delivers

**The server half** (lantern-box#294). `readInfo` decided whether a flow carried client info from a **single** `Conn.Read`, then prefix-matched whatever that returned. TCP is a stream, so an 11-byte `CLIENTINFO ` prefix split across reads — routine under DPI throttling — was read as ordinary traffic. The server never sent `OK`, so the client blocked on its response read; and the fall-through forwarded the prefix bytes to the real destination, which reset the connection.

From RU Android logs ([ticket #180956](https://lantern.freshdesk.com/a/tickets/180956), 438 occurrences Aug 1–5): **954s median**, 1964s max, 312 of 438 over two minutes. Shared root cause behind #3718 (Iran/Android UDP) and #3772 (Windows TCP).

**Three other fixes in the radiance range** that bear on the same reports:

- **`fix: removing reject quic rule`** (radiance#585) — those logs show 949 `match[8] network=udp port=443 => reject` with 949 matching `connection closed: rejected`; QUIC was being rejected outright, forcing TCP fallback
- **`fronted: race a jsDelivr mirror for the config`** (radiance#575) — against 13,185 `Failed to dial front`, 8,033 of them `network is unreachable` to Akamai IPs from RU
- **`smart: one dialer per config host`** (radiance#579) and the reversed disorder/split ordering fix (#580)

## Incidental cleanup

`go mod tidy` also removes a stale `radiance 76fcac0ceebb` hash pair that a previous bump left in `go.sum`. Same hazard as radiance#587: a superseded version keeping valid hashes is what let a build resolve `lantern-box v0.0.58` while `go.mod` declared v0.0.65 on 2026-04-13, silently disabling Reflex for every user.

## Verification

Done on a clean `git worktree` of `origin/main` with no untracked files — the contamination that caused radiance#587 came from verifying in a dirty tree, so this was checked the other way:

- `go mod tidy` — exit 0
- `go mod verify` — all modules verified
- `go build ./...` and `go vet ./...` — clean
- `go test ./...` — 5 packages pass, rest have no tests
- confirmed both halves are actually reachable in the resolved module:
  - `tracker/clientcontext/manager.go` → `io.ReadAtLeast(c.Conn, buf[:], len(packetPrefix))`
  - `tracker/clientcontext/injector.go` → `sendInfoTimeout`

## Note on rollout

The server-side fix only takes effect once **the proxy fleet** runs v0.0.107. This PR is what gets the client half — the 10s deadline instead of a kernel-timeout stall — into a release, and stops one stalled flow holding a healthy-pool slot for 16 minutes.

Both `v9.1.17-beta` and `v9.1.18-beta` were cut before any of this; the deadline fix has been on `main` and unreleased since 2026-07-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->