### PR TITLE
go.mod: bump radiance for the unbounded teardown fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260809065423-4a83abc7c33a
+	github.com/getlantern/radiance v0.0.0-20260810184453-2a25d888b977
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -165,13 +165,13 @@ require (
 	github.com/gaukas/wazerofs v0.1.0 // indirect
 	github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 // indirect
 	github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c // indirect
-	github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 // indirect
+	github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 // indirect
 	github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c // indirect
 	github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac // indirect
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 // indirect
-	github.com/getlantern/lantern-box v0.0.107 // indirect
+	github.com/getlantern/lantern-box v0.0.111 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,10 +60,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa h1:LHTHcTQiSGT7VVbI0o4wBRNQIgn917usHWOd6VAffYI=
 github.com/alexbrainman/sspi v0.0.0-20231016080023-1a75b4708caa/go.mod h1:cEWa1LVoE5KvSD9ONXsZrj0z6KqySlCCNKHlLzbqAt4=
-github.com/alexflint/go-arg v1.6.1 h1:uZogJ6VDBjcuosydKgvYYRhh9sRCusjOvoOLZopBlnA=
-github.com/alexflint/go-arg v1.6.1/go.mod h1:nQ0LFYftLJ6njcaee0sU+G0iS2+2XJQfA8I062D0LGc=
-github.com/alexflint/go-scalar v1.2.0 h1:WR7JPKkeNpnYIOfHRa7ivM21aWAdHD0gEWHCx+WQBRw=
-github.com/alexflint/go-scalar v1.2.0/go.mod h1:LoFvNMqS1CPrMVltza4LvnGKhaSpc3oyLEBUZVhhS2o=
 github.com/alitto/pond v1.9.2 h1:9Qb75z/scEZVCoSU+osVmQ0I0JOeLfdTDafrbcJ8CLs=
 github.com/alitto/pond v1.9.2/go.mod h1:xQn3P/sHTYcU/1BR3i86IGIrilcrGC2LiS+E2+CJWsI=
 github.com/anacrolix/btree v0.0.0-20251201064447-d86c3fa41bd8 h1:c02PsmoaChabVqAFm7pqPI1UIkDdDAjUaWa6ZmfxybQ=
@@ -227,8 +223,8 @@ github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52 h1:w2/RqYPw7Pb
 github.com/getlantern/algeneva v0.0.0-20250307163401-1824e7b54f52/go.mod h1:PrNR8tMXO26YNs8K9653XCUH7u2Kv4OdfFC3Ke1GsX0=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6wPYUq8Smntlgg+y39L5OOyMJY+k=
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
-github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86 h1:r7j54Ol1wak59OY0SK2Fw5lOI3YvrAEDW3QAQEj12mA=
-github.com/getlantern/broflake v0.0.0-20260717153233-f2cacf69fe86/go.mod h1:bIxM6xon/ADgprn6tZXYdXGrUIMCzq6u8zO9rET50IE=
+github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
+github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
 github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c h1:Hpxu12ORnAcyYuIqV2yAqrmDAnTaY1Cd3yL7TvFB6ME=
 github.com/getlantern/common v1.2.1-0.20260708083946-cc657b08792c/go.mod h1:eSSuV4bMPgQJnczBw+KWWqWNo1itzmVxC++qUBPRTt0=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
@@ -249,8 +245,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.107 h1:uTRoj5BKijO6Q2a9JZWunFL7Z29WDg8WzEuoliJ+kJg=
-github.com/getlantern/lantern-box v0.0.107/go.mod h1:HHdmZsGwkiaweBycCYv1Jolk3jkrXbb/R5UUXtY2n3o=
+github.com/getlantern/lantern-box v0.0.111 h1:1DNrhaxpn9mRE7qMX/efi1I4wYx4FoBh7stVFIEPcYU=
+github.com/getlantern/lantern-box v0.0.111/go.mod h1:avZOnXNHLNT/d/Mrkjqn8i02HB1C805Dk7EtcWYq9lw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
@@ -263,10 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89 h1:ZgdE/qPjx7ptpv0msnu4NSReL9neFlXQzC7kDVYty6g=
-github.com/getlantern/radiance v0.0.0-20260805182705-0aebcab87c89/go.mod h1:ZfvjwdgV6HbffcH7ZAkLsmt5Vs3TTd4AbWJMajOeyww=
-github.com/getlantern/radiance v0.0.0-20260809065423-4a83abc7c33a h1:Trb3QueFk+fYxoJHqrnpkRAmH/NrVftQzJeWPABdLVQ=
-github.com/getlantern/radiance v0.0.0-20260809065423-4a83abc7c33a/go.mod h1:ZfvjwdgV6HbffcH7ZAkLsmt5Vs3TTd4AbWJMajOeyww=
+github.com/getlantern/radiance v0.0.0-20260810184453-2a25d888b977 h1:YV1CnZVxT7sIgzNYUdfYXL6i7tMmWnEZ++RSRI7TFQM=
+github.com/getlantern/radiance v0.0.0-20260810184453-2a25d888b977/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
## Why

Final link in the chain that delivers the unbounded teardown-leak fix to clients, and a prerequisite for 9.1.20-beta.

getlantern/unbounded#412 (merged) → getlantern/lantern-box#297, `v0.0.111` (merged) → getlantern/radiance#593 (merged) → **this**.

`radiance → v0.0.0-20260810184453-2a25d888b977`, transitively upgrading `lantern-box 0.0.107 → 0.0.111` and `broflake f2cacf69fe86 → bef5e5234952`.

## What was leaking

A broflake `WorkerFSM` parked in a control-plane send on `com.tx` could not be cancelled — the send had no ctx guard, and the FSM only checks `ctx.Done()` *between* states. Its `wg.Done()` never ran, so `BroflakeEngine.stop()`, which waited on that `WaitGroup` before cancelling the engine ctx, never released the bus, both routers, or any other worker. Every re-create of the unbounded outbound retained a full WebRTC/ICE stack.

Signature in Freshdesk 181174 (Windows 9.1.18, CN): the outbound re-created **82 times in 13h at a flat ~6/hr**, CPU climbing to 80% with disk at 0 MB/s and network at 0 Mbps — a per-event leak, not a spin. Reproduced in broflake's tests at 30 goroutines leaked over 10 create/stop cycles, 0 after the fix.

## Why this needed radiance#577 merged first

`main`'s previous pin, `4a83abc`, was **not on radiance `main`** — it was the tip of the unmerged `atavism/issue-3723` branch, pinned in #8926 so this repo could use `lanternd --environment staging`. Bumping straight to radiance main would have silently dropped that flag, which `.github/scripts/windows_smoke_suite.ps1:318` invokes:

```powershell
-ArgumentList @("install", "--environment", $ServiceEnvironment)
```

`go build` and `go test` do **not** catch that — it is a runtime CLI contract, exercised only by the PowerShell smoke suite. radiance#577 was merged first so main carries both changes.

Verified by content diff rather than ancestry (a squash merge means the old branch tip is not an ancestor by construction): `git diff 4a83abc 2a25d88` touches **only** `go.mod`/`go.sum`, and `cmd/lanternd/` is byte-identical — so #577's work is fully preserved and nothing is reverted. The `--environment` flag is present in the new pin at `cmd/lanternd/lanternd.go:33,40`.

## Testing

`CGO_ENABLED=1 go build` and `go test` with the CI tag set (`with_gvisor,with_quic,with_wireguard,with_utls,with_grpc,with_conntrack`): build clean, 5 packages, 0 failures.

Also verified the resolved modules actually carry the fix rather than trusting version strings — `sendCtx` present in the resolved broflake, and `unbounded.Outbound.Close()` calling `ui.Stop()` before `ql.Close()` in the resolved lantern-box.

## Prod mitigation already live

Track `unbounded-linode-free` (id 1570) had its client-version floor raised `>=9.1.16` → `>=9.1.20-beta`, so **no currently-released client receives unbounded**. Verified against `/v1/config-new`: 9.1.19 → 0/5 probes, 9.1.20-beta → 4/5, 9.1.20 → 4/5 (misses are bandit selection, not eligibility — the server strips the prerelease before the constraint check, so beta and final behave identically).

9.1.20-beta is therefore the first release to receive unbounded again, and it must ship with this bump.

## Pre-PR review (local Codex gate)
- Rounds: 2 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: `go.mod:28` — round 1 caught that the bump dropped radiance's `lanternd --environment` support, because the old pin was an unmerged branch tip. Resolved by merging radiance#577 first and re-pinning to a main that contains both.
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal libraries to newer versions.
  * Improved compatibility and maintenance through dependency updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->