### PR TITLE
macos/ios: stop the tunnel wedging on setTunnelNetworkSettings

### DIFF
--- a/ios/Tunnel/SingBox/Extension+RunBlocking.swift
+++ b/ios/Tunnel/SingBox/Extension+RunBlocking.swift
@@ -27,12 +27,16 @@ enum RunBlockingError: Error {
 func runBlocking<T>(_ block: @escaping () async -> T) -> T? {
   let semaphore = DispatchSemaphore(value: 0)
   let box = resultBox<T>()
-  Task.detached {
+  let task = Task.detached {
     let value = await block()
     box.result0 = value
     semaphore.signal()
   }
   guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    // Cancellation is cooperative, so this only helps if the awaited work checks
+    // for it — but a framework await that ignores it would otherwise run to
+    // completion long after we gave up.
+    task.cancel()
     return nil
   }
   return box.result0
@@ -41,7 +45,7 @@ func runBlocking<T>(_ block: @escaping () async -> T) -> T? {
 func runBlocking<T>(_ tBlock: @escaping () async throws -> T) throws -> T {
   let semaphore = DispatchSemaphore(value: 0)
   let box = resultBox<T>()
-  Task.detached {
+  let task = Task.detached {
     do {
       let value = try await tBlock()
       box.result = .success(value)
@@ -51,6 +55,7 @@ func runBlocking<T>(_ tBlock: @escaping () async throws -> T) throws -> T {
     semaphore.signal()
   }
   guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    task.cancel()
     throw RunBlockingError.timedOut
   }
   return try box.result.get()

--- a/ios/Tunnel/SingBox/Extension+RunBlocking.swift
+++ b/ios/Tunnel/SingBox/Extension+RunBlocking.swift
@@ -9,7 +9,22 @@ import Foundation
 import Liblantern
 import NetworkExtension
 
-func runBlocking<T>(_ block: @escaping () async -> T) -> T {
+/// Bound on every sync-over-async bridge below. Blocking a thread while awaiting a
+/// continuation is exactly what Swift concurrency forbids: the continuation may need
+/// a cooperative-pool thread that this wait is holding, and then nothing ever
+/// signals. Without a deadline that wedges the extension permanently — a tunnel with
+/// its routes installed and nothing servicing them. Generous, because the real work
+/// here is milliseconds.
+let runBlockingTimeout: DispatchTimeInterval = .seconds(15)
+
+enum RunBlockingError: Error {
+  /// The awaited work never completed. Treat as a failed operation, not a retryable
+  /// stall: something upstream is wedged and the caller should tear down.
+  case timedOut
+}
+
+/// Returns nil if the block did not finish within `runBlockingTimeout`.
+func runBlocking<T>(_ block: @escaping () async -> T) -> T? {
   let semaphore = DispatchSemaphore(value: 0)
   let box = resultBox<T>()
   Task.detached {
@@ -17,7 +32,9 @@ func runBlocking<T>(_ block: @escaping () async -> T) -> T {
     box.result0 = value
     semaphore.signal()
   }
-  semaphore.wait()
+  guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    return nil
+  }
   return box.result0
 }
 
@@ -33,7 +50,9 @@ func runBlocking<T>(_ tBlock: @escaping () async throws -> T) throws -> T {
     }
     semaphore.signal()
   }
-  semaphore.wait()
+  guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    throw RunBlockingError.timedOut
+  }
   return try box.result.get()
 }
 

--- a/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
@@ -25,17 +25,40 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     self.tunnel = tunnel
   }
 
-  public func openTun(_ options: LibboxTunOptionsProtocol?, ret0_: UnsafeMutablePointer<Int32>?)
-    throws
-  {
-    try runBlocking { [self] in
-      try await openTun0(options, ret0_)
+  /// Applies tunnel network settings and waits for NetworkExtension's completion.
+  ///
+  /// Uses the completion-handler form rather than the `async` one deliberately. The
+  /// async form resumes its continuation on Swift's cooperative pool; when the caller
+  /// is a libbox thread blocked in a semaphore, that resumption can be starved and the
+  /// call never returns — leaving a routed-but-unserviced utun, which is a total
+  /// traffic blackhole. NE delivers this completion on its own queue, so it cannot be
+  /// starved by the wait here.
+  private func applyNetworkSettings(_ settings: NEPacketTunnelNetworkSettings?) throws {
+    let semaphore = DispatchSemaphore(value: 0)
+    var failure: Error?
+    tunnel.setTunnelNetworkSettings(settings) { error in
+      failure = error
+      semaphore.signal()
+    }
+    guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+      throw RunBlockingError.timedOut
+    }
+    if let failure {
+      throw failure
     }
   }
 
-  private func openTun0(_ options: LibboxTunOptionsProtocol?, _ ret0_: UnsafeMutablePointer<Int32>?)
-    async throws
+  public func openTun(_ options: LibboxTunOptionsProtocol?, ret0_: UnsafeMutablePointer<Int32>?)
+    throws
   {
+    // Called directly: this path's only await was setTunnelNetworkSettings, now handled
+    // by applyNetworkSettings, so there is nothing to bridge.
+    try openTunSync(options, ret0_)
+  }
+
+  private func openTunSync(
+    _ options: LibboxTunOptionsProtocol?, _ ret0_: UnsafeMutablePointer<Int32>?
+  ) throws {
     guard let options else {
       throw NSError(domain: "nil options", code: 0)
     }
@@ -206,7 +229,7 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     }
 
     networkSettings = settings
-    try await tunnel.setTunnelNetworkSettings(settings)
+    try applyNetworkSettings(settings)
 
     if let tunFd = tunnel.packetFlow.value(forKeyPath: "socket.fileDescriptor") as? Int32 {
       ret0_.pointee = tunFd
@@ -272,7 +295,14 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
       }
     }
     monitor.start(queue: DispatchQueue.global())
-    semaphore.wait()
+    // Wait for the first path so libbox starts with an interface, but never
+    // indefinitely: with no network at all the first update may not arrive, and this
+    // runs on the libbox thread during tunnel bring-up. On timeout carry on — the
+    // handler above stays installed and reports the interface once one appears.
+    if semaphore.wait(timeout: .now() + runBlockingTimeout) == .timedOut {
+      appLogger.error(
+        "startDefaultInterfaceMonitor: no path update within \(runBlockingTimeout); continuing")
+    }
   }
 
   private func onUpdateDefaultInterface(
@@ -364,9 +394,12 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
   }
 
   public func readWIFIState() -> LibboxWIFIState? {
-    let network = runBlocking {
-      await NEHotspotNetwork.fetchCurrent()
-    }
+    // Double optional: runBlocking returns nil on timeout, fetchCurrent returns nil
+    // when there is no network. Both mean "no WIFI state", so flatten them.
+    let network =
+      runBlocking {
+        await NEHotspotNetwork.fetchCurrent()
+      } ?? nil
     guard let network else {
       return nil
     }
@@ -374,9 +407,7 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
   }
 
   public func restartService() throws {
-    try runBlocking { [self] in
-      try tunnel.restartService()
-    }
+    try tunnel.restartService()
   }
 
   public func postServiceClose() {
@@ -415,9 +446,7 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     proxySettings.httpEnabled = isEnabled
     proxySettings.httpsEnabled = isEnabled
     networkSettings.proxySettings = proxySettings
-    try runBlocking {
-      try await self.tunnel.setTunnelNetworkSettings(networkSettings)
-    }
+    try applyNetworkSettings(networkSettings)
   }
 
   func reset() {

--- a/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
@@ -473,6 +473,9 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
         identifier: notification.identifier, content: content, trigger: nil)
       try runBlocking {
         try await center.requestAuthorization(options: [.alert])
+        // requestAuthorization ignores cancellation, so a timed-out runBlocking would
+        // otherwise still post the notification long after the caller gave up.
+        try Task.checkCancellation()
         try await center.add(request)
       }
     #endif

--- a/macos/PacketTunnel/SingBox/Extension+RunBlocking.swift
+++ b/macos/PacketTunnel/SingBox/Extension+RunBlocking.swift
@@ -8,7 +8,22 @@
 import Foundation
 import NetworkExtension
 
-func runBlocking<T>(_ block: @escaping () async -> T) -> T {
+/// Bound on every sync-over-async bridge below. Blocking a thread while awaiting a
+/// continuation is exactly what Swift concurrency forbids: the continuation may need
+/// a cooperative-pool thread that this wait is holding, and then nothing ever
+/// signals. Without a deadline that wedges the extension permanently — a tunnel with
+/// its routes installed and nothing servicing them. Generous, because the real work
+/// here is milliseconds.
+let runBlockingTimeout: DispatchTimeInterval = .seconds(15)
+
+enum RunBlockingError: Error {
+  /// The awaited work never completed. Treat as a failed operation, not a retryable
+  /// stall: something upstream is wedged and the caller should tear down.
+  case timedOut
+}
+
+/// Returns nil if the block did not finish within `runBlockingTimeout`.
+func runBlocking<T>(_ block: @escaping () async -> T) -> T? {
   let semaphore = DispatchSemaphore(value: 0)
   let box = resultBox<T>()
   Task.detached {
@@ -16,7 +31,9 @@ func runBlocking<T>(_ block: @escaping () async -> T) -> T {
     box.result0 = value
     semaphore.signal()
   }
-  semaphore.wait()
+  guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    return nil
+  }
   return box.result0
 }
 
@@ -32,7 +49,9 @@ func runBlocking<T>(_ tBlock: @escaping () async throws -> T) throws -> T {
     }
     semaphore.signal()
   }
-  semaphore.wait()
+  guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    throw RunBlockingError.timedOut
+  }
   return try box.result.get()
 }
 

