### PR TITLE
ci: disable the update-metadata sidecar step so releases publish again

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -903,6 +903,12 @@ jobs:
         run: python3 -m unittest scripts/ci/generate_update_metadata_test.py
 
       - name: Publish update metadata sidecars
+        # DISABLED: `auto_updater:sign_update` exits 255 on the dmg, which failed
+        # this job and made release-finalize delete the draft release on every
+        # tagged run (v9.1.19-beta, v9.1.20-beta got tags with no release).
+        if: |
+          false &&
+          needs.set-metadata.outputs.build_type != 'nightly'
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -983,7 +989,10 @@ jobs:
 
   verify-update-service:
     needs: [set-metadata, publish-update-metadata, release-finalize]
+    # DISABLED with the sidecar step above: with nothing published, this polls
+    # for its full 2700s timeout and then fails.
     if: |
+      false &&
       !cancelled() &&
       needs.set-metadata.outputs.build_type == 'beta' &&
       needs.publish-update-metadata.result == 'success' &&


### PR DESCRIPTION
## The bug

`v9.1.19-beta` and `v9.1.20-beta` both have **tags but no GitHub release**. The last published beta is `v9.1.18-beta` (2026-07-26). Not a tagging mistake — the pipeline rolls itself back:

1. `release-create` makes a **draft** (`gh release create --draft`)
2. `publish-update-metadata` **fails**: `dart run auto_updater:sign_update release-assets/lantern-installer-beta.dmg` → **exit 255**, at `generate_update_metadata.py:56`
3. `release-finalize` runs `if: always()` and, because it gates on that job, takes its rollback branch — `gh release delete --yes` instead of `gh release edit --draft=false`

The draft is deleted, the tag is orphaned, and `release-finalize` reports *success* because the cleanup worked — which is why the failure doesn't look like it's about publishing.

Both tagged runs failed identically ([v9.1.20-beta](https://github.com/getlantern/lantern/actions/runs/31421481649), v9.1.19-beta on 08-05). Everything else in those runs succeeded: all five platform builds, TestFlight, Play, S3, artifact upload.

**Why nobody noticed:** the daily cron is exempt (`build_type != 'nightly'` skips the job), so CI has looked green every day for two weeks while the only runs that publish to users were failing. The job arrived in #8903, which lands inside `v9.1.18-beta..v9.1.20-beta` — 9.1.18 published because it didn't exist yet.

`publish-update-metadata` has **never succeeded in any run** (checked the last 25), so no client has ever consumed its sidecars.

## The change

Two lines, both trivially reversible, no script or gate changes:

- **`false &&` on the sidecar step** — the step only, not the job. `Publish legacy appcast.xml` is a later step in the same job and is self-contained (it runs `scripts/generate_appcast.py`, which fetches assets from the GitHub API itself), so it keeps publishing the S3 feed that pre-#8903 clients read. Disabling the *job* would have taken that feed down too.
- **`false &&` on `verify-update-service`** — the job now succeeds, so verification would otherwise run against metadata that was never published and fail after its full 2700s timeout.

`release-finalize`'s gates are untouched; the diff is additions only. Remove the two `false &&` lines to re-enable.

## Verification

- `actionlint` on `release.yml`: **15 issues, identical to `origin/main`** — none added. (The `false &&` form is used rather than a bare `if: false`, which trips actionlint's `if-cond` rule.)
- YAML parses; the sidecar step is the only one gated off, and `Publish legacy appcast.xml` keeps its original condition.

## Follow-up

The real fix is making `auto_updater:sign_update` work in CI — exit 255 is usually a missing or malformed Sparkle EdDSA key in the job environment. Until then macOS/Windows clients won't discover releases through the update service.

Two things worth knowing while this is disabled:
- The `.exe` is signed by the same code path and was never reached (artifacts are sorted, so it died on `.dmg` first) — Windows signing is untested.
- Neither update feed is currently serving: the legacy S3 beta appcast returns **403 AccessDenied** and `update.getlantern.org/update/lantern/appcast.xml?channel=beta` returns **Not Found**. Separate from this PR, but worth checking before assuming auto-update works once releases publish again.

## Pre-PR review (local Codex gate)
- Rounds: 5 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed:
  - disabling the whole job would also have stopped `Publish legacy appcast.xml`, the feed pre-#8903 clients read — narrowed to the step
  - `continue-on-error` on the step would have masked release-download and S3-upload failures too — rejected in favour of gating the step off
  - with the job now succeeding, `verify-update-service` would have run against absent metadata and timed out — disabled alongside
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic update metadata publication during releases.
  * Disabled beta update-service verification and polling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->