### PR TITLE
Fix: duplicate connect toggle tears down the winning VPN attempt

### DIFF
--- a/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt
@@ -215,9 +215,16 @@ class MethodHandler : FlutterPlugin,
                     result.runCatching {
                         val map = call.arguments as Map<*, *>
                         val tag = map["serverName"] as String? ?: error("Missing serverName")
+                        // As in Methods.Start above: the connect runs for seconds inside
+                        // the service, and the Dart toggle debounces only on a connecting
+                        // / disconnecting state. Without this post the state stays
+                        // disconnected for the whole attempt, so a second tap dispatches a
+                        // duplicate connect (Freshdesk #181166).
+                        VpnStatusManager.postVPNStatus(VPNStatus.Connecting)
                         MainActivity.instance.connectToServer(tag)
                         success("ok")
                     }.onFailure { e ->
+                        VpnStatusManager.postVPNStatus(VPNStatus.Disconnected)
                         result.error(
                             "set_private_server",
                             e.localizedMessage ?: "Please try again",

--- a/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
+++ b/android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt
@@ -403,6 +403,10 @@ class LanternVpnService :
             VpnStatusManager.postVPNStatus(VPNStatus.MissingPermission)
             return@withContext
         }
+        // Ownership of connectInFlight passes to the Deferred completion path below once
+        // the connect coroutine exists; until then any failure has to release it here or
+        // the flag wedges every later attempt.
+        var connectLaunched = false
         runCatching {
             // Show foreground notification immediately — required by the OS as soon as
             // VPN service starts, replaced by the connected notification on success.
@@ -411,8 +415,19 @@ class LanternVpnService :
             // so a refusal takes this operation's own failure path — errorCode-tagged
             // reporting, network-monitor teardown, and serviceCleanUp when the caller
             // asked for it — rather than the service-wide handler, which only logs and
-            // posts a generic error.
+            // posts a generic error. Runs before the in-flight check below because the
+            // OS still expects a startForeground() for the duplicate startForegroundService().
             notificationHelper.showStartingVPNConnectedNotification(this@LanternVpnService)
+            // Reject concurrent attempts so repeated retries while a previous call is
+            // stuck in JNI don't accumulate orphan coroutines on Dispatchers.IO. Claim
+            // the flag before touching any shared state and leave by returning rather
+            // than throwing: a rejected attempt owns none of the state the failure path
+            // tears down, and doing it anyway unregistered the winning attempt's network
+            // listener and posted Error moments before its tunnel came up (Freshdesk #181166).
+            if (!connectInFlight.compareAndSet(false, true)) {
+                AppLogger.d(TAG, "Ignoring VPN operation ($errorCode): previous connect attempt still in flight")
+                return@withContext
+            }
             // Radiance is pre-warmed via ACTION_START_RADIANCE, but as a background
             // service it may have been killed by the OS before setup completed.
             // Re-run setup here under the foreground notification so it is guaranteed
@@ -447,16 +462,12 @@ class LanternVpnService :
             // of a frozen button only a phone reboot can clear
             // (Freshdesk #173507).
             //
-            // Reject concurrent attempts with connectInFlight so repeated
-            // retries while a previous call is stuck in JNI don't accumulate
-            // orphan coroutines on Dispatchers.IO. Clear the flag from the
-            // Deferred completion path so early cancellation before the async
-            // body starts can't wedge future attempts.
-            if (!connectInFlight.compareAndSet(false, true)) {
-                throw IllegalStateException("previous VPN connect attempt still in flight")
-            }
+            // connectInFlight is cleared from the Deferred completion path so
+            // early cancellation before the async body starts can't wedge
+            // future attempts.
             val connectScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
             val deferred = connectScope.async { connect() }
+            connectLaunched = true
             deferred.invokeOnCompletion {
                 connectInFlight.set(false)
             }
@@ -474,6 +485,7 @@ class LanternVpnService :
                 QuickTileService.triggerUpdateTileState(this@LanternVpnService, true)
             }
         }.onFailure { e ->
+            if (!connectLaunched) connectInFlight.set(false)
             val timedOut = e is TimeoutCancellationException
             if (timedOut) {
                 AppLogger.e(TAG, "VPN operation ($errorCode) timed out after ${VPN_START_TIMEOUT_MS}ms — Go side likely deadlocked", e)


### PR DESCRIPTION
## Summary
Auto-fix for Freshdesk ticket [#181166](https://lantern.freshdesk.com/a/tickets/181166) (Android 9.1.18, China / AS4134, Pro user: "打开软件跟没打开一样始终连接不上").

**Root cause:** `Methods.ConnectToServer` posts no `VPNStatus.Connecting`, so the duplicate connect it lets through is rejected in a way that tears down the network listener owned by the attempt that is still running.

Chain, as observed in the ticket's logs (36 occurrences over the capture; the reported session at `03:44:22.612`–`03:44:27.068`):

1. `MethodHandler.kt` `Methods.ConnectToServer` dispatched without posting `VPNStatus.Connecting`, unlike its sibling `Methods.Start`. The only debounce for the toggle is the Dart guard in `lib/features/vpn/provider/vpn_notifier.dart`, which returns early only on `connecting` / `disconnecting` — so the state stayed `disconnected` for the entire ~4.4 s connect and a second tap 1.48 s later dispatched a duplicate `ACTION_CONNECT_TO_SERVER`.
2. The duplicate hit the `connectInFlight` single-flight gate in `LanternVpnService.launchVPN`, which rejected it by `throw`ing into the shared `runCatching { }.onFailure { }`. That failure path belongs to the *in-flight, ultimately successful* attempt, so the rejected attempt: posted `VPNStatus.Error` (UI showed Error 202 ms before the tunnel reported `Connected`), called `DefaultNetworkMonitor.setNetworkChangeCallback(null)` + `stop()`, and — for the `start_vpn` variant, which sets `cleanUpOnFailure = true` — ran `serviceCleanUp()`, unregistering the VPN status receiver.
3. `DefaultNetworkListener.listeners` is keyed by the `DefaultNetworkMonitor` singleton, so both attempts share one entry: the loser's `stop()` unregisters the connectivity callback outright. The winner never re-registers, so `updateUnderlyingNetworks()` stops firing on Wi-Fi/cellular roam — the tunnel reports Connected while outbound dials fail (14,611 `dial wlan0 (42)` / `rmnet0 (8): i/o timeout` in the capture, only 25 `updated default interface` events over three days).

## What changed
`android/app/src/main/kotlin/org/getlantern/lantern/handler/MethodHandler.kt`
- `Methods.ConnectToServer` now posts `VPNStatus.Connecting` before dispatching and resets to `VPNStatus.Disconnected` in `onFailure`, matching `Methods.Start`. This arms the Dart guard for the whole connect so the duplicate is never dispatched.

`android/app/src/main/kotlin/org/getlantern/lantern/service/LanternVpnService.kt`
- The `connectInFlight` check moves ahead of the `DefaultNetworkMonitor` setup and exits with `return@withContext` instead of `throw`, so a rejected attempt performs no teardown and posts no status. It stays after `showStartingVPNConnectedNotification()` because the OS still expects a `startForeground()` for the duplicate `startForegroundService()`.
- Because the flag is now claimed before `setupRadiance()` / the monitor setup, `onFailure` releases it when the connect coroutine was never created (`connectLaunched`), so a failure in that window can't wedge every later attempt.

Diagnosis was written against `v9.1.18-beta` (`dcd5bbb1b`); the change is rebased onto current `main`, where `launchVPN` has since moved the foreground-notification call inside `runCatching`.

## Test plan
- [ ] Cold-start with radiance not yet initialized (so `setupRadiance()` runs inside `launchVPN`), select a specific (non-auto) server so the Dart path is `connectToServer`, tap the toggle twice ~1.5 s apart. Expect: one `ACTION_CONNECT_TO_SERVER` dispatch, second tap filtered by the Dart guard, no `previous VPN connect attempt still in flight`, no `Error` before `Connected`.
- [ ] With the Dart guard bypassed (or via a rapid double intent), confirm the rejected attempt logs `Ignoring VPN operation (...)`, leaves `DefaultNetworkListener` registered, and posts no status.
- [ ] Force a failure inside `setupRadiance()` and confirm a subsequent connect attempt still runs (flag released).
- [ ] Toggle connect/disconnect repeatedly and verify no state gets stuck in `connecting` (VPN consent denial should still land on `MissingPermission`).
- [ ] Wi-Fi ⇄ cellular roam while connected: `updated default interface` continues to fire.

---
*Auto-generated by `/issue-fix` from an interactive `/ticket-autodiagnose` run.*