### PR TITLE
harmonize desktop payment smoke tests

### DIFF
--- a/.github/scripts/macos_payment_checkout_smoke.sh
+++ b/.github/scripts/macos_payment_checkout_smoke.sh
@@ -17,6 +17,12 @@ cleanup() {
   exit "$status"
 }
 
+# This script deletes the shared Lantern data directory.
+if [[ -z "${CI:-}" ]]; then
+  echo "Refusing to run outside CI: this wipes $LANTERN_DATA_DIR" >&2
+  exit 1
+fi
+
 trap cleanup EXIT
 
 pkill -x Lantern 2>/dev/null || true
@@ -24,13 +30,15 @@ rm -rf "$LANTERN_DATA_DIR"
 mkdir -p "$LANTERN_LOG_DIR"
 mkdir -p "$ARTIFACT_DIR"
 
+# The debug test build reads this marker before initializing Radiance.
+touch "$LANTERN_DATA_DIR/.radiance_env"
+
 flutter test \
   "$TEST_PATH" \
   -d macos \
   --reporter=expanded \
   --dart-define=DISABLE_SYSTEM_TRAY=true \
-  --dart-define=PAYMENT_SMOKE_SCREENSHOT_PATH="$SCREENSHOT_PATH" \
-  --dart-define=RADIANCE_ENV=staging
+  --dart-define=PAYMENT_SMOKE_SCREENSHOT_PATH="$SCREENSHOT_PATH"
 
 if [[ ! -s "$SCREENSHOT_PATH" ]]; then
   echo "Stripe Checkout screenshot was not created" >&2

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -211,6 +211,15 @@ jobs:
             -RunConnectSmoke:$false `
             -RunPaymentConversionSmoke
 
+      - name: Upload Windows payment smoke logs
+        if: ${{ always() && (inputs.run_payment_checkout_smoke || inputs.run_payment_conversion_smoke) }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: windows-payment-smoke-logs
+          path: C:\Users\Public\Lantern\logs
+          if-no-files-found: ignore
+          retention-days: 7
+
       - name: Sign embedded binaries
         if: ${{ !inputs.skip_signing }}
         shell: pwsh

--- a/integration_test/payment/desktop_stripe_checkout_smoke_test.dart
+++ b/integration_test/payment/desktop_stripe_checkout_smoke_test.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 import 'dart:io';
-import 'dart:math';
+import 'dart:math' show max;
 import 'dart:typed_data';
 import 'dart:ui' as ui;
 
@@ -13,8 +13,10 @@ import 'package:lantern/core/models/plan_data.dart' as plan_models;
 import 'package:lantern/core/widgets/app_webview.dart';
 import 'package:lantern/features/home/provider/home_notifier.dart';
 import 'package:lantern/features/plans/provider/plans_notifier.dart';
-import 'package:lantern/lantern_app.dart';
 import 'package:lantern/main.dart' as app;
+
+import '../utils/app_robot.dart';
+import '../utils/payment_robot.dart';
 
 const _stripeHost = 'checkout.stripe.com';
 const _e2eHost = 'api.staging.iantem.io';
@@ -71,23 +73,12 @@ void main() {
 
 Future<_RunningApp> _launchApp(WidgetTester tester) async {
   await app.main();
-  await _waitFor(
-    tester,
-    () => find.byType(LanternApp).evaluate().isNotEmpty,
-    timeout: const Duration(seconds: 30),
-    failure: () => 'Lantern did not render its Flutter UI',
-  );
-
-  final appElement = find.byType(LanternApp).evaluate().first;
-  final container = ProviderScope.containerOf(appElement, listen: false);
-  final plansSubscription = container.listen(plansProvider, (_, _) {});
-  addTearDown(plansSubscription.close);
-
-  final plans = await container
-      .read(plansProvider.future)
-      .timeout(const Duration(seconds: 60));
+  final robot = AppRobot(tester);
+  await robot.waitForHomeReady();
+  final payment = PaymentRobot(tester, robot);
+  final plans = await payment.loadPlans();
   expect(plans.plans, isNotEmpty, reason: 'Staging returned no plans');
-  return _RunningApp(container: container, plans: plans);
+  return _RunningApp(payment: payment, plans: plans);
 }
 
 Future<void> _runStripeRenderSmoke(
@@ -104,31 +95,32 @@ Future<void> _runStripeRenderSmoke(
     reason: 'Staging Stripe must support subscriptions',
   );
 
-  _selectBestPlan(runningApp);
-  final observer = _StripeCheckoutObserver();
-  await _openPaymentMethods(
-    email: 'e2e+${_newUuid()}@getlantern.org',
-    observer: observer,
+  runningApp.payment.selectBestValuePlan(runningApp.plans);
+  final checkout = _StripeCheckoutTracker();
+  await runningApp.payment.openPaymentMethods(
+    email: e2eEmail(),
+    authFlow: AuthFlow.renewSubscription,
+    checkoutObserver: checkout,
   );
-  await _startCheckout(tester, provider: 'stripe');
+  await runningApp.payment.startCheckout(provider: 'stripe');
 
   await _waitFor(
     tester,
-    () => observer.finished,
+    () => checkout.finished,
     timeout: const Duration(minutes: 3),
-    failure: () => observer.failureMessage,
+    failure: () => checkout.failureMessage,
   );
 
-  if (observer.failure != null) {
-    fail('Stripe Checkout failed to load: ${observer.failure}');
+  if (checkout.failure != null) {
+    fail('Stripe Checkout failed to load: ${checkout.failure}');
   }
   expect(find.byKey(const ValueKey('app-webview')), findsOneWidget);
-  expect(observer.uri?.host, _stripeHost);
-  expect(observer.documentLength, greaterThan(0));
-  expect(observer.screenshot, isNotNull);
-  debugPrint(
+  expect(checkout.uri?.host, _stripeHost);
+  expect(checkout.documentLength, greaterThan(0));
+  expect(checkout.screenshot, isNotNull);
+  e2eLog(
     'Stripe Checkout rendered from $_stripeHost '
-    '(${observer.documentLength} document characters)',
+    '(${checkout.documentLength} document characters)',
   );
 }
 
@@ -136,7 +128,7 @@ Future<void> _runPaymentConversionSmoke(
   WidgetTester tester,
   _RunningApp runningApp,
 ) async {
-  final runID = _newUuid();
+  final runID = newE2ERunID();
   final e2eProvider = plan_models.Android(
     method: 'E2E Checkout',
     providers: plan_models.Provider(
@@ -185,25 +177,24 @@ Future<void> _runPaymentConversionSmoke(
   final currentPlans = runningApp.container.read(plansProvider).value;
   final plansWithE2E = withE2EProvider(currentPlans ?? runningApp.plans);
   runningApp.container.read(plansProvider.notifier).updatePlans(plansWithE2E);
-  _selectBestPlan(
-    _RunningApp(container: runningApp.container, plans: plansWithE2E),
-  );
+  runningApp.payment.selectBestValuePlan(plansWithE2E);
 
-  final observer = _PaymentConversionObserver();
-  await _openPaymentMethods(
-    email: 'e2e+$runID@getlantern.org',
-    observer: observer,
+  final checkout = _PaymentConversionTracker();
+  await runningApp.payment.openPaymentMethods(
+    email: e2eEmail(runID),
+    authFlow: AuthFlow.renewSubscription,
+    checkoutObserver: checkout,
   );
-  await _startCheckout(tester, provider: 'e2e');
+  await runningApp.payment.startCheckout(provider: 'e2e');
 
   await _waitFor(
     tester,
-    () => observer.completeClicked || observer.failure != null,
+    () => checkout.completeClicked || checkout.failure != null,
     timeout: const Duration(minutes: 2),
-    failure: () => observer.failureMessage,
+    failure: () => checkout.failureMessage,
   );
-  if (observer.failure != null) {
-    fail('E2E checkout failed: ${observer.failure}');
+  if (checkout.failure != null) {
+    fail('E2E checkout failed: ${checkout.failure}');
   }
 
   await _waitFor(
@@ -221,65 +212,14 @@ Future<void> _runPaymentConversionSmoke(
     failure: () => 'The Lantern Pro success dialog was not shown',
   );
 
-  expect(observer.uri?.host, _e2eHost);
-  expect(observer.documentLength, greaterThan(0));
-  expect(observer.screenshot, isNotNull);
+  expect(checkout.uri?.host, _e2eHost);
+  expect(checkout.documentLength, greaterThan(0));
+  expect(checkout.screenshot, isNotNull);
   expect(
     runningApp.container.read(homeProvider).value?.legacyUserData.isPro,
     isTrue,
   );
-  debugPrint('Staging E2E checkout converted run $runID to Pro');
-}
-
-void _selectBestPlan(_RunningApp runningApp) {
-  final selectedPlan = runningApp.plans.plans.firstWhere(
-    (plan) => plan.bestValue,
-    orElse: () => runningApp.plans.plans.first,
-  );
-  runningApp.container
-      .read(plansProvider.notifier)
-      .setSelectedPlan(selectedPlan);
-}
-
-Future<void> _openPaymentMethods({
-  required String email,
-  required AppWebViewObserver observer,
-}) {
-  return appRouter.replaceAll([
-    ChoosePaymentMethod(
-      email: email,
-      authFlow: AuthFlow.renewSubscription,
-      checkoutObserver: observer,
-    ),
-  ]);
-}
-
-Future<void> _startCheckout(
-  WidgetTester tester, {
-  required String provider,
-}) async {
-  final providerTile = find.byKey(Key('payment.provider.$provider'));
-  await _waitFor(
-    tester,
-    () => providerTile.evaluate().isNotEmpty,
-    timeout: const Duration(seconds: 30),
-    failure: () => '$provider was not shown on the payment-method screen',
-  );
-
-  final checkoutButton = find.byKey(Key('payment.checkout.$provider'));
-  if (checkoutButton.evaluate().isEmpty) {
-    await tester.tap(providerTile);
-    await tester.pump(const Duration(milliseconds: 300));
-  }
-  await _waitFor(
-    tester,
-    () => checkoutButton.evaluate().isNotEmpty,
-    timeout: const Duration(seconds: 10),
-    failure: () => '$provider checkout button was not available',
-  );
-
-  await tester.ensureVisible(checkoutButton);
-  await tester.tap(checkoutButton);
+  e2eLog('Staging E2E checkout converted run $runID to Pro');
 }
 
 Future<Uint8List> _waitForRenderedScreenshot(
@@ -312,7 +252,7 @@ Future<void> _saveScreenshot(Uint8List screenshot) async {
   final file = File(_screenshotPath);
   await file.parent.create(recursive: true);
   await file.writeAsBytes(screenshot, flush: true);
-  debugPrint('Checkout screenshot saved to ${file.path}');
+  e2eLog('Checkout screenshot saved to ${file.path}');
 }
 
 Future<bool> _hasVisibleContent(Uint8List screenshot) async {
@@ -369,30 +309,20 @@ Future<void> _waitFor(
   fail(failure());
 }
 
-String _newUuid() {
-  final random = Random.secure();
-  final bytes = List<int>.generate(16, (_) => random.nextInt(256));
-  bytes[6] = (bytes[6] & 0x0f) | 0x40;
-  bytes[8] = (bytes[8] & 0x3f) | 0x80;
-  final hex = bytes
-      .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
-      .join();
-  return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
-      '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
-      '${hex.substring(20)}';
-}
-
 bool _isJavaScriptTrue(Object? value) =>
     value == true || value == 1 || value?.toString().toLowerCase() == 'true';
 
 class _RunningApp {
-  final ProviderContainer container;
+  final PaymentRobot payment;
   final plan_models.PlansData plans;
 
-  const _RunningApp({required this.container, required this.plans});
+  const _RunningApp({required this.payment, required this.plans});
+
+  ProviderContainer get container => payment.container;
 }
 
-class _StripeCheckoutObserver implements AppWebViewObserver {
+/// Folds scoped WebView callbacks into a stateful Stripe checkout verdict.
+class _StripeCheckoutTracker implements AppWebViewObserver {
   Uri? uri;
   int documentLength = 0;
   Uint8List? screenshot;
@@ -432,7 +362,8 @@ class _StripeCheckoutObserver implements AppWebViewObserver {
   }
 }
 
-class _PaymentConversionObserver implements AppWebViewObserver {
+/// Tracks the staging checkout state and completes it through the WebView.
+class _PaymentConversionTracker implements AppWebViewObserver {
   static const _clickCompleteScript = r'''
     (() => {
       const candidates = Array.from(

--- a/integration_test/utils/app_robot.dart
+++ b/integration_test/utils/app_robot.dart
@@ -9,8 +9,8 @@ import 'widget_wait_utils.dart';
 /// that Firebase Test Lab captures (adb logcat | grep E2E).
 void e2eLog(String message) => debugPrint('[E2E] $message');
 
-/// Drives the app shell during integration tests, independent of any feature.
-/// Android-only for now; other platforms still use `vpn/vpn_smoke_helpers.dart`.
+/// Drives the app shell during Android and desktop integration tests,
+/// independent of any feature.
 class AppRobot {
   AppRobot(this.tester);
 
@@ -20,6 +20,9 @@ class AppRobot {
   final Finder onboardingScreen = find.byKey(const Key('onboarding.screen'));
   final Finder onboardingSkip = find.byKey(const Key('onboarding.skip'));
   final Finder onboardingPrimary = find.byKey(const Key('onboarding.primary'));
+  final Finder macosExtensionScreen = find.byKey(
+    const Key('macos_extension.screen'),
+  );
 
   /// String-valued widget keys currently in the tree, sorted — a lightweight
   /// "what's on screen" dump for failure diagnostics. `Key('foo')` is a
@@ -244,6 +247,41 @@ class AppRobot {
     return true;
   }
 
+  /// Dismisses the macOS system-extension screen when it covers home. Payment
+  /// smokes do not exercise the VPN, so they can safely close this prompt.
+  Future<bool> dismissMacOSExtensionScreenIfShown() async {
+    if (macosExtensionScreen.evaluate().isEmpty) {
+      return false;
+    }
+    e2eLog('macOS system extension screen shown — dismissing');
+
+    final close = find
+        .descendant(
+          of: macosExtensionScreen,
+          matching: find.byType(CloseButton),
+        )
+        .hitTestable();
+    final tapDeadline = DateTime.now().add(const Duration(seconds: 5));
+    while (DateTime.now().isBefore(tapDeadline)) {
+      if (macosExtensionScreen.evaluate().isEmpty) return true;
+      if (close.evaluate().isNotEmpty) {
+        await tester.tap(close);
+        await tester.pump(const Duration(milliseconds: 400));
+        break;
+      }
+      await tester.pump(const Duration(milliseconds: 200));
+    }
+
+    await WidgetWaitUtils.waitForFinderToDisappear(
+      tester,
+      macosExtensionScreen,
+      timeout: const Duration(seconds: 10),
+      reason: 'macOS system extension screen did not close after dismiss',
+    );
+    e2eLog('macOS system extension screen dismissed');
+    return true;
+  }
+
   /// Waits until [control] is hit-testable — the app-ready gate — clearing
   /// onboarding that appears while waiting. Home renders before onboarding is
   /// pushed on top of it, so we first spend up to [onboardingGrace] letting
@@ -266,6 +304,10 @@ class AppRobot {
     while (DateTime.now().isBefore(end)) {
       if (onboardingScreen.evaluate().isNotEmpty) {
         await dismissOnboardingIfShown();
+        continue;
+      }
+      if (macosExtensionScreen.evaluate().isNotEmpty) {
+        await dismissMacOSExtensionScreenIfShown();
         continue;
       }
 

--- a/integration_test/utils/payment_robot.dart
+++ b/integration_test/utils/payment_robot.dart
@@ -9,6 +9,7 @@ import 'package:lantern/core/widgets/app_webview.dart';
 import 'package:lantern/features/plans/provider/plans_notifier.dart';
 
 import 'app_robot.dart';
+import 'widget_wait_utils.dart';
 
 /// Drives plan selection and the payment-method screen through the same state
 /// and controls used by the app.
@@ -85,6 +86,13 @@ class PaymentRobot {
       await tester.tap(providerTile);
       await tester.pump(const Duration(milliseconds: 300));
     }
+    await WidgetWaitUtils.waitForFinder(
+      tester,
+      checkoutButton,
+      timeout: const Duration(seconds: 10),
+      reason: '$provider checkout button was not available',
+    );
+    await tester.ensureVisible(checkoutButton);
     await app.waitForControlReady(
       checkoutButton,
       controlName: '$provider checkout button',
@@ -92,7 +100,6 @@ class PaymentRobot {
     );
 
     e2eLog('Starting $provider checkout');
-    await tester.ensureVisible(checkoutButton);
     await tester.tap(checkoutButton);
   }
 }

--- a/integration_test/utils/payment_robot.dart
+++ b/integration_test/utils/payment_robot.dart
@@ -1,0 +1,114 @@
+import 'dart:math';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/models/plan_data.dart';
+import 'package:lantern/core/widgets/app_webview.dart';
+import 'package:lantern/features/plans/provider/plans_notifier.dart';
+
+import 'app_robot.dart';
+
+/// Drives plan selection and the payment-method screen through the same state
+/// and controls used by the app.
+class PaymentRobot {
+  PaymentRobot(this.tester, this.app);
+
+  final WidgetTester tester;
+  final AppRobot app;
+
+  ProviderContainer? _cachedContainer;
+
+  /// Resolves and caches the root provider container before route changes.
+  ProviderContainer get container {
+    final cached = _cachedContainer;
+    if (cached != null) return cached;
+
+    final elements = app.homeScreen.evaluate();
+    if (elements.isEmpty) {
+      fail('Cannot resolve providers: home screen is not mounted');
+    }
+    return _cachedContainer = ProviderScope.containerOf(
+      elements.first,
+      listen: false,
+    );
+  }
+
+  /// Loads plans while keeping the auto-disposed provider alive for the test.
+  Future<PlansData> loadPlans({
+    Duration timeout = const Duration(seconds: 60),
+  }) {
+    final subscription = container.listen(plansProvider, (_, _) {});
+    addTearDown(subscription.close);
+    return container.read(plansProvider.future).timeout(timeout);
+  }
+
+  /// Selects the best-value plan, falling back to the first available plan.
+  Plan selectBestValuePlan(PlansData plans) {
+    final plan = plans.plans.firstWhere(
+      (plan) => plan.bestValue,
+      orElse: () => plans.plans.first,
+    );
+    container.read(plansProvider.notifier).setSelectedPlan(plan);
+    e2eLog('Selected plan ${plan.id}');
+    return plan;
+  }
+
+  /// Opens the payment-method screen directly for a checkout smoke test.
+  Future<void> openPaymentMethods({
+    required String email,
+    required AuthFlow authFlow,
+    AppWebViewObserver? checkoutObserver,
+  }) {
+    return appRouter.replaceAll([
+      ChoosePaymentMethod(
+        email: email,
+        authFlow: authFlow,
+        checkoutObserver: checkoutObserver,
+      ),
+    ]);
+  }
+
+  /// Expands [provider] when needed and starts its checkout flow.
+  Future<void> startCheckout({required String provider}) async {
+    final providerTile = find.byKey(Key('payment.provider.$provider'));
+    final checkoutButton = find.byKey(Key('payment.checkout.$provider'));
+
+    await app.waitForControlReady(
+      providerTile,
+      controlName: '$provider payment method',
+      onboardingGrace: Duration.zero,
+    );
+    if (checkoutButton.evaluate().isEmpty) {
+      e2eLog('Expanding the $provider payment method');
+      await tester.tap(providerTile);
+      await tester.pump(const Duration(milliseconds: 300));
+    }
+    await app.waitForControlReady(
+      checkoutButton,
+      controlName: '$provider checkout button',
+      onboardingGrace: Duration.zero,
+    );
+
+    e2eLog('Starting $provider checkout');
+    await tester.ensureVisible(checkoutButton);
+    await tester.tap(checkoutButton);
+  }
+}
+
+String e2eEmail([String? runID]) =>
+    'e2e+${runID ?? newE2ERunID()}@getlantern.org';
+
+String newE2ERunID() {
+  final random = Random.secure();
+  final bytes = List<int>.generate(16, (_) => random.nextInt(256));
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  final hex = bytes
+      .map((byte) => byte.toRadixString(16).padLeft(2, '0'))
+      .join();
+  return '${hex.substring(0, 8)}-${hex.substring(8, 12)}-'
+      '${hex.substring(12, 16)}-${hex.substring(16, 20)}-'
+      '${hex.substring(20)}';
+}


### PR DESCRIPTION
Builds on #8939 by incorporating the reusable payment-test structure and CI improvements from @jigar-f’s #8960 while preserving the staging E2E conversion flow.

- Adds a reusable payment robot for Stripe rendering and conversion tests.
- Improves state-based checkout tracking and desktop test readiness.
- Prevents the macOS smoke script from deleting app data outside CI.
- Captures Windows payment logs for easier failure diagnosis.