--- a/macos/PacketTunnel/SingBox/Extension+RunBlocking.swift
+++ b/macos/PacketTunnel/SingBox/Extension+RunBlocking.swift
@@ -26,12 +26,16 @@ enum RunBlockingError: Error {
 func runBlocking<T>(_ block: @escaping () async -> T) -> T? {
   let semaphore = DispatchSemaphore(value: 0)
   let box = resultBox<T>()
-  Task.detached {
+  let task = Task.detached {
     let value = await block()
     box.result0 = value
     semaphore.signal()
   }
   guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    // Cancellation is cooperative, so this only helps if the awaited work checks
+    // for it — but a framework await that ignores it would otherwise run to
+    // completion long after we gave up.
+    task.cancel()
     return nil
   }
   return box.result0
@@ -40,7 +44,7 @@ func runBlocking<T>(_ block: @escaping () async -> T) -> T? {
 func runBlocking<T>(_ tBlock: @escaping () async throws -> T) throws -> T {
   let semaphore = DispatchSemaphore(value: 0)
   let box = resultBox<T>()
-  Task.detached {
+  let task = Task.detached {
     do {
       let value = try await tBlock()
       box.result = .success(value)
@@ -50,6 +54,7 @@ func runBlocking<T>(_ tBlock: @escaping () async throws -> T) throws -> T {
     semaphore.signal()
   }
   guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+    task.cancel()
     throw RunBlockingError.timedOut
   }
   return try box.result.get()

--- a/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
@@ -518,6 +518,9 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
         identifier: notification.identifier, content: content, trigger: nil)
       try runBlocking {
         try await center.requestAuthorization(options: [.alert])
+        // requestAuthorization ignores cancellation, so a timed-out runBlocking would
+        // otherwise still post the notification long after the caller gave up.
+        try Task.checkCancellation()
         try await center.add(request)
       }
     #endif

--- a/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
@@ -29,6 +29,29 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     self.tunnel = tunnel
   }
 
+  /// Applies tunnel network settings and waits for NetworkExtension's completion.
+  ///
+  /// Uses the completion-handler form rather than the `async` one deliberately. The
+  /// async form resumes its continuation on Swift's cooperative pool; when the caller
+  /// is a libbox thread blocked in a semaphore, that resumption can be starved and the
+  /// call never returns — leaving a routed-but-unserviced utun, which is a total
+  /// traffic blackhole the user can only escape by killing the extension. NE delivers
+  /// this completion on its own queue, so it cannot be starved by the wait here.
+  private func applyNetworkSettings(_ settings: NEPacketTunnelNetworkSettings?) throws {
+    let semaphore = DispatchSemaphore(value: 0)
+    var failure: Error?
+    tunnel.setTunnelNetworkSettings(settings) { error in
+      failure = error
+      semaphore.signal()
+    }
+    guard semaphore.wait(timeout: .now() + runBlockingTimeout) == .success else {
+      throw RunBlockingError.timedOut
+    }
+    if let failure {
+      throw failure
+    }
+  }
+
   public func openTun(_ options: LibboxTunOptionsProtocol?, ret0_: UnsafeMutablePointer<Int32>?)
     throws
   {
@@ -36,18 +59,16 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     guard let opts = options, let retPtr = ret0_ else {
       throw NSError(domain: "Invalid arguments to openTun", code: 0)
     }
-    runBlocking { [self] in
-      do {
-        try await openTunAsync(opts, retPtr)
-      } catch {
-        appLogger.error("Error opening TUN: \(error)")
-      }
-    }
+    // Called directly: openTun's only await was setTunnelNetworkSettings, now handled
+    // by applyNetworkSettings, so there is nothing to bridge. Errors propagate instead
+    // of being logged and swallowed — libbox must not be told the TUN opened when
+    // ret0_ was never written.
+    try openTunSync(opts, retPtr)
   }
 
-  private func openTunAsync(
+  private func openTunSync(
     _ options: LibboxTunOptionsProtocol, _ ret0_: UnsafeMutablePointer<Int32>
-  ) async throws {
+  ) throws {
     // Use subranges instead of a single default route
     let autoRouteUseSubRangesByDefault = true
     // Exclude Apple Push Notification Service by default
@@ -232,7 +253,7 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
 
     networkSettings = settings
     appLogger.info("Setting tunnel network settings to \(settings)...")
-    try await tunnel.setTunnelNetworkSettings(settings)
+    try applyNetworkSettings(settings)
 
     appLogger.info("Accessing the socket file descriptor...")
     if let tunFd = tunnel.packetFlow.value(forKeyPath: "socket.fileDescriptor") as? Int32 {
@@ -304,7 +325,14 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
       }
     }
     monitor.start(queue: DispatchQueue.global())
-    semaphore.wait()
+    // Wait for the first path so libbox starts with an interface, but never
+    // indefinitely: with no network at all the first update may not arrive, and this
+    // runs on the libbox thread during tunnel bring-up. On timeout carry on — the
+    // handler above stays installed and reports the interface once one appears.
+    if semaphore.wait(timeout: .now() + runBlockingTimeout) == .timedOut {
+      appLogger.error(
+        "startDefaultInterfaceMonitor: no path update within \(runBlockingTimeout); continuing")
+    }
   }
 
   private func onUpdateDefaultInterface(
@@ -395,9 +423,12 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
 
   public func readWIFIState() -> LibboxWIFIState? {
     #if os(iOS)
-      let network = runBlocking {
-        await NEHotspotNetwork.fetchCurrent()
-      }
+      // Double optional: runBlocking returns nil on timeout, fetchCurrent returns nil
+      // when there is no network. Both mean "no WIFI state", so flatten them.
+      let network =
+        runBlocking {
+          await NEHotspotNetwork.fetchCurrent()
+        } ?? nil
       guard let network else {
         return nil
       }
@@ -450,9 +481,7 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     proxySettings.httpEnabled = isEnabled
     proxySettings.httpsEnabled = isEnabled
     networkSettings.proxySettings = proxySettings
-    try runBlocking {
-      try await self.tunnel.setTunnelNetworkSettings(networkSettings)
-    }
+    try applyNetworkSettings(networkSettings)
   }
 
   func reset() {
@@ -460,9 +489,7 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
   }
 
   public func restartService() throws {
-    try runBlocking { [self] in
-      try tunnel.restartService()
-    }
+    try tunnel.restartService()
   }
 
   public func postServiceClose() {


### PR DESCRIPTION
Fixes engineering#3781 — the macOS "cannot reach anything until I kill the PacketTunnel process" report (Freshdesk 181146, macOS 12.7.6, CN).

## The deadlock

`openTun` is called **synchronously** by libbox and bridged to async with `runBlocking`, which blocks the calling thread on a semaphore while a detached `Task` awaits `tunnel.setTunnelNetworkSettings`:

```swift
// Extension+RunBlocking.swift, before
Task.detached { let value = await block(); semaphore.signal() }
semaphore.wait()          // no deadline
```

The `async` form of `setTunnelNetworkSettings` resumes its continuation on Swift's **cooperative pool**, which is sized to core count — so the resumption can be starved by the very thread this wait is holding. Blocking a thread while awaiting a continuation is precisely what Swift concurrency forbids, and neither `wait()` had a deadline.

When it happens the call never returns. `Opening TUN` and route computation have already completed by then, so **the utun is installed and routed with nothing servicing it** — every packet is blackholed, and the only escape is killing the system extension by hand, which is exactly what the reporter found.

**Evidence** from `lantern_macos.log`: 146 `starting tunnel` against **66** `tunnel started successfully` over six days, and one hang timestamped precisely:

```
16:35:29.641  Setting tunnel network settings to {   ← call made
16:35:43.800  Stopping tunnel..                     ← 14.2s later, never returned
```

A retry 54 s later succeeded, so it is intermittent per-start rather than a stuck state — which matches "disconnect/connect sometimes helps".

## Changes

- **`applyNetworkSettings`** uses NE's **completion-handler** form. NE delivers that completion on its own queue, so it cannot be starved by the wait. Replaces both `await setTunnelNetworkSettings` sites.
- **`openTun` no longer bridges at all.** `setTunnelNetworkSettings` was the *only* live await in the TUN-open path (the others in that function are commented out), so the builder is now synchronous. This removes the cooperative pool from tunnel bring-up rather than time-boxing it — the structural fix, not a mitigation.
- **macOS `openTun` propagated nothing.** It caught the error, logged it, and returned — telling libbox the TUN opened while `ret0_` was never written, so libbox got an uninitialised fd. It now throws. **iOS already did this correctly**; macOS was the sibling that didn't.
- **Both `runBlocking` overloads take a 15 s deadline** (throwing one throws `RunBlockingError.timedOut`; non-throwing returns `nil`). Any remaining sync-over-async bridge now fails instead of wedging.
- **`startDefaultInterfaceMonitor` waited forever** for `NWPathMonitor`'s first path, which never arrives when there is no network — on the libbox thread, during bring-up. Bounded, and it carries on: the handler stays installed and reports an interface once one appears.
- **`restartService`** wrapped a call with no `await` in it; dropped the pointless bridge.

There are now **no unbounded `semaphore.wait()` calls left** in either tunnel path.

## iOS is included

`ios/Tunnel/SingBox/` has the identical pattern. It matters more there, if anything: the extension survives tunnel stop/start, so a wedged one persists across reconnects.

## Testing

I can't build the app here (Flutter + Xcode + pods), so this is **not runtime-verified** — worth saying plainly. What was checked:

- `swiftc -parse` on all four files
- `swift-format` on all four: the repo was already swift-format clean and still is
- The audit that motivated it: every `runBlocking` call site and every `semaphore.wait()` in both tunnel paths

A `sample` or spindump of a wedged `org.getlantern.lantern.PacketTunnel` would confirm which thread is blocked and what holds the NE queue — worth capturing if this recurs after the fix, since it would distinguish cooperative-pool starvation from a queue inversion I haven't accounted for.

## Note on the timeout value

15 s is deliberately generous — the real work here is milliseconds, and the observed hang gave up at 14.2 s. It exists so a hang becomes a failed connect the user can retry, not a blackhole. If it ever fires in practice that is itself a signal worth alerting on.

## Pre-PR review (local Codex gate)
- Rounds: 1 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed: none (no findings raised)
- Dismissed: none

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RVgb2MDpZ4wpH6fywKC2hE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeouts to tunnel and network operations to prevent indefinite waiting.
  * Improved handling of network-setting failures by surfacing errors instead of silently suppressing them.
  * Prevented network monitoring and Wi‑Fi lookups from hanging when no connection is available.
  * Improved reliability when opening, restarting, and updating tunnel services.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->