### PR TITLE
Add macOS E2E test for auto-updates

### DIFF
--- a/.github/scripts/macos_auto_update_smoke.sh
+++ b/.github/scripts/macos_auto_update_smoke.sh
@@ -6,7 +6,8 @@ readonly APP_EXECUTABLE="$APP_PATH/Contents/MacOS/Lantern"
 readonly DATA_PATH="/Users/Shared/Lantern"
 readonly HANDOFF_PATH="$DATA_PATH/E2E/auto-update-handoff.json"
 readonly DEFAULTS_DOMAIN="org.getlantern.lantern"
-readonly ROBOT_SCRIPT=".github/scripts/macos_sparkle_handoff.applescript"
+readonly ROBOT_SOURCE=".github/scripts/macos_sparkle_handoff.applescript"
+readonly ROBOT_SCRIPT="${RUNNER_TEMP:?RUNNER_TEMP is required}/macos-sparkle-handoff.scpt"
 readonly FIXTURE_DMG="${FIXTURE_DMG:?FIXTURE_DMG is required}"
 readonly TARGET_JSON="${TARGET_JSON:?TARGET_JSON is required}"
 readonly APPCAST_XML="${APPCAST_XML:?APPCAST_XML is required}"
@@ -221,7 +222,7 @@ guard_ci_paths
 mkdir -p "$ARTIFACT_DIR"
 cp "$APPCAST_XML" "$ARTIFACT_DIR/appcast.xml"
 cp "$TARGET_JSON" "$ARTIFACT_DIR/resolved-target.json"
-osacompile -o "$RUNNER_TEMP/macos-sparkle-handoff.scpt" "$ROBOT_SCRIPT"
+osacompile -o "$ROBOT_SCRIPT" "$ROBOT_SOURCE"
 revalidate_target
 
 TARGET_BUILD="$(jq -er '.target_build | tostring' "$TARGET_JSON")"

--- a/.github/scripts/macos_auto_update_smoke.sh
+++ b/.github/scripts/macos_auto_update_smoke.sh
@@ -203,28 +203,11 @@ install_fixture() {
   detach_dmg
 }
 
-revalidate_target() {
-  local recheck="$ARTIFACT_DIR/live-recheck"
-  mkdir -p "$recheck"
-  python3 scripts/ci/resolve_desktop_update_target.py \
-    --platform macos \
-    --appcast-url "$(jq -r .appcast_url "$TARGET_JSON")" \
-    --appcast-output "$recheck/appcast.xml" \
-    --target-output "$recheck/target.json" \
-    --pubspec-input pubspec.yaml \
-    --pubspec-output "$recheck/pubspec.yaml"
-  [[ "$(jq -r .appcast_sha256 "$TARGET_JSON")" == "$(jq -r .appcast_sha256 "$recheck/target.json")" ]] || {
-    printf 'The staging beta appcast changed while the fixture was building; rerun the workflow.\n' >&2
-    return 1
-  }
-}
-
 guard_ci_paths
 mkdir -p "$ARTIFACT_DIR"
 cp "$APPCAST_XML" "$ARTIFACT_DIR/appcast.xml"
 cp "$TARGET_JSON" "$ARTIFACT_DIR/resolved-target.json"
 osacompile -o "$ROBOT_SCRIPT" "$ROBOT_SOURCE"
-revalidate_target
 
 TARGET_BUILD="$(jq -er '.target_build | tostring' "$TARGET_JSON")"
 FIXTURE_BUILD="$(jq -er '.fixture_build | tostring' "$TARGET_JSON")"

--- a/.github/scripts/macos_auto_update_smoke.sh
+++ b/.github/scripts/macos_auto_update_smoke.sh
@@ -1,0 +1,304 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+readonly APP_PATH="/Applications/Lantern.app"
+readonly APP_EXECUTABLE="$APP_PATH/Contents/MacOS/Lantern"
+readonly DATA_PATH="/Users/Shared/Lantern"
+readonly HANDOFF_PATH="$DATA_PATH/E2E/auto-update-handoff.json"
+readonly DEFAULTS_DOMAIN="org.getlantern.lantern"
+readonly ROBOT_SCRIPT=".github/scripts/macos_sparkle_handoff.applescript"
+readonly FIXTURE_DMG="${FIXTURE_DMG:?FIXTURE_DMG is required}"
+readonly TARGET_JSON="${TARGET_JSON:?TARGET_JSON is required}"
+readonly APPCAST_XML="${APPCAST_XML:?APPCAST_XML is required}"
+readonly ARTIFACT_DIR="${ARTIFACT_DIR:-smoke-artifacts/macos-auto-update}"
+readonly UI_TIMEOUT_SECONDS="${UI_TIMEOUT_SECONDS:-120}"
+readonly UPDATE_TIMEOUT_SECONDS="${UPDATE_TIMEOUT_SECONDS:-600}"
+
+[[ "$UI_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+  printf 'UI_TIMEOUT_SECONDS must be a positive integer.\n' >&2
+  exit 2
+}
+[[ "$UPDATE_TIMEOUT_SECONDS" =~ ^[1-9][0-9]*$ ]] || {
+  printf 'UPDATE_TIMEOUT_SECONDS must be a positive integer.\n' >&2
+  exit 2
+}
+
+MOUNT_PATH=""
+ORIGINAL_PID=""
+RELAUNCHED_PID=""
+RESULT="failure"
+
+log_e2e() {
+  printf '[E2E] %s\n' "$*" >&2
+}
+
+guard_ci_paths() {
+  [[ "${CI:-}" == "true" && "${GITHUB_ACTIONS:-}" == "true" ]] || {
+    printf 'This smoke only runs in GitHub Actions CI.\n' >&2
+    exit 2
+  }
+  [[ "${RUNNER_ENVIRONMENT:-}" == "self-hosted" ]] || {
+    printf 'This smoke requires the dedicated self-hosted macOS runner.\n' >&2
+    exit 2
+  }
+  [[ "${LANTERN_AUTO_UPDATE_SMOKE:-}" == "true" ]] || {
+    printf 'The explicit auto-update cleanup guard is missing.\n' >&2
+    exit 2
+  }
+  [[ "$APP_PATH" == "/Applications/Lantern.app" && "$DATA_PATH" == "/Users/Shared/Lantern" ]] || {
+    printf 'Refusing to use unexpected Lantern paths.\n' >&2
+    exit 2
+  }
+}
+
+lantern_pids() {
+  pgrep -f "^${APP_EXECUTABLE}([[:space:]]|$)" 2>/dev/null || true
+}
+
+quit_lantern() {
+  osascript -e 'tell application id "org.getlantern.lantern" to quit' >/dev/null 2>&1 || true
+  local pid
+  while IFS= read -r pid; do
+    [[ -n "$pid" ]] && kill -TERM "$pid" 2>/dev/null || true
+  done < <(lantern_pids)
+}
+
+wait_for_exit() {
+  local pid="$1"
+  local deadline=$((SECONDS + $2))
+  while kill -0 "$pid" 2>/dev/null; do
+    ((SECONDS < deadline)) || return 1
+    sleep 1
+  done
+}
+
+wait_for_new_pid() {
+  local excluded_pid="$1"
+  local deadline=$((SECONDS + $2))
+  while ((SECONDS < deadline)); do
+    local pid
+    while IFS= read -r pid; do
+      if [[ -n "$pid" && "$pid" != "$excluded_pid" ]] && kill -0 "$pid" 2>/dev/null; then
+        printf '%s\n' "$pid"
+        return 0
+      fi
+    done < <(lantern_pids)
+    sleep 1
+  done
+  return 1
+}
+
+capture_screenshot() {
+  local name="$1"
+  screencapture -x "$ARTIFACT_DIR/$name.png" \
+    2>"$ARTIFACT_DIR/$name-screenshot-error.txt" || true
+}
+
+capture_processes() {
+  local name="$1"
+  { date -u; ps -axo pid=,ppid=,etime=,state=,command=; } \
+    >"$ARTIFACT_DIR/processes-$name.txt" 2>&1 || true
+}
+
+bundle_value() {
+  /usr/libexec/PlistBuddy -c "Print :$1" "$APP_PATH/Contents/Info.plist"
+}
+
+capture_versions() {
+  local name="$1"
+  {
+    printf 'CFBundleVersion=%s\n' "$(bundle_value CFBundleVersion)"
+    printf 'CFBundleShortVersionString=%s\n' "$(bundle_value CFBundleShortVersionString)"
+    codesign -dvvv "$APP_PATH"
+  } >"$ARTIFACT_DIR/versions-$name.txt" 2>&1 || true
+}
+
+verify_bundle() {
+  local name="$1"
+  local expected_build="$2"
+  local expected_display="$3"
+  [[ "$(bundle_value CFBundleVersion)" == "$expected_build" ]] || {
+    printf '%s bundle build did not match %s.\n' "$name" "$expected_build" >&2
+    return 1
+  }
+  [[ "$(bundle_value CFBundleShortVersionString)" == "$expected_display" ]] || {
+    printf '%s display version did not match %s.\n' "$name" "$expected_display" >&2
+    return 1
+  }
+  {
+    codesign --verify --deep --strict --verbose=4 "$APP_PATH"
+    spctl --assess --type execute --verbose=4 "$APP_PATH"
+  } >"$ARTIFACT_DIR/signature-$name.txt" 2>&1
+}
+
+detach_dmg() {
+  if [[ -n "$MOUNT_PATH" && -d "$MOUNT_PATH" ]]; then
+    hdiutil detach "$MOUNT_PATH" -quiet >/dev/null 2>&1 || true
+    rmdir "$MOUNT_PATH" 2>/dev/null || true
+    MOUNT_PATH=""
+  fi
+}
+
+cleanup() {
+  guard_ci_paths
+  quit_lantern
+  local tracked_pid
+  for tracked_pid in "$ORIGINAL_PID" "$RELAUNCHED_PID"; do
+    if [[ -n "$tracked_pid" ]] && kill -0 "$tracked_pid" 2>/dev/null; then
+      kill -TERM "$tracked_pid" 2>/dev/null || true
+      wait_for_exit "$tracked_pid" 10 || kill -KILL "$tracked_pid" 2>/dev/null || true
+    fi
+  done
+  local pid
+  while IFS= read -r pid; do
+    if [[ -n "$pid" ]] && ! wait_for_exit "$pid" 10; then
+      kill -KILL "$pid" 2>/dev/null || true
+    fi
+  done < <(lantern_pids)
+  rm -rf -- "$APP_PATH"
+  rm -rf -- "$DATA_PATH"
+  defaults delete "$DEFAULTS_DOMAIN" >/dev/null 2>&1 || true
+}
+
+capture_diagnostics() {
+  mkdir -p "$ARTIFACT_DIR"
+  {
+    printf 'result=%s\noriginal_pid=%s\nrelaunched_pid=%s\n' \
+      "$RESULT" "$ORIGINAL_PID" "$RELAUNCHED_PID"
+  } >"$ARTIFACT_DIR/result.txt"
+  capture_processes final
+  [[ -d "$APP_PATH" ]] && capture_versions final
+  if [[ -d "$DATA_PATH/Logs" ]]; then
+    mkdir -p "$ARTIFACT_DIR/lantern-logs"
+    cp -R "$DATA_PATH/Logs/." "$ARTIFACT_DIR/lantern-logs/" 2>/dev/null || true
+  fi
+  if [[ -d "$HOME/Library/Logs/Sparkle" ]]; then
+    mkdir -p "$ARTIFACT_DIR/sparkle-logs"
+    cp -R "$HOME/Library/Logs/Sparkle/." "$ARTIFACT_DIR/sparkle-logs/" 2>/dev/null || true
+  fi
+  log show --last 90m --style syslog \
+    --predicate 'process == "Lantern" OR process == "Updater" OR process == "Installer" OR process == "Downloader" OR eventMessage CONTAINS[c] "Sparkle" OR subsystem == "org.getlantern.lantern"' \
+    >"$ARTIFACT_DIR/unified-lantern-sparkle.log" 2>&1 || true
+}
+
+on_exit() {
+  local status=$?
+  set +e
+  capture_diagnostics
+  capture_screenshot final
+  detach_dmg
+  cleanup
+  exit "$status"
+}
+trap on_exit EXIT
+
+install_fixture() {
+  MOUNT_PATH="$(mktemp -d)"
+  hdiutil attach "$FIXTURE_DMG" -nobrowse -readonly -mountpoint "$MOUNT_PATH" >/dev/null
+  local source_app
+  source_app="$(find "$MOUNT_PATH" -maxdepth 3 -type d -name Lantern.app -print -quit)"
+  [[ -n "$source_app" ]] || return 1
+  ditto "$source_app" "$APP_PATH"
+  detach_dmg
+}
+
+revalidate_target() {
+  local recheck="$ARTIFACT_DIR/live-recheck"
+  mkdir -p "$recheck"
+  python3 scripts/ci/resolve_macos_update_target.py \
+    --appcast-url "$(jq -r .appcast_url "$TARGET_JSON")" \
+    --appcast-output "$recheck/appcast.xml" \
+    --target-output "$recheck/target.json" \
+    --pubspec-input pubspec.yaml \
+    --pubspec-output "$recheck/pubspec.yaml"
+  [[ "$(jq -r .appcast_sha256 "$TARGET_JSON")" == "$(jq -r .appcast_sha256 "$recheck/target.json")" ]] || {
+    printf 'The live beta appcast changed while the fixture was building; rerun the workflow.\n' >&2
+    return 1
+  }
+}
+
+guard_ci_paths
+mkdir -p "$ARTIFACT_DIR"
+cp "$APPCAST_XML" "$ARTIFACT_DIR/appcast.xml"
+cp "$TARGET_JSON" "$ARTIFACT_DIR/resolved-target.json"
+osacompile -o "$RUNNER_TEMP/macos-sparkle-handoff.scpt" "$ROBOT_SCRIPT"
+revalidate_target
+
+TARGET_BUILD="$(jq -er '.target_build | tostring' "$TARGET_JSON")"
+FIXTURE_BUILD="$(jq -er '.fixture_build | tostring' "$TARGET_JSON")"
+DISPLAY_VERSION="$(jq -er .display_version "$TARGET_JSON")"
+readonly TARGET_BUILD FIXTURE_BUILD DISPLAY_VERSION
+
+cleanup
+mkdir -p "$DATA_PATH/E2E"
+{
+  xcrun stapler validate "$FIXTURE_DMG"
+  spctl --assess --type open --context context:primary-signature --verbose=4 "$FIXTURE_DMG"
+} >"$ARTIFACT_DIR/fixture-notarization.txt" 2>&1
+install_fixture
+verify_bundle fixture "$FIXTURE_BUILD" "$DISPLAY_VERSION"
+capture_versions fixture
+
+log_e2e "running the Flutter auto-update robot against the installed fixture"
+set +e
+flutter drive \
+  --profile \
+  --use-application-binary="$APP_PATH" \
+  --keep-app-running \
+  --driver=test_driver/integration_test.dart \
+  --target=integration_test/auto_update/macos_auto_update_smoke_test.dart \
+  --device-id=macos \
+  >"$ARTIFACT_DIR/flutter-drive.log" 2>&1
+drive_status=$?
+set -e
+cat "$ARTIFACT_DIR/flutter-drive.log"
+[[ "$drive_status" -eq 0 ]] || exit "$drive_status"
+
+[[ -f "$HANDOFF_PATH" ]] || {
+  printf 'Flutter test completed without creating its native handoff.\n' >&2
+  exit 1
+}
+cp "$HANDOFF_PATH" "$ARTIFACT_DIR/auto-update-handoff.json"
+if [[ -f "$DATA_PATH/Logs/screenshots/auto-update-before.png" ]]; then
+  cp "$DATA_PATH/Logs/screenshots/auto-update-before.png" "$ARTIFACT_DIR/before.png"
+fi
+ORIGINAL_PID="$(jq -er '.pid | tostring' "$HANDOFF_PATH")"
+[[ "$(jq -er .build_number "$HANDOFF_PATH")" == "$FIXTURE_BUILD" ]] || {
+  printf 'Flutter test ran against the wrong fixture build.\n' >&2
+  exit 1
+}
+[[ "$(jq -er .display_version "$HANDOFF_PATH")" == "$DISPLAY_VERSION" ]] || {
+  printf 'Flutter test ran against the wrong fixture display version.\n' >&2
+  exit 1
+}
+kill -0 "$ORIGINAL_PID"
+original_command="$(ps -p "$ORIGINAL_PID" -o command=)"
+[[ "$original_command" == "$APP_EXECUTABLE"* ]] || {
+  printf 'Flutter handoff PID %s is not the installed Lantern app: %s\n' \
+    "$ORIGINAL_PID" "$original_command" >&2
+  exit 1
+}
+capture_processes prompt
+
+log_e2e "waiting for the native Sparkle prompt from process $ORIGINAL_PID"
+osascript "$ROBOT_SCRIPT" wait-prompt "$ORIGINAL_PID" "$UI_TIMEOUT_SECONDS" \
+  | tee "$ARTIFACT_DIR/sparkle-prompt.txt"
+capture_screenshot prompt
+osascript "$ROBOT_SCRIPT" install-until-exit "$ORIGINAL_PID" "$UPDATE_TIMEOUT_SECONDS" \
+  2>&1 | tee "$ARTIFACT_DIR/sparkle-install.txt"
+
+log_e2e "waiting for Sparkle to replace and relaunch Lantern"
+if kill -0 "$ORIGINAL_PID" 2>/dev/null; then
+  printf 'Original Lantern process is still running after Sparkle completed.\n' >&2
+  exit 1
+fi
+RELAUNCHED_PID="$(wait_for_new_pid "$ORIGINAL_PID" "$UI_TIMEOUT_SECONDS")"
+osascript "$ROBOT_SCRIPT" wait-main "$RELAUNCHED_PID" "$UI_TIMEOUT_SECONDS" \
+  | tee "$ARTIFACT_DIR/main-window-after.txt"
+verify_bundle updated "$TARGET_BUILD" "$DISPLAY_VERSION"
+capture_versions updated
+capture_processes after
+capture_screenshot after
+
+RESULT="success"
+log_e2e "auto-update smoke passed: build $FIXTURE_BUILD -> $TARGET_BUILD"

--- a/.github/scripts/macos_auto_update_smoke.sh
+++ b/.github/scripts/macos_auto_update_smoke.sh
@@ -206,14 +206,15 @@ install_fixture() {
 revalidate_target() {
   local recheck="$ARTIFACT_DIR/live-recheck"
   mkdir -p "$recheck"
-  python3 scripts/ci/resolve_macos_update_target.py \
+  python3 scripts/ci/resolve_desktop_update_target.py \
+    --platform macos \
     --appcast-url "$(jq -r .appcast_url "$TARGET_JSON")" \
     --appcast-output "$recheck/appcast.xml" \
     --target-output "$recheck/target.json" \
     --pubspec-input pubspec.yaml \
     --pubspec-output "$recheck/pubspec.yaml"
   [[ "$(jq -r .appcast_sha256 "$TARGET_JSON")" == "$(jq -r .appcast_sha256 "$recheck/target.json")" ]] || {
-    printf 'The live beta appcast changed while the fixture was building; rerun the workflow.\n' >&2
+    printf 'The staging beta appcast changed while the fixture was building; rerun the workflow.\n' >&2
     return 1
   }
 }
@@ -247,7 +248,7 @@ flutter drive \
   --use-application-binary="$APP_PATH" \
   --keep-app-running \
   --driver=test_driver/integration_test.dart \
-  --target=integration_test/auto_update/macos_auto_update_smoke_test.dart \
+  --target=integration_test/auto_update/desktop_auto_update_smoke_test.dart \
   --device-id=macos \
   >"$ARTIFACT_DIR/flutter-drive.log" 2>&1
 drive_status=$?

--- a/.github/scripts/macos_sparkle_handoff.applescript
+++ b/.github/scripts/macos_sparkle_handoff.applescript
@@ -1,0 +1,144 @@
+-- The Flutter integration test owns Lantern's UI. This helper only crosses
+-- the native Sparkle boundary and confirms a window exists after relaunch.
+
+property installButtonNames : {"Install Update", "Install and Relaunch"}
+property pollInterval : 0.5
+
+on findButton(elementRef)
+  tell application "System Events"
+    try
+      if role of elementRef is "AXButton" then
+        set buttonName to name of elementRef as text
+        if installButtonNames contains buttonName and enabled of elementRef then return elementRef
+      end if
+    end try
+    try
+      set children to UI elements of elementRef
+    on error
+      set children to {}
+    end try
+  end tell
+  repeat with childRef in children
+    set matchRef to my findButton(childRef)
+    if matchRef is not missing value then return matchRef
+  end repeat
+  return missing value
+end findButton
+
+on processForPID(targetPID)
+  tell application "System Events"
+    repeat with processRef in application processes
+      try
+        if (unix id of processRef as integer) is targetPID then return processRef
+      end try
+    end repeat
+  end tell
+  return missing value
+end processForPID
+
+on findInstallButton(processRef)
+  tell application "System Events"
+    try
+      set processWindows to windows of processRef
+    on error
+      set processWindows to {}
+    end try
+  end tell
+  repeat with windowRef in processWindows
+    set matchRef to my findButton(windowRef)
+    if matchRef is not missing value then return matchRef
+  end repeat
+  return missing value
+end findInstallButton
+
+on waitForInstallButton(targetPID, timeoutSeconds)
+  set deadline to (current date) + timeoutSeconds
+  set checkedAccessibility to false
+  repeat while (current date) is less than deadline
+    set processRef to my processForPID(targetPID)
+    if processRef is not missing value then
+      if not checkedAccessibility then
+        tell application "System Events"
+          try
+            count of UI elements of processRef
+          on error errorMessage number errorNumber
+            error "macOS Accessibility is unavailable (" & errorNumber & "): " & errorMessage
+          end try
+        end tell
+        set checkedAccessibility to true
+      end if
+      set buttonRef to my findInstallButton(processRef)
+      if buttonRef is not missing value then return buttonRef
+    end if
+    delay pollInterval
+  end repeat
+  error "Sparkle install prompt did not appear before timeout"
+end waitForInstallButton
+
+on waitForMainWindow(targetPID, timeoutSeconds)
+  set deadline to (current date) + timeoutSeconds
+  repeat while (current date) is less than deadline
+    set processRef to my processForPID(targetPID)
+    if processRef is not missing value then
+      tell application "System Events"
+        try
+          repeat with windowRef in windows of processRef
+            if visible of windowRef and subrole of windowRef is "AXStandardWindow" then
+              set frontmost of processRef to true
+              return "main window ready"
+            end if
+          end repeat
+        end try
+      end tell
+    end if
+    delay pollInterval
+  end repeat
+  error "Lantern did not expose a main window before timeout"
+end waitForMainWindow
+
+on installUntilExit(targetPID, timeoutSeconds)
+  set deadline to (current date) + timeoutSeconds
+  repeat while (current date) is less than deadline
+    set processRef to my processForPID(targetPID)
+    if processRef is missing value then return "original process exited"
+    set buttonRef to my findInstallButton(processRef)
+    if buttonRef is not missing value then
+      tell application "System Events"
+        set buttonName to name of buttonRef as text
+        perform action "AXPress" of buttonRef
+      end tell
+      log "[E2E] pressed Sparkle " & buttonName
+    end if
+    delay pollInterval
+  end repeat
+  error "Lantern did not exit after accepting the Sparkle update"
+end installUntilExit
+
+on positiveInteger(valueText, fieldName)
+  try
+    set parsedValue to valueText as integer
+  on error
+    error fieldName & " must be an integer"
+  end try
+  if parsedValue < 1 then error fieldName & " must be positive"
+  return parsedValue
+end positiveInteger
+
+on run argv
+  if (count of argv) is not 3 then error "action, PID, and timeout are required"
+  set actionName to item 1 of argv
+  set targetPID to my positiveInteger(item 2 of argv, "PID")
+  set timeoutSeconds to my positiveInteger(item 3 of argv, "timeout")
+
+  if actionName is "wait-prompt" then
+    set buttonRef to my waitForInstallButton(targetPID, timeoutSeconds)
+    tell application "System Events" to return name of buttonRef as text
+  end if
+  if actionName is "install-until-exit" then
+    return my installUntilExit(targetPID, timeoutSeconds)
+  end if
+  if actionName is "wait-main" then
+    return my waitForMainWindow(targetPID, timeoutSeconds)
+  end if
+  error "unknown action: " & actionName
+end run

--- a/.github/scripts/windows_auto_update_smoke.ps1
+++ b/.github/scripts/windows_auto_update_smoke.ps1
@@ -1,0 +1,401 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$AppDirectory = 'C:\Program Files\Lantern'
+$AppExecutable = Join-Path $AppDirectory 'lantern.exe'
+$DataDirectory = 'C:\ProgramData\Lantern'
+$HandoffPath = Join-Path $DataDirectory 'E2E\auto-update-handoff.json'
+$FixtureInstaller = $env:FIXTURE_INSTALLER
+$TargetJson = $env:TARGET_JSON
+$AppcastXml = $env:APPCAST_XML
+$ArtifactDirectory = if ($env:ARTIFACT_DIR) { $env:ARTIFACT_DIR } else { 'smoke-artifacts\windows-auto-update' }
+$UiTimeoutSeconds = if ($env:UI_TIMEOUT_SECONDS) { [int]$env:UI_TIMEOUT_SECONDS } else { 120 }
+$UpdateTimeoutSeconds = if ($env:UPDATE_TIMEOUT_SECONDS) { [int]$env:UPDATE_TIMEOUT_SECONDS } else { 600 }
+$script:OriginalPid = 0
+$script:RelaunchedPid = 0
+$script:Result = 'failure'
+
+Add-Type -AssemblyName System.Drawing
+Add-Type -AssemblyName System.Windows.Forms
+Add-Type -AssemblyName UIAutomationClient
+Add-Type -AssemblyName UIAutomationTypes
+
+function Write-E2E([string]$Message) {
+  Write-Host "[E2E] $Message"
+}
+
+function Assert-SmokeGuard {
+  if ($env:CI -ne 'true' -or $env:GITHUB_ACTIONS -ne 'true') {
+    throw 'This smoke only runs in GitHub Actions CI.'
+  }
+  if ($env:LANTERN_AUTO_UPDATE_SMOKE -ne 'true') {
+    throw 'The explicit auto-update cleanup guard is missing.'
+  }
+  if ($AppDirectory -ne 'C:\Program Files\Lantern' -or $DataDirectory -ne 'C:\ProgramData\Lantern') {
+    throw 'Refusing to use unexpected Lantern paths.'
+  }
+  foreach ($requiredPath in @($FixtureInstaller, $TargetJson, $AppcastXml)) {
+    if ([string]::IsNullOrWhiteSpace($requiredPath) -or -not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
+      throw "Required smoke input was not found: $requiredPath"
+    }
+  }
+  if ($UiTimeoutSeconds -lt 1 -or $UpdateTimeoutSeconds -lt 1) {
+    throw 'Update smoke timeouts must be positive integers.'
+  }
+}
+
+function Get-LanternProcesses {
+  @(Get-Process -Name 'lantern' -ErrorAction SilentlyContinue | Where-Object {
+      try { $_.Path -eq $AppExecutable } catch { $false }
+    })
+}
+
+function Stop-LanternProcesses {
+  foreach ($process in Get-LanternProcesses) {
+    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Invoke-ProcessAndWait {
+  param(
+    [Parameter(Mandatory = $true)][string]$FilePath,
+    [string[]]$ArgumentList = @(),
+    [int]$TimeoutSeconds = 180,
+    [Parameter(Mandatory = $true)][string]$Description
+  )
+
+  Write-E2E "${Description}: $FilePath $($ArgumentList -join ' ')"
+  $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -PassThru
+  if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
+    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
+    throw "$Description timed out after $TimeoutSeconds seconds"
+  }
+  if ($process.ExitCode -ne 0) {
+    throw "$Description failed with exit code $($process.ExitCode)"
+  }
+}
+
+function Remove-InstalledLantern {
+  Assert-SmokeGuard
+  Stop-LanternProcesses
+  $uninstaller = Get-ChildItem -LiteralPath $AppDirectory -Filter 'unins*.exe' -File -ErrorAction SilentlyContinue |
+    Sort-Object Name |
+    Select-Object -First 1
+  if ($uninstaller) {
+    Invoke-ProcessAndWait `
+      -FilePath $uninstaller.FullName `
+      -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-') `
+      -Description 'Uninstalling the existing Lantern fixture'
+  } elseif (Test-Path -LiteralPath (Join-Path $AppDirectory 'lanternd.exe')) {
+    & (Join-Path $AppDirectory 'lanternd.exe') uninstall 2>&1 | Out-Null
+  }
+  if (Test-Path -LiteralPath $AppDirectory) {
+    Remove-Item -LiteralPath $AppDirectory -Recurse -Force
+  }
+  if (Test-Path -LiteralPath $DataDirectory) {
+    Remove-Item -LiteralPath $DataDirectory -Recurse -Force
+  }
+}
+
+function Save-Screenshot([string]$Name) {
+  try {
+    $bounds = [System.Windows.Forms.SystemInformation]::VirtualScreen
+    $bitmap = [System.Drawing.Bitmap]::new($bounds.Width, $bounds.Height)
+    $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
+    try {
+      $graphics.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
+      $bitmap.Save((Join-Path $ArtifactDirectory "$Name.png"), [System.Drawing.Imaging.ImageFormat]::Png)
+    } finally {
+      $graphics.Dispose()
+      $bitmap.Dispose()
+    }
+  } catch {
+    $_ | Out-String | Set-Content (Join-Path $ArtifactDirectory "$Name-screenshot-error.txt")
+  }
+}
+
+function Save-Processes([string]$Name) {
+  Get-CimInstance Win32_Process |
+    Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CommandLine |
+    Format-List |
+    Out-String -Width 4096 |
+    Set-Content (Join-Path $ArtifactDirectory "processes-$Name.txt")
+}
+
+function Get-AppVersion {
+  if (-not (Test-Path -LiteralPath $AppExecutable -PathType Leaf)) {
+    throw "Lantern executable was not found: $AppExecutable"
+  }
+  $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($AppExecutable)
+  [pscustomobject]@{
+    DisplayVersion = $version.ProductVersion
+    BuildNumber = $version.FilePrivatePart
+    FileVersion = $version.FileVersion
+    ProductVersion = $version.ProductVersion
+  }
+}
+
+function Test-InstalledAppVersion {
+  param(
+    [Parameter(Mandatory = $true)][string]$Name,
+    [Parameter(Mandatory = $true)][int]$ExpectedBuild,
+    [Parameter(Mandatory = $true)][string]$ExpectedDisplay
+  )
+  $version = Save-AppVersion $Name
+  $signature = Get-AuthenticodeSignature -LiteralPath $AppExecutable
+  Add-Content (Join-Path $ArtifactDirectory "versions-$Name.txt") @(
+    "authenticode_status=$($signature.Status)"
+    "authenticode_subject=$($signature.SignerCertificate.Subject)"
+  )
+  if ($version.DisplayVersion -ne $ExpectedDisplay) {
+    throw "$Name display version $($version.DisplayVersion) did not match $ExpectedDisplay"
+  }
+  if ($version.BuildNumber -ne $ExpectedBuild) {
+    throw "$Name build $($version.BuildNumber) did not match $ExpectedBuild"
+  }
+  if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
+    throw "$Name Authenticode signature is $($signature.Status)"
+  }
+}
+
+function Save-AppVersion([string]$Name) {
+  $version = Get-AppVersion
+  @(
+    "display_version=$($version.DisplayVersion)"
+    "build_number=$($version.BuildNumber)"
+    "file_version=$($version.FileVersion)"
+    "product_version=$($version.ProductVersion)"
+  ) | Set-Content (Join-Path $ArtifactDirectory "versions-$Name.txt")
+  return $version
+}
+
+function Get-TopLevelWindows {
+  $condition = [System.Windows.Automation.PropertyCondition]::new(
+    [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+    [System.Windows.Automation.ControlType]::Window
+  )
+  [System.Windows.Automation.AutomationElement]::RootElement.FindAll(
+    [System.Windows.Automation.TreeScope]::Children,
+    $condition
+  )
+}
+
+function Find-Window {
+  param([string[]]$Names)
+  foreach ($window in Get-TopLevelWindows) {
+    if ($Names -contains $window.Current.Name) {
+      return $window
+    }
+  }
+  return $null
+}
+
+function Find-Button {
+  param(
+    [Parameter(Mandatory = $true)][System.Windows.Automation.AutomationElement]$Window,
+    [Parameter(Mandatory = $true)][string[]]$Names
+  )
+  $condition = [System.Windows.Automation.PropertyCondition]::new(
+    [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+    [System.Windows.Automation.ControlType]::Button
+  )
+  foreach ($button in $Window.FindAll([System.Windows.Automation.TreeScope]::Descendants, $condition)) {
+    $name = $button.Current.Name.Replace('&', '')
+    if ($button.Current.IsEnabled -and $Names -contains $name) {
+      return $button
+    }
+  }
+  return $null
+}
+
+function Invoke-Button([System.Windows.Automation.AutomationElement]$Button) {
+  $pattern = $null
+  if (-not $Button.TryGetCurrentPattern(
+      [System.Windows.Automation.InvokePattern]::Pattern,
+      [ref]$pattern
+    )) {
+    throw "Button '$($Button.Current.Name)' does not support InvokePattern"
+  }
+  Write-E2E "pressing $($Button.Current.Name)"
+  ([System.Windows.Automation.InvokePattern]$pattern).Invoke()
+}
+
+function Save-UiTree([string]$Name) {
+  $lines = [System.Collections.Generic.List[string]]::new()
+  foreach ($window in Get-TopLevelWindows) {
+    $lines.Add("WINDOW name='$($window.Current.Name)' pid=$($window.Current.ProcessId)")
+    $condition = [System.Windows.Automation.PropertyCondition]::new(
+      [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+      [System.Windows.Automation.ControlType]::Button
+    )
+    foreach ($button in $window.FindAll([System.Windows.Automation.TreeScope]::Descendants, $condition)) {
+      $lines.Add("  BUTTON name='$($button.Current.Name)' enabled=$($button.Current.IsEnabled)")
+    }
+  }
+  $lines | Set-Content (Join-Path $ArtifactDirectory "ui-$Name.txt")
+}
+
+function Wait-ForWinSparklePrompt {
+  $deadline = [DateTime]::UtcNow.AddSeconds($UiTimeoutSeconds)
+  while ([DateTime]::UtcNow -lt $deadline) {
+    $window = Find-Window @('Software Update')
+    if ($window) {
+      $button = Find-Button $window @('Install update', 'Get update')
+      if ($button) { return $button }
+    }
+    Start-Sleep -Milliseconds 250
+  }
+  Save-UiTree 'prompt-timeout'
+  throw 'WinSparkle update prompt did not appear before timeout'
+}
+
+function Install-ThroughNativeUi {
+  $deadline = [DateTime]::UtcNow.AddSeconds($UpdateTimeoutSeconds)
+  while ([DateTime]::UtcNow -lt $deadline) {
+    $lantern = Get-Process -Id $script:OriginalPid -ErrorAction SilentlyContinue
+    if ($lantern) {
+      $sparkle = Find-Window @('Software Update')
+      if ($sparkle) {
+        $button = Find-Button $sparkle @('Install update', 'Get update', 'Run installer')
+        if ($button) {
+          Invoke-Button $button
+          Start-Sleep -Milliseconds 500
+          continue
+        }
+      }
+    }
+
+    $installer = Find-Window @('Setup - Lantern', 'Lantern Setup')
+    if ($installer) {
+      $button = Find-Button $installer @('Next >', 'Install', 'Finish')
+      if ($button) {
+        Invoke-Button $button
+        Start-Sleep -Milliseconds 500
+        continue
+      }
+    }
+
+    if (-not $lantern) {
+      $newProcess = Get-LanternProcesses | Where-Object { $_.Id -ne $script:OriginalPid } | Select-Object -First 1
+      if ($newProcess) { return $newProcess }
+    }
+    Start-Sleep -Milliseconds 250
+  }
+  Save-UiTree 'install-timeout'
+  throw 'The Windows update did not install and relaunch before timeout'
+}
+
+function Wait-ForMainWindow([int]$ProcessId) {
+  $deadline = [DateTime]::UtcNow.AddSeconds($UiTimeoutSeconds)
+  while ([DateTime]::UtcNow -lt $deadline) {
+    $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
+    if ($process) {
+      $process.Refresh()
+      if ($process.MainWindowHandle -ne 0) { return }
+    }
+    Start-Sleep -Milliseconds 250
+  }
+  Save-UiTree 'main-window-timeout'
+  throw "Lantern process $ProcessId did not expose a main window before timeout"
+}
+
+function Save-Diagnostics {
+  New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
+  @(
+    "result=$script:Result"
+    "original_pid=$script:OriginalPid"
+    "relaunched_pid=$script:RelaunchedPid"
+  ) | Set-Content (Join-Path $ArtifactDirectory 'result.txt')
+  Save-Processes 'final'
+  Save-UiTree 'final'
+  if (Test-Path -LiteralPath $AppExecutable) {
+    try { Save-AppVersion 'final' | Out-Null } catch {}
+  }
+  $logDirectory = Join-Path $DataDirectory 'Logs'
+  if (Test-Path -LiteralPath $logDirectory) {
+    Copy-Item -LiteralPath $logDirectory -Destination (Join-Path $ArtifactDirectory 'lantern-logs') -Recurse -Force
+  }
+  Get-ChildItem -Path $env:TEMP -Filter 'Update-*' -Directory -ErrorAction SilentlyContinue |
+    Select-Object FullName, Length, LastWriteTime |
+    Format-Table -AutoSize |
+    Out-String -Width 4096 |
+    Set-Content (Join-Path $ArtifactDirectory 'sparkle-files.txt')
+}
+
+Assert-SmokeGuard
+New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
+Copy-Item -LiteralPath $AppcastXml -Destination (Join-Path $ArtifactDirectory 'appcast.xml')
+Copy-Item -LiteralPath $TargetJson -Destination (Join-Path $ArtifactDirectory 'resolved-target.json')
+$target = Get-Content -LiteralPath $TargetJson -Raw | ConvertFrom-Json
+$targetBuild = [int]$target.target_build
+$fixtureBuild = [int]$target.fixture_build
+$displayVersion = [string]$target.display_version
+$recheckDirectory = Join-Path $ArtifactDirectory 'live-recheck'
+New-Item -ItemType Directory -Path $recheckDirectory -Force | Out-Null
+& python scripts/ci/resolve_desktop_update_target.py `
+  --platform windows `
+  --appcast-url ([string]$target.appcast_url) `
+  --appcast-output (Join-Path $recheckDirectory 'appcast.xml') `
+  --target-output (Join-Path $recheckDirectory 'target.json') `
+  --pubspec-input pubspec.yaml `
+  --pubspec-output (Join-Path $recheckDirectory 'pubspec.yaml')
+if ($LASTEXITCODE -ne 0) { throw 'Unable to revalidate the live Windows beta target.' }
+$recheckedTarget = Get-Content -LiteralPath (Join-Path $recheckDirectory 'target.json') -Raw | ConvertFrom-Json
+if ($recheckedTarget.appcast_sha256 -ne $target.appcast_sha256) {
+  throw 'The staging beta appcast changed while the fixture was building; rerun the workflow.'
+}
+
+try {
+  Remove-InstalledLantern
+  Invoke-ProcessAndWait `
+    -FilePath $FixtureInstaller `
+    -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-') `
+    -Description 'Installing lower Lantern fixture'
+  Test-InstalledAppVersion -Name 'fixture' -ExpectedBuild $fixtureBuild -ExpectedDisplay $displayVersion
+  Save-Screenshot 'before'
+
+  Write-E2E 'running the Flutter auto-update robot against the installed fixture'
+  $driveArguments = @(
+    'drive', '--profile', "--use-application-binary=$AppExecutable", '--keep-app-running',
+    '--driver=test_driver/integration_test.dart',
+    '--target=integration_test/auto_update/desktop_auto_update_smoke_test.dart',
+    '--device-id=windows'
+  )
+  & flutter @driveArguments *>&1 | Tee-Object -FilePath (Join-Path $ArtifactDirectory 'flutter-drive.log')
+  if ($LASTEXITCODE -ne 0) { throw "Flutter auto-update robot failed with exit code $LASTEXITCODE" }
+  if (-not (Test-Path -LiteralPath $HandoffPath -PathType Leaf)) {
+    throw 'Flutter test completed without creating its native handoff.'
+  }
+  Copy-Item -LiteralPath $HandoffPath -Destination (Join-Path $ArtifactDirectory 'auto-update-handoff.json')
+  $handoff = Get-Content -LiteralPath $HandoffPath -Raw | ConvertFrom-Json
+  $script:OriginalPid = [int]$handoff.pid
+  if ([string]$handoff.build_number -ne [string]$fixtureBuild -or
+      [string]$handoff.display_version -ne $displayVersion) {
+    throw 'Flutter test ran against the wrong fixture version.'
+  }
+  $original = Get-Process -Id $script:OriginalPid -ErrorAction Stop
+  if ($original.Path -ne $AppExecutable) {
+    throw "Flutter handoff PID $script:OriginalPid is not the installed Lantern app"
+  }
+
+  Save-Processes 'prompt'
+  $installButton = Wait-ForWinSparklePrompt
+  Save-UiTree 'prompt'
+  Save-Screenshot 'prompt'
+  Invoke-Button $installButton
+  $relaunched = Install-ThroughNativeUi
+  $script:RelaunchedPid = $relaunched.Id
+  if (Get-Process -Id $script:OriginalPid -ErrorAction SilentlyContinue) {
+    throw 'Original Lantern process is still running after WinSparkle completed.'
+  }
+  Wait-ForMainWindow $script:RelaunchedPid
+  Test-InstalledAppVersion -Name 'updated' -ExpectedBuild $targetBuild -ExpectedDisplay $displayVersion
+  Save-Processes 'after'
+  Save-Screenshot 'after'
+  $script:Result = 'success'
+  Write-E2E "auto-update smoke passed: build $fixtureBuild -> $targetBuild"
+} finally {
+  try { Save-Diagnostics } catch { Write-Warning "Unable to save all diagnostics: $_" }
+  try { Save-Screenshot 'final' } catch { Write-Warning "Unable to save final screenshot: $_" }
+  try { Remove-InstalledLantern } catch { Write-Warning "Unable to clean up Lantern fixture: $_" }
+}

--- a/.github/scripts/windows_auto_update_smoke.ps1
+++ b/.github/scripts/windows_auto_update_smoke.ps1
@@ -140,14 +140,17 @@ function Assert-AppVersion {
   }
 }
 
-function Get-Window([string[]]$Names) {
+function Get-Window([string[]]$NamePrefixes) {
   $condition = [System.Windows.Automation.PropertyCondition]::new(
     [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
     [System.Windows.Automation.ControlType]::Window
   )
   foreach ($window in [System.Windows.Automation.AutomationElement]::RootElement.FindAll(
       [System.Windows.Automation.TreeScope]::Children, $condition)) {
-    if ($Names -contains $window.Current.Name) { return $window }
+    $name = $window.Current.Name
+    foreach ($prefix in $NamePrefixes) {
+      if ($name -eq $prefix -or $name.StartsWith("$prefix ")) { return $window }
+    }
   }
   return $null
 }
@@ -206,15 +209,14 @@ function Wait-ForUpdatePrompt {
 function Install-Update([int]$OriginalPid) {
   $deadline = [DateTime]::UtcNow.AddSeconds($UpdateTimeout)
   while ([DateTime]::UtcNow -lt $deadline) {
-    foreach ($candidate in @(
-        @{ Window = @('Software Update'); Button = @('Install update', 'Get update', 'Run installer') },
-        @{ Window = @('Setup - Lantern', 'Lantern Setup'); Button = @('Next >', 'Install', 'Finish') }
-      )) {
-      $button = Get-Button (Get-Window $candidate.Window) $candidate.Button
-      if ($button) {
-        Press-Button $button
-        Start-Sleep -Milliseconds 500
-      }
+    $installer = Get-Window @('Setup - Lantern', 'Lantern Setup')
+    $button = Get-Button $installer @('Next >', 'Next', 'Install', 'Finish', 'Yes')
+    if (-not $button) {
+      $button = Get-Button (Get-Window @('Software Update')) @('Run installer')
+    }
+    if ($button) {
+      Press-Button $button
+      Start-Sleep -Milliseconds 500
     }
     if (-not (Get-Process -Id $OriginalPid -ErrorAction SilentlyContinue)) {
       $relaunched = Get-LanternProcesses | Where-Object Id -ne $OriginalPid | Select-Object -First 1
@@ -245,7 +247,7 @@ function Save-Diagnostics {
     "original_pid=$script:OriginalPid"
     "relaunched_pid=$script:RelaunchedPid"
   ) | Set-Content (Join-Path $ArtifactDirectory 'result.txt')
-  Get-CimInstance Win32_Process | Where-Object Name -Match '^(lantern|lanternd|Update|unins\d*)\.exe$' |
+  Get-CimInstance Win32_Process | Where-Object Name -Match '^(lantern|lanternd|lantern-installer.*|Update|unins\d*)\.exe$' |
     Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CommandLine |
     Format-List | Out-String -Width 4096 |
     Set-Content (Join-Path $ArtifactDirectory 'processes-final.txt')

--- a/.github/scripts/windows_auto_update_smoke.ps1
+++ b/.github/scripts/windows_auto_update_smoke.ps1
@@ -220,10 +220,12 @@ function Get-DownloadedInstaller([string]$ExpectedName, [long]$ExpectedLength) {
 function Install-Update(
   [int]$OriginalPid,
   [string]$ExpectedInstallerName,
-  [long]$ExpectedInstallerLength
+  [long]$ExpectedInstallerLength,
+  [int]$ExpectedBuild
 ) {
   $deadline = [DateTime]::UtcNow.AddSeconds($UpdateTimeout)
   $launchRequested = $false
+  $originalExited = $false
   while ([DateTime]::UtcNow -lt $deadline) {
     $installer = Get-Window @('Setup - Lantern', 'Lantern Setup')
     $button = Get-Button $installer @('Next >', 'Next', 'Install', 'Finish', 'Yes')
@@ -242,27 +244,28 @@ function Install-Update(
         }
       }
     }
-    if (-not (Get-Process -Id $OriginalPid -ErrorAction SilentlyContinue)) {
-      $relaunched = Get-LanternProcesses | Where-Object Id -ne $OriginalPid | Select-Object -First 1
-      if ($relaunched) { return $relaunched }
+    if (-not $originalExited -and -not (Get-Process -Id $OriginalPid -ErrorAction SilentlyContinue)) {
+      $originalExited = $true
+      Write-E2E "original Lantern process $OriginalPid exited"
+    }
+    if ($originalExited -and (Test-Path -LiteralPath $AppExecutable)) {
+      try {
+        $installedBuild = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($AppExecutable).FilePrivatePart
+        if ($installedBuild -eq $ExpectedBuild) {
+          $relaunchCandidates = @(Get-LanternProcesses | Where-Object Id -ne $OriginalPid)
+          foreach ($relaunched in $relaunchCandidates) {
+            $relaunched.Refresh()
+            if ($relaunched.MainWindowHandle -ne 0) { return $relaunched }
+          }
+        }
+      } catch {
+        # The installer may be replacing the executable while this poll runs.
+      }
     }
     Start-Sleep -Milliseconds 250
   }
   Save-UiTree 'install-timeout'
   throw 'WinSparkle did not install and relaunch Lantern before timeout'
-}
-
-function Wait-ForMainWindow([int]$ProcessId) {
-  $deadline = [DateTime]::UtcNow.AddSeconds($UiTimeout)
-  while ([DateTime]::UtcNow -lt $deadline) {
-    $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
-    if ($process) {
-      $process.Refresh()
-      if ($process.MainWindowHandle -ne 0) { return }
-    }
-    Start-Sleep -Milliseconds 250
-  }
-  throw "Lantern process $ProcessId did not expose a main window before timeout"
 }
 
 function Save-Diagnostics {
@@ -331,9 +334,12 @@ try {
   Save-UiTree 'prompt'
   Save-Screenshot 'prompt'
   Press-Button $installButton
-  $relaunched = Install-Update $script:OriginalPid $targetInstallerName $targetInstallerLength
+  $relaunched = Install-Update `
+    $script:OriginalPid `
+    $targetInstallerName `
+    $targetInstallerLength `
+    $targetBuild
   $script:RelaunchedPid = $relaunched.Id
-  Wait-ForMainWindow $script:RelaunchedPid
   Assert-AppVersion 'updated' $targetBuild $displayVersion
   Save-Screenshot 'after'
   $script:Result = 'success'

--- a/.github/scripts/windows_auto_update_smoke.ps1
+++ b/.github/scripts/windows_auto_update_smoke.ps1
@@ -206,17 +206,41 @@ function Wait-ForUpdatePrompt {
   throw 'WinSparkle update prompt did not appear before timeout'
 }
 
-function Install-Update([int]$OriginalPid) {
+function Get-DownloadedInstaller([string]$ExpectedName, [long]$ExpectedLength) {
+  @(
+    Get-ChildItem $env:TEMP -Filter 'Update-*' -Directory -ErrorAction SilentlyContinue |
+      ForEach-Object {
+        Get-ChildItem $_.FullName -Filter $ExpectedName -File -ErrorAction SilentlyContinue
+      } |
+      Where-Object Length -eq $ExpectedLength |
+      Sort-Object LastWriteTimeUtc -Descending
+  ) | Select-Object -First 1
+}
+
+function Install-Update(
+  [int]$OriginalPid,
+  [string]$ExpectedInstallerName,
+  [long]$ExpectedInstallerLength
+) {
   $deadline = [DateTime]::UtcNow.AddSeconds($UpdateTimeout)
+  $launchRequested = $false
   while ([DateTime]::UtcNow -lt $deadline) {
     $installer = Get-Window @('Setup - Lantern', 'Lantern Setup')
     $button = Get-Button $installer @('Next >', 'Next', 'Install', 'Finish', 'Yes')
-    if (-not $button) {
-      $button = Get-Button (Get-Window @('Software Update')) @('Run installer')
-    }
     if ($button) {
       Press-Button $button
       Start-Sleep -Milliseconds 500
+    } elseif (-not $launchRequested) {
+      $download = Get-DownloadedInstaller $ExpectedInstallerName $ExpectedInstallerLength
+      if ($download) {
+        $button = Get-Button (Get-Window @('Software Update')) @('Install update', 'Run installer')
+        if ($button) {
+          Write-E2E "download complete; launching $($download.Name)"
+          Press-Button $button
+          $launchRequested = $true
+          Start-Sleep -Milliseconds 500
+        }
+      }
     }
     if (-not (Get-Process -Id $OriginalPid -ErrorAction SilentlyContinue)) {
       $relaunched = Get-LanternProcesses | Where-Object Id -ne $OriginalPid | Select-Object -First 1
@@ -271,6 +295,9 @@ $target = Get-Content $TargetJson -Raw | ConvertFrom-Json
 $targetBuild = [int]$target.target_build
 $fixtureBuild = [int]$target.fixture_build
 $displayVersion = [string]$target.display_version
+$targetUri = [Uri][string]$target.artifact_url
+$targetInstallerName = [IO.Path]::GetFileName($targetUri.AbsolutePath)
+$targetInstallerLength = [long]$target.artifact_length
 
 try {
   Install-Fixture
@@ -304,7 +331,7 @@ try {
   Save-UiTree 'prompt'
   Save-Screenshot 'prompt'
   Press-Button $installButton
-  $relaunched = Install-Update $script:OriginalPid
+  $relaunched = Install-Update $script:OriginalPid $targetInstallerName $targetInstallerLength
   $script:RelaunchedPid = $relaunched.Id
   Wait-ForMainWindow $script:RelaunchedPid
   Assert-AppVersion 'updated' $targetBuild $displayVersion

--- a/.github/scripts/windows_auto_update_smoke.ps1
+++ b/.github/scripts/windows_auto_update_smoke.ps1
@@ -5,12 +5,12 @@ $AppDirectory = 'C:\Program Files\Lantern'
 $AppExecutable = Join-Path $AppDirectory 'lantern.exe'
 $DataDirectory = 'C:\ProgramData\Lantern'
 $HandoffPath = Join-Path $DataDirectory 'E2E\auto-update-handoff.json'
-$FixtureInstaller = $env:FIXTURE_INSTALLER
+$FixtureDirectory = $env:FIXTURE_APP_DIR
 $TargetJson = $env:TARGET_JSON
 $AppcastXml = $env:APPCAST_XML
-$ArtifactDirectory = if ($env:ARTIFACT_DIR) { $env:ARTIFACT_DIR } else { 'smoke-artifacts\windows-auto-update' }
-$UiTimeoutSeconds = if ($env:UI_TIMEOUT_SECONDS) { [int]$env:UI_TIMEOUT_SECONDS } else { 120 }
-$UpdateTimeoutSeconds = if ($env:UPDATE_TIMEOUT_SECONDS) { [int]$env:UPDATE_TIMEOUT_SECONDS } else { 600 }
+$ArtifactDirectory = $env:ARTIFACT_DIR
+$UiTimeout = if ($env:UI_TIMEOUT_SECONDS) { [int]$env:UI_TIMEOUT_SECONDS } else { 120 }
+$UpdateTimeout = if ($env:UPDATE_TIMEOUT_SECONDS) { [int]$env:UPDATE_TIMEOUT_SECONDS } else { 600 }
 $script:OriginalPid = 0
 $script:RelaunchedPid = 0
 $script:Result = 'failure'
@@ -25,47 +25,46 @@ function Write-E2E([string]$Message) {
 }
 
 function Assert-SmokeGuard {
-  if ($env:CI -ne 'true' -or $env:GITHUB_ACTIONS -ne 'true') {
-    throw 'This smoke only runs in GitHub Actions CI.'
+  if ($env:CI -ne 'true' -or $env:GITHUB_ACTIONS -ne 'true' -or
+      $env:LANTERN_AUTO_UPDATE_SMOKE -ne 'true') {
+    throw 'This destructive smoke requires its explicit GitHub Actions guard.'
   }
-  if ($env:LANTERN_AUTO_UPDATE_SMOKE -ne 'true') {
-    throw 'The explicit auto-update cleanup guard is missing.'
-  }
-  if ($AppDirectory -ne 'C:\Program Files\Lantern' -or $DataDirectory -ne 'C:\ProgramData\Lantern') {
+  if ($AppDirectory -ne 'C:\Program Files\Lantern' -or
+      $DataDirectory -ne 'C:\ProgramData\Lantern') {
     throw 'Refusing to use unexpected Lantern paths.'
   }
-  foreach ($requiredPath in @($FixtureInstaller, $TargetJson, $AppcastXml)) {
-    if ([string]::IsNullOrWhiteSpace($requiredPath) -or -not (Test-Path -LiteralPath $requiredPath -PathType Leaf)) {
-      throw "Required smoke input was not found: $requiredPath"
+  foreach ($path in @($TargetJson, $AppcastXml)) {
+    if ([string]::IsNullOrWhiteSpace($path) -or
+        -not (Test-Path -LiteralPath $path -PathType Leaf)) {
+      throw "Required smoke input was not found: $path"
     }
   }
-  if ($UiTimeoutSeconds -lt 1 -or $UpdateTimeoutSeconds -lt 1) {
-    throw 'Update smoke timeouts must be positive integers.'
+  if ([string]::IsNullOrWhiteSpace($FixtureDirectory) -or
+      -not (Test-Path -LiteralPath $FixtureDirectory -PathType Container) -or
+      -not (Test-Path -LiteralPath (Join-Path $FixtureDirectory 'lantern.exe') -PathType Leaf)) {
+    throw "Signed fixture app was not found: $FixtureDirectory"
+  }
+  if ([string]::IsNullOrWhiteSpace($ArtifactDirectory) -or
+      $UiTimeout -lt 1 -or $UpdateTimeout -lt 1) {
+    throw 'Artifact directory and positive timeouts are required.'
   }
 }
 
 function Get-LanternProcesses {
-  @(Get-Process -Name 'lantern' -ErrorAction SilentlyContinue | Where-Object {
+  @(Get-Process -Name lantern -ErrorAction SilentlyContinue | Where-Object {
       try { $_.Path -eq $AppExecutable } catch { $false }
     })
 }
 
-function Stop-LanternProcesses {
-  foreach ($process in Get-LanternProcesses) {
-    Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
-  }
-}
-
-function Invoke-ProcessAndWait {
+function Invoke-Checked {
   param(
     [Parameter(Mandatory = $true)][string]$FilePath,
-    [string[]]$ArgumentList = @(),
-    [int]$TimeoutSeconds = 180,
-    [Parameter(Mandatory = $true)][string]$Description
+    [string[]]$Arguments = @(),
+    [Parameter(Mandatory = $true)][string]$Description,
+    [int]$TimeoutSeconds = 180
   )
-
-  Write-E2E "${Description}: $FilePath $($ArgumentList -join ' ')"
-  $process = Start-Process -FilePath $FilePath -ArgumentList $ArgumentList -PassThru
+  Write-E2E "${Description}: $FilePath $($Arguments -join ' ')"
+  $process = Start-Process $FilePath -ArgumentList $Arguments -PassThru
   if (-not $process.WaitForExit($TimeoutSeconds * 1000)) {
     Stop-Process -Id $process.Id -Force -ErrorAction SilentlyContinue
     throw "$Description timed out after $TimeoutSeconds seconds"
@@ -75,26 +74,28 @@ function Invoke-ProcessAndWait {
   }
 }
 
-function Remove-InstalledLantern {
+function Reset-Lantern {
   Assert-SmokeGuard
-  Stop-LanternProcesses
-  $uninstaller = Get-ChildItem -LiteralPath $AppDirectory -Filter 'unins*.exe' -File -ErrorAction SilentlyContinue |
-    Sort-Object Name |
-    Select-Object -First 1
+  Get-LanternProcesses | Stop-Process -Force -ErrorAction SilentlyContinue
+  $uninstaller = Get-ChildItem $AppDirectory -Filter 'unins*.exe' -File -ErrorAction SilentlyContinue |
+    Sort-Object Name | Select-Object -First 1
   if ($uninstaller) {
-    Invoke-ProcessAndWait `
-      -FilePath $uninstaller.FullName `
-      -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-') `
-      -Description 'Uninstalling the existing Lantern fixture'
-  } elseif (Test-Path -LiteralPath (Join-Path $AppDirectory 'lanternd.exe')) {
-    & (Join-Path $AppDirectory 'lanternd.exe') uninstall 2>&1 | Out-Null
+    Invoke-Checked $uninstaller.FullName @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-') `
+      'Uninstalling existing Lantern'
+  } else {
+    $service = Join-Path $AppDirectory 'lanternd.exe'
+    if (Test-Path -LiteralPath $service) {
+      & $service uninstall 2>&1 | Out-Null
+    }
   }
-  if (Test-Path -LiteralPath $AppDirectory) {
-    Remove-Item -LiteralPath $AppDirectory -Recurse -Force
-  }
-  if (Test-Path -LiteralPath $DataDirectory) {
-    Remove-Item -LiteralPath $DataDirectory -Recurse -Force
-  }
+  Remove-Item -LiteralPath $AppDirectory, $DataDirectory -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+function Install-Fixture {
+  Reset-Lantern
+  New-Item -ItemType Directory -Path $AppDirectory -Force | Out-Null
+  Copy-Item -Path (Join-Path $FixtureDirectory '*') -Destination $AppDirectory -Recurse -Force
+  Invoke-Checked (Join-Path $AppDirectory 'lanternd.exe') @('install') 'Registering fixture service'
 }
 
 function Save-Screenshot([string]$Name) {
@@ -104,7 +105,7 @@ function Save-Screenshot([string]$Name) {
     $graphics = [System.Drawing.Graphics]::FromImage($bitmap)
     try {
       $graphics.CopyFromScreen($bounds.Location, [System.Drawing.Point]::Empty, $bounds.Size)
-      $bitmap.Save((Join-Path $ArtifactDirectory "$Name.png"), [System.Drawing.Imaging.ImageFormat]::Png)
+      $bitmap.Save((Join-Path $ArtifactDirectory "$Name.png"))
     } finally {
       $graphics.Dispose()
       $bitmap.Dispose()
@@ -114,179 +115,119 @@ function Save-Screenshot([string]$Name) {
   }
 }
 
-function Save-Processes([string]$Name) {
-  Get-CimInstance Win32_Process |
-    Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CommandLine |
-    Format-List |
-    Out-String -Width 4096 |
-    Set-Content (Join-Path $ArtifactDirectory "processes-$Name.txt")
-}
-
-function Get-AppVersion {
-  if (-not (Test-Path -LiteralPath $AppExecutable -PathType Leaf)) {
-    throw "Lantern executable was not found: $AppExecutable"
-  }
-  $version = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($AppExecutable)
-  [pscustomobject]@{
-    DisplayVersion = $version.ProductVersion
-    BuildNumber = $version.FilePrivatePart
-    FileVersion = $version.FileVersion
-    ProductVersion = $version.ProductVersion
-  }
-}
-
-function Test-InstalledAppVersion {
+function Assert-AppVersion {
   param(
-    [Parameter(Mandatory = $true)][string]$Name,
-    [Parameter(Mandatory = $true)][int]$ExpectedBuild,
-    [Parameter(Mandatory = $true)][string]$ExpectedDisplay
+    [string]$Name,
+    [int]$ExpectedBuild,
+    [string]$ExpectedDisplay
   )
-  $version = Save-AppVersion $Name
+  $info = [System.Diagnostics.FileVersionInfo]::GetVersionInfo($AppExecutable)
+  $display = ($info.ProductVersion -split '\+', 2)[0]
   $signature = Get-AuthenticodeSignature -LiteralPath $AppExecutable
-  Add-Content (Join-Path $ArtifactDirectory "versions-$Name.txt") @(
+  $subject = if ($null -eq $signature.SignerCertificate) { '' } else { $signature.SignerCertificate.Subject }
+  @(
+    "display_version=$display"
+    "raw_product_version=$($info.ProductVersion)"
+    "build_number=$($info.FilePrivatePart)"
     "authenticode_status=$($signature.Status)"
-    "authenticode_subject=$($signature.SignerCertificate.Subject)"
-  )
-  if ($version.DisplayVersion -ne $ExpectedDisplay) {
-    throw "$Name display version $($version.DisplayVersion) did not match $ExpectedDisplay"
-  }
-  if ($version.BuildNumber -ne $ExpectedBuild) {
-    throw "$Name build $($version.BuildNumber) did not match $ExpectedBuild"
+    "authenticode_subject=$subject"
+  ) | Set-Content (Join-Path $ArtifactDirectory "versions-$Name.txt")
+  if ($display -ne $ExpectedDisplay -or $info.FilePrivatePart -ne $ExpectedBuild) {
+    throw "$Name version $display+$($info.FilePrivatePart) did not match $ExpectedDisplay+$ExpectedBuild"
   }
   if ($signature.Status -ne [System.Management.Automation.SignatureStatus]::Valid) {
-    throw "$Name Authenticode signature is $($signature.Status)"
+    throw "$Name Lantern executable Authenticode status is $($signature.Status)"
   }
 }
 
-function Save-AppVersion([string]$Name) {
-  $version = Get-AppVersion
-  @(
-    "display_version=$($version.DisplayVersion)"
-    "build_number=$($version.BuildNumber)"
-    "file_version=$($version.FileVersion)"
-    "product_version=$($version.ProductVersion)"
-  ) | Set-Content (Join-Path $ArtifactDirectory "versions-$Name.txt")
-  return $version
-}
-
-function Get-TopLevelWindows {
+function Get-Window([string[]]$Names) {
   $condition = [System.Windows.Automation.PropertyCondition]::new(
     [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
     [System.Windows.Automation.ControlType]::Window
   )
-  [System.Windows.Automation.AutomationElement]::RootElement.FindAll(
-    [System.Windows.Automation.TreeScope]::Children,
-    $condition
-  )
-}
-
-function Find-Window {
-  param([string[]]$Names)
-  foreach ($window in Get-TopLevelWindows) {
-    if ($Names -contains $window.Current.Name) {
-      return $window
-    }
+  foreach ($window in [System.Windows.Automation.AutomationElement]::RootElement.FindAll(
+      [System.Windows.Automation.TreeScope]::Children, $condition)) {
+    if ($Names -contains $window.Current.Name) { return $window }
   }
   return $null
 }
 
-function Find-Button {
-  param(
-    [Parameter(Mandatory = $true)][System.Windows.Automation.AutomationElement]$Window,
-    [Parameter(Mandatory = $true)][string[]]$Names
-  )
+function Get-Button($Window, [string[]]$Names) {
+  if ($null -eq $Window) { return $null }
   $condition = [System.Windows.Automation.PropertyCondition]::new(
     [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
     [System.Windows.Automation.ControlType]::Button
   )
   foreach ($button in $Window.FindAll([System.Windows.Automation.TreeScope]::Descendants, $condition)) {
-    $name = $button.Current.Name.Replace('&', '')
-    if ($button.Current.IsEnabled -and $Names -contains $name) {
+    if ($button.Current.IsEnabled -and $Names -contains $button.Current.Name.Replace('&', '')) {
       return $button
     }
   }
   return $null
 }
 
-function Invoke-Button([System.Windows.Automation.AutomationElement]$Button) {
+function Press-Button($Button) {
   $pattern = $null
-  if (-not $Button.TryGetCurrentPattern(
-      [System.Windows.Automation.InvokePattern]::Pattern,
-      [ref]$pattern
-    )) {
-    throw "Button '$($Button.Current.Name)' does not support InvokePattern"
+  if (-not $Button.TryGetCurrentPattern([System.Windows.Automation.InvokePattern]::Pattern, [ref]$pattern)) {
+    throw "Button '$($Button.Current.Name)' cannot be invoked"
   }
   Write-E2E "pressing $($Button.Current.Name)"
   ([System.Windows.Automation.InvokePattern]$pattern).Invoke()
 }
 
 function Save-UiTree([string]$Name) {
-  $lines = [System.Collections.Generic.List[string]]::new()
-  foreach ($window in Get-TopLevelWindows) {
-    $lines.Add("WINDOW name='$($window.Current.Name)' pid=$($window.Current.ProcessId)")
-    $condition = [System.Windows.Automation.PropertyCondition]::new(
-      [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
-      [System.Windows.Automation.ControlType]::Button
-    )
-    foreach ($button in $window.FindAll([System.Windows.Automation.TreeScope]::Descendants, $condition)) {
-      $lines.Add("  BUTTON name='$($button.Current.Name)' enabled=$($button.Current.IsEnabled)")
+  $lines = foreach ($windowName in @('Software Update', 'Setup - Lantern', 'Lantern Setup')) {
+    $window = Get-Window @($windowName)
+    if ($window) {
+      "WINDOW name='$($window.Current.Name)' pid=$($window.Current.ProcessId)"
+      $condition = [System.Windows.Automation.PropertyCondition]::new(
+        [System.Windows.Automation.AutomationElement]::ControlTypeProperty,
+        [System.Windows.Automation.ControlType]::Button
+      )
+      foreach ($button in $window.FindAll([System.Windows.Automation.TreeScope]::Descendants, $condition)) {
+        "  BUTTON name='$($button.Current.Name)' enabled=$($button.Current.IsEnabled)"
+      }
     }
   }
   $lines | Set-Content (Join-Path $ArtifactDirectory "ui-$Name.txt")
 }
 
-function Wait-ForWinSparklePrompt {
-  $deadline = [DateTime]::UtcNow.AddSeconds($UiTimeoutSeconds)
+function Wait-ForUpdatePrompt {
+  $deadline = [DateTime]::UtcNow.AddSeconds($UiTimeout)
   while ([DateTime]::UtcNow -lt $deadline) {
-    $window = Find-Window @('Software Update')
-    if ($window) {
-      $button = Find-Button $window @('Install update', 'Get update')
-      if ($button) { return $button }
-    }
+    $button = Get-Button (Get-Window @('Software Update')) @('Install update', 'Get update')
+    if ($button) { return $button }
     Start-Sleep -Milliseconds 250
   }
   Save-UiTree 'prompt-timeout'
   throw 'WinSparkle update prompt did not appear before timeout'
 }
 
-function Install-ThroughNativeUi {
-  $deadline = [DateTime]::UtcNow.AddSeconds($UpdateTimeoutSeconds)
+function Install-Update([int]$OriginalPid) {
+  $deadline = [DateTime]::UtcNow.AddSeconds($UpdateTimeout)
   while ([DateTime]::UtcNow -lt $deadline) {
-    $lantern = Get-Process -Id $script:OriginalPid -ErrorAction SilentlyContinue
-    if ($lantern) {
-      $sparkle = Find-Window @('Software Update')
-      if ($sparkle) {
-        $button = Find-Button $sparkle @('Install update', 'Get update', 'Run installer')
-        if ($button) {
-          Invoke-Button $button
-          Start-Sleep -Milliseconds 500
-          continue
-        }
-      }
-    }
-
-    $installer = Find-Window @('Setup - Lantern', 'Lantern Setup')
-    if ($installer) {
-      $button = Find-Button $installer @('Next >', 'Install', 'Finish')
+    foreach ($candidate in @(
+        @{ Window = @('Software Update'); Button = @('Install update', 'Get update', 'Run installer') },
+        @{ Window = @('Setup - Lantern', 'Lantern Setup'); Button = @('Next >', 'Install', 'Finish') }
+      )) {
+      $button = Get-Button (Get-Window $candidate.Window) $candidate.Button
       if ($button) {
-        Invoke-Button $button
+        Press-Button $button
         Start-Sleep -Milliseconds 500
-        continue
       }
     }
-
-    if (-not $lantern) {
-      $newProcess = Get-LanternProcesses | Where-Object { $_.Id -ne $script:OriginalPid } | Select-Object -First 1
-      if ($newProcess) { return $newProcess }
+    if (-not (Get-Process -Id $OriginalPid -ErrorAction SilentlyContinue)) {
+      $relaunched = Get-LanternProcesses | Where-Object Id -ne $OriginalPid | Select-Object -First 1
+      if ($relaunched) { return $relaunched }
     }
     Start-Sleep -Milliseconds 250
   }
   Save-UiTree 'install-timeout'
-  throw 'The Windows update did not install and relaunch before timeout'
+  throw 'WinSparkle did not install and relaunch Lantern before timeout'
 }
 
 function Wait-ForMainWindow([int]$ProcessId) {
-  $deadline = [DateTime]::UtcNow.AddSeconds($UiTimeoutSeconds)
+  $deadline = [DateTime]::UtcNow.AddSeconds($UiTimeout)
   while ([DateTime]::UtcNow -lt $deadline) {
     $process = Get-Process -Id $ProcessId -ErrorAction SilentlyContinue
     if ($process) {
@@ -295,79 +236,58 @@ function Wait-ForMainWindow([int]$ProcessId) {
     }
     Start-Sleep -Milliseconds 250
   }
-  Save-UiTree 'main-window-timeout'
   throw "Lantern process $ProcessId did not expose a main window before timeout"
 }
 
 function Save-Diagnostics {
-  New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
   @(
     "result=$script:Result"
     "original_pid=$script:OriginalPid"
     "relaunched_pid=$script:RelaunchedPid"
   ) | Set-Content (Join-Path $ArtifactDirectory 'result.txt')
-  Save-Processes 'final'
+  Get-CimInstance Win32_Process | Where-Object Name -Match '^(lantern|lanternd|Update|unins\d*)\.exe$' |
+    Select-Object ProcessId, ParentProcessId, Name, ExecutablePath, CommandLine |
+    Format-List | Out-String -Width 4096 |
+    Set-Content (Join-Path $ArtifactDirectory 'processes-final.txt')
   Save-UiTree 'final'
-  if (Test-Path -LiteralPath $AppExecutable) {
-    try { Save-AppVersion 'final' | Out-Null } catch {}
+  $logs = Join-Path $DataDirectory 'Logs'
+  if (Test-Path -LiteralPath $logs) {
+    Copy-Item $logs (Join-Path $ArtifactDirectory 'lantern-logs') -Recurse -Force
   }
-  $logDirectory = Join-Path $DataDirectory 'Logs'
-  if (Test-Path -LiteralPath $logDirectory) {
-    Copy-Item -LiteralPath $logDirectory -Destination (Join-Path $ArtifactDirectory 'lantern-logs') -Recurse -Force
-  }
-  Get-ChildItem -Path $env:TEMP -Filter 'Update-*' -Directory -ErrorAction SilentlyContinue |
+  Get-ChildItem $env:TEMP -Filter 'Update-*' -Directory -ErrorAction SilentlyContinue |
+    ForEach-Object { Get-ChildItem $_.FullName -Recurse -ErrorAction SilentlyContinue } |
     Select-Object FullName, Length, LastWriteTime |
-    Format-Table -AutoSize |
-    Out-String -Width 4096 |
-    Set-Content (Join-Path $ArtifactDirectory 'sparkle-files.txt')
+    Format-Table -AutoSize | Out-String -Width 4096 |
+    Set-Content (Join-Path $ArtifactDirectory 'winsparkle-files.txt')
 }
 
 Assert-SmokeGuard
 New-Item -ItemType Directory -Path $ArtifactDirectory -Force | Out-Null
-Copy-Item -LiteralPath $AppcastXml -Destination (Join-Path $ArtifactDirectory 'appcast.xml')
-Copy-Item -LiteralPath $TargetJson -Destination (Join-Path $ArtifactDirectory 'resolved-target.json')
-$target = Get-Content -LiteralPath $TargetJson -Raw | ConvertFrom-Json
+Copy-Item $AppcastXml (Join-Path $ArtifactDirectory 'appcast.xml')
+Copy-Item $TargetJson (Join-Path $ArtifactDirectory 'resolved-target.json')
+$target = Get-Content $TargetJson -Raw | ConvertFrom-Json
 $targetBuild = [int]$target.target_build
 $fixtureBuild = [int]$target.fixture_build
 $displayVersion = [string]$target.display_version
-$recheckDirectory = Join-Path $ArtifactDirectory 'live-recheck'
-New-Item -ItemType Directory -Path $recheckDirectory -Force | Out-Null
-& python scripts/ci/resolve_desktop_update_target.py `
-  --platform windows `
-  --appcast-url ([string]$target.appcast_url) `
-  --appcast-output (Join-Path $recheckDirectory 'appcast.xml') `
-  --target-output (Join-Path $recheckDirectory 'target.json') `
-  --pubspec-input pubspec.yaml `
-  --pubspec-output (Join-Path $recheckDirectory 'pubspec.yaml')
-if ($LASTEXITCODE -ne 0) { throw 'Unable to revalidate the live Windows beta target.' }
-$recheckedTarget = Get-Content -LiteralPath (Join-Path $recheckDirectory 'target.json') -Raw | ConvertFrom-Json
-if ($recheckedTarget.appcast_sha256 -ne $target.appcast_sha256) {
-  throw 'The staging beta appcast changed while the fixture was building; rerun the workflow.'
-}
 
 try {
-  Remove-InstalledLantern
-  Invoke-ProcessAndWait `
-    -FilePath $FixtureInstaller `
-    -ArgumentList @('/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-') `
-    -Description 'Installing lower Lantern fixture'
-  Test-InstalledAppVersion -Name 'fixture' -ExpectedBuild $fixtureBuild -ExpectedDisplay $displayVersion
+  Install-Fixture
+  Assert-AppVersion 'fixture' $fixtureBuild $displayVersion
   Save-Screenshot 'before'
 
   Write-E2E 'running the Flutter auto-update robot against the installed fixture'
-  $driveArguments = @(
-    'drive', '--profile', "--use-application-binary=$AppExecutable", '--keep-app-running',
-    '--driver=test_driver/integration_test.dart',
-    '--target=integration_test/auto_update/desktop_auto_update_smoke_test.dart',
-    '--device-id=windows'
-  )
-  & flutter @driveArguments *>&1 | Tee-Object -FilePath (Join-Path $ArtifactDirectory 'flutter-drive.log')
+  & flutter drive --profile "--use-application-binary=$AppExecutable" --keep-app-running `
+    --driver=test_driver/integration_test.dart `
+    --target=integration_test/auto_update/desktop_auto_update_smoke_test.dart `
+    --device-id=windows *>&1 |
+    Tee-Object -FilePath (Join-Path $ArtifactDirectory 'flutter-drive.log')
   if ($LASTEXITCODE -ne 0) { throw "Flutter auto-update robot failed with exit code $LASTEXITCODE" }
+
   if (-not (Test-Path -LiteralPath $HandoffPath -PathType Leaf)) {
     throw 'Flutter test completed without creating its native handoff.'
   }
-  Copy-Item -LiteralPath $HandoffPath -Destination (Join-Path $ArtifactDirectory 'auto-update-handoff.json')
-  $handoff = Get-Content -LiteralPath $HandoffPath -Raw | ConvertFrom-Json
+  $handoff = Get-Content $HandoffPath -Raw | ConvertFrom-Json
+  Copy-Item $HandoffPath (Join-Path $ArtifactDirectory 'auto-update-handoff.json')
   $script:OriginalPid = [int]$handoff.pid
   if ([string]$handoff.build_number -ne [string]$fixtureBuild -or
       [string]$handoff.display_version -ne $displayVersion) {
@@ -378,24 +298,19 @@ try {
     throw "Flutter handoff PID $script:OriginalPid is not the installed Lantern app"
   }
 
-  Save-Processes 'prompt'
-  $installButton = Wait-ForWinSparklePrompt
+  $installButton = Wait-ForUpdatePrompt
   Save-UiTree 'prompt'
   Save-Screenshot 'prompt'
-  Invoke-Button $installButton
-  $relaunched = Install-ThroughNativeUi
+  Press-Button $installButton
+  $relaunched = Install-Update $script:OriginalPid
   $script:RelaunchedPid = $relaunched.Id
-  if (Get-Process -Id $script:OriginalPid -ErrorAction SilentlyContinue) {
-    throw 'Original Lantern process is still running after WinSparkle completed.'
-  }
   Wait-ForMainWindow $script:RelaunchedPid
-  Test-InstalledAppVersion -Name 'updated' -ExpectedBuild $targetBuild -ExpectedDisplay $displayVersion
-  Save-Processes 'after'
+  Assert-AppVersion 'updated' $targetBuild $displayVersion
   Save-Screenshot 'after'
   $script:Result = 'success'
   Write-E2E "auto-update smoke passed: build $fixtureBuild -> $targetBuild"
 } finally {
   try { Save-Diagnostics } catch { Write-Warning "Unable to save all diagnostics: $_" }
   try { Save-Screenshot 'final' } catch { Write-Warning "Unable to save final screenshot: $_" }
-  try { Remove-InstalledLantern } catch { Write-Warning "Unable to clean up Lantern fixture: $_" }
+  try { Reset-Lantern } catch { Write-Warning "Unable to clean up Lantern fixture: $_" }
 }

--- a/.github/workflows/android-compile-check.yml
+++ b/.github/workflows/android-compile-check.yml
@@ -98,7 +98,7 @@ jobs:
           make android-env >> "$GITHUB_ENV"
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -52,11 +52,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate auto-update selection
-        if: ${{ inputs.tests == 'auto-update' && !contains(fromJSON('["macos", "windows"]'), inputs.platforms) }}
+        if: ${{ inputs.tests == 'auto-update' && !contains(fromJSON('["all", "macos", "windows"]'), inputs.platforms) }}
         shell: bash
         run: |
-          echo '::error title=Invalid smoke selection::auto-update requires platforms=macos or windows'
+          echo '::error title=Invalid smoke selection::auto-update requires platforms=all, macos, or windows'
           exit 2
+
+  # Build one signed/notarized macOS target and one signed Windows target with
+  # the same numeric update version. Publishing stays outside Actions so the
+  # Lantern repository does not need a long-lived cross-repository token.
+  auto-update-fixture:
+    needs: validate-inputs
+    if: ${{ inputs.platforms == 'all' && inputs.tests == 'auto-update' }}
+    uses: ./.github/workflows/build-auto-update-fixtures.yml
+    secrets: inherit
+    with:
+      publish: false
 
   # Android builds its own versioned APKs and runs on Firebase Test Lab, so it
   # doesn't need the desktop version stamping from `prepare`. The vpn-smoke
@@ -65,7 +76,7 @@ jobs:
   # matrix (physical Pixel 8 + Arm virtual) with retries for flaky tests.
   android:
     needs: validate-inputs
-    if: ${{ contains(fromJSON('["all", "android", ""]'), inputs.platforms) }}
+    if: ${{ inputs.tests != 'auto-update' && contains(fromJSON('["all", "android", ""]'), inputs.platforms) }}
     uses: ./.github/workflows/firebase-test-lab.yml
     secrets: inherit
     with:
@@ -121,7 +132,7 @@ jobs:
   # to the optional suites: vpn-smoke leaves them off, `all` turns them on.
   linux:
     needs: prepare
-    if: ${{ contains(fromJSON('["all", "linux", ""]'), inputs.platforms) }}
+    if: ${{ inputs.tests != 'auto-update' && contains(fromJSON('["all", "linux", ""]'), inputs.platforms) }}
     uses: ./.github/workflows/build-linux.yml
     secrets: inherit
     with:

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -22,7 +22,7 @@ on:
         type: choice
         options:
           - vpn-smoke # connect/disconnect smoke only (validates the public IP changes) — the fast confidence check
-          - auto-update # macOS only: install a lower signed fixture and update it from the live beta feed
+          - auto-update # desktop: install a lower signed fixture and update it from the isolated staging feed
           - all # every standard suite the platform supports
         default: vpn-smoke
       linux_arch:
@@ -52,10 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Validate auto-update selection
-        if: ${{ inputs.tests == 'auto-update' && inputs.platforms != 'macos' }}
+        if: ${{ inputs.tests == 'auto-update' && !contains(fromJSON('["macos", "windows"]'), inputs.platforms) }}
         shell: bash
         run: |
-          echo '::error title=Invalid smoke selection::auto-update requires platforms=macos'
+          echo '::error title=Invalid smoke selection::auto-update requires platforms=macos or windows'
           exit 2
 
   # Android builds its own versioned APKs and runs on Firebase Test Lab, so it
@@ -159,7 +159,7 @@ jobs:
 
   windows:
     needs: prepare
-    if: ${{ contains(fromJSON('["all", "windows", ""]'), inputs.platforms) }}
+    if: ${{ contains(fromJSON('["all", "windows", ""]'), inputs.platforms) && inputs.tests != 'auto-update' }}
     uses: ./.github/workflows/build-windows.yml
     secrets: inherit
     with:
@@ -171,3 +171,9 @@ jobs:
       run_auth_smoke: ${{ (inputs.tests || 'all') == 'all' }}
       run_split_tunnel_website_smoke: ${{ (inputs.tests || 'all') == 'all' }}
       run_payment_checkout_smoke: ${{ (inputs.tests || 'all') == 'all' }}
+
+  windows-auto-update:
+    needs: validate-inputs
+    if: ${{ inputs.platforms == 'windows' && inputs.tests == 'auto-update' }}
+    uses: ./.github/workflows/windows-auto-update-smoke.yml
+    secrets: inherit

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -22,7 +22,8 @@ on:
         type: choice
         options:
           - vpn-smoke # connect/disconnect smoke only (validates the public IP changes) — the fast confidence check
-          - all # every suite the platform supports
+          - auto-update # macOS only: install a lower signed fixture and update it from the live beta feed
+          - all # every standard suite the platform supports
         default: vpn-smoke
       linux_arch:
         description: "Linux arch to test"
@@ -68,6 +69,7 @@ jobs:
       flaky_attempts: ${{ (inputs.tests || 'all') == 'all' && '2' || '' }}
 
   prepare:
+    if: ${{ inputs.tests != 'auto-update' }}
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.meta.outputs.version }}
@@ -123,7 +125,7 @@ jobs:
   # runs only when asked for explicitly.
   macos:
     needs: prepare
-    if: ${{ inputs.platforms == 'macos' }}
+    if: ${{ inputs.platforms == 'macos' && inputs.tests != 'auto-update' }}
     uses: ./.github/workflows/build-macos.yml
     secrets: inherit
     with:
@@ -133,6 +135,14 @@ jobs:
       runner_label: lantern-macos-smoke
       run_connect_smoke: true
       run_payment_checkout_smoke: ${{ (inputs.tests || 'all') == 'all' }}
+
+  # This is deliberately separate from the regular macOS build job: it
+  # replaces /Applications/Lantern.app and verifies Sparkle's relaunch. It is
+  # selected explicitly, and never runs in the nightly sweep.
+  macos-auto-update:
+    if: ${{ inputs.platforms == 'macos' && inputs.tests == 'auto-update' }}
+    uses: ./.github/workflows/macos-auto-update-smoke.yml
+    secrets: inherit
 
   windows:
     needs: prepare

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -58,17 +58,6 @@ jobs:
           echo '::error title=Invalid smoke selection::auto-update requires platforms=all, macos, or windows'
           exit 2
 
-  # Build one signed/notarized macOS target and one signed Windows target with
-  # the same numeric update version. Publishing stays outside Actions so the
-  # Lantern repository does not need a long-lived cross-repository token.
-  auto-update-fixture:
-    needs: validate-inputs
-    if: ${{ inputs.platforms == 'all' && inputs.tests == 'auto-update' }}
-    uses: ./.github/workflows/build-auto-update-fixtures.yml
-    secrets: inherit
-    with:
-      publish: false
-
   # Android builds its own versioned APKs and runs on Firebase Test Lab, so it
   # doesn't need the desktop version stamping from `prepare`. The vpn-smoke
   # tier builds only the VPN suite and runs it on one virtual device with no
@@ -164,7 +153,7 @@ jobs:
   # selected explicitly, and never runs in the nightly sweep.
   macos-auto-update:
     needs: validate-inputs
-    if: ${{ inputs.platforms == 'macos' && inputs.tests == 'auto-update' }}
+    if: ${{ contains(fromJSON('["all", "macos"]'), inputs.platforms) && inputs.tests == 'auto-update' }}
     uses: ./.github/workflows/macos-auto-update-smoke.yml
     secrets: inherit
 
@@ -185,6 +174,6 @@ jobs:
 
   windows-auto-update:
     needs: validate-inputs
-    if: ${{ inputs.platforms == 'windows' && inputs.tests == 'auto-update' }}
+    if: ${{ contains(fromJSON('["all", "windows"]'), inputs.platforms) && inputs.tests == 'auto-update' }}
     uses: ./.github/workflows/windows-auto-update-smoke.yml
     secrets: inherit

--- a/.github/workflows/app-smoke-tests.yml
+++ b/.github/workflows/app-smoke-tests.yml
@@ -48,12 +48,23 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  validate-inputs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate auto-update selection
+        if: ${{ inputs.tests == 'auto-update' && inputs.platforms != 'macos' }}
+        shell: bash
+        run: |
+          echo '::error title=Invalid smoke selection::auto-update requires platforms=macos'
+          exit 2
+
   # Android builds its own versioned APKs and runs on Firebase Test Lab, so it
   # doesn't need the desktop version stamping from `prepare`. The vpn-smoke
   # tier builds only the VPN suite and runs it on one virtual device with no
   # retries; `all` builds the full aggregator on the script's two-device
   # matrix (physical Pixel 8 + Arm virtual) with retries for flaky tests.
   android:
+    needs: validate-inputs
     if: ${{ contains(fromJSON('["all", "android", ""]'), inputs.platforms) }}
     uses: ./.github/workflows/firebase-test-lab.yml
     secrets: inherit
@@ -69,6 +80,7 @@ jobs:
       flaky_attempts: ${{ (inputs.tests || 'all') == 'all' && '2' || '' }}
 
   prepare:
+    needs: validate-inputs
     if: ${{ inputs.tests != 'auto-update' }}
     runs-on: ubuntu-latest
     outputs:
@@ -140,6 +152,7 @@ jobs:
   # replaces /Applications/Lantern.app and verifies Sparkle's relaunch. It is
   # selected explicitly, and never runs in the nightly sweep.
   macos-auto-update:
+    needs: validate-inputs
     if: ${{ inputs.platforms == 'macos' && inputs.tests == 'auto-update' }}
     uses: ./.github/workflows/macos-auto-update-smoke.yml
     secrets: inherit

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -91,7 +91,7 @@ jobs:
           make android-env >> "$GITHUB_ENV"
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml

--- a/.github/workflows/build-auto-update-fixtures.yml
+++ b/.github/workflows/build-auto-update-fixtures.yml
@@ -8,6 +8,13 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      publish:
+        description: "Publish the signed targets as a fixture-repository prerelease"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read

--- a/.github/workflows/build-auto-update-fixtures.yml
+++ b/.github/workflows/build-auto-update-fixtures.yml
@@ -1,0 +1,172 @@
+name: Build auto-update fixture targets
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish the signed targets as a fixture-repository prerelease"
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: build-auto-update-fixtures
+  cancel-in-progress: false
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      display_version: ${{ steps.fixture.outputs.display_version }}
+      release_tag: ${{ steps.fixture.outputs.release_tag }}
+      release_version: ${{ steps.fixture.outputs.release_version }}
+      target_build: ${{ steps.fixture.outputs.target_build }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Prepare target version
+        id: fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          DISPLAY_VERSION="$(sed -nE 's/^version:[[:space:]]*([^+[:space:]]+).*/\1/p' pubspec.yaml)"
+          TARGET_BUILD="$((1000 + GITHUB_RUN_NUMBER))"
+          RELEASE_VERSION="${DISPLAY_VERSION}-beta.e2e.${GITHUB_RUN_ID}"
+          RELEASE_TAG="v${RELEASE_VERSION}"
+          [[ "$TARGET_BUILD" =~ ^[0-9]+$ && "$TARGET_BUILD" -gt 1 && "$TARGET_BUILD" -le 65535 ]]
+          sed -i.bak -E "s/^version:.*/version: ${DISPLAY_VERSION}+${TARGET_BUILD}/" pubspec.yaml
+          rm pubspec.yaml.bak
+          {
+            echo "display_version=$DISPLAY_VERSION"
+            echo "release_tag=$RELEASE_TAG"
+            echo "release_version=$RELEASE_VERSION"
+            echo "target_build=$TARGET_BUILD"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Upload target pubspec
+        uses: actions/upload-artifact@v4
+        with:
+          name: auto-update-target-pubspec
+          path: pubspec.yaml
+          retention-days: 2
+
+  build-macos:
+    needs: prepare
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-macos.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prepare.outputs.display_version }}
+      build_type: beta
+      installer_base_name: lantern-installer
+      pubspec_artifact: auto-update-target-pubspec
+      auto_update_e2e: true
+      sign_update_artifact: true
+      run_connect_smoke: false
+      run_payment_checkout_smoke: false
+
+  build-windows:
+    needs: prepare
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-windows.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.prepare.outputs.display_version }}
+      build_type: beta
+      installer_base_name: lantern-installer
+      pubspec_artifact: auto-update-target-pubspec
+      auto_update_e2e: true
+      sign_update_artifact: true
+      run_installer_smoke: false
+      run_connect_smoke: false
+      run_split_tunnel_website_smoke: false
+      run_config_url_smoke: false
+      run_auth_smoke: false
+      run_payment_checkout_smoke: false
+
+  assemble:
+    needs:
+      - prepare
+      - build-macos
+      - build-windows
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download signed installers
+        uses: actions/download-artifact@v4
+        with:
+          pattern: lantern-installer-*
+          path: fixture-downloads
+
+      - name: Assemble and verify fixture release
+        shell: bash
+        env:
+          ASSET_BASE_URL: https://github.com/getlantern/lantern-update-fixtures/releases/download/${{ needs.prepare.outputs.release_tag }}
+          RELEASE_VERSION: ${{ needs.prepare.outputs.release_version }}
+          TARGET_BUILD: ${{ needs.prepare.outputs.target_build }}
+        run: |
+          set -euo pipefail
+          mkdir -p fixture-release/artifacts fixture-release/metadata fixture-release/signatures
+          find fixture-downloads -type f -name 'lantern-installer-beta.dmg' -exec cp {} fixture-release/artifacts/ \;
+          find fixture-downloads -type f -name 'lantern-installer-beta.exe' -exec cp {} fixture-release/artifacts/ \;
+          find fixture-downloads -type f -name '*.sparkle-signature' -exec cp {} fixture-release/signatures/ \;
+          test -f fixture-release/artifacts/lantern-installer-beta.dmg
+          test -f fixture-release/artifacts/lantern-installer-beta.exe
+          test -f fixture-release/signatures/lantern-installer-beta.dmg.sparkle-signature
+          test -f fixture-release/signatures/lantern-installer-beta.exe.sparkle-signature
+          python scripts/ci/generate_update_metadata.py \
+            --build-type beta \
+            --version "$RELEASE_VERSION" \
+            --sparkle-version "$TARGET_BUILD" \
+            --bucket unused-fixture-bucket \
+            --asset-base-url "$ASSET_BASE_URL" \
+            --output-dir fixture-release/metadata \
+            --sparkle-signature-dir fixture-release/signatures \
+            fixture-release/artifacts/*
+          python scripts/ci/verify_fixture_update_artifacts.py \
+            --artifact-dir fixture-release/artifacts \
+            --metadata-dir fixture-release/metadata \
+            --asset-base-url "$ASSET_BASE_URL"
+          cp fixture-release/metadata/* fixture-release/artifacts/
+
+      - name: Upload verified fixture release
+        uses: actions/upload-artifact@v4
+        with:
+          name: auto-update-fixture-release
+          path: fixture-release/artifacts
+          if-no-files-found: error
+          retention-days: 7
+
+      - name: Publish fixture prerelease
+        if: ${{ inputs.publish }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.UPDATE_FIXTURES_GH_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          [[ -n "$GH_TOKEN" ]] || {
+            echo '::error title=Missing fixture token::Set UPDATE_FIXTURES_GH_TOKEN before publishing.'
+            exit 1
+          }
+          gh release create "$RELEASE_TAG" \
+            --repo getlantern/lantern-update-fixtures \
+            --prerelease \
+            --title "Lantern auto-update fixture $RELEASE_TAG" \
+            --notes "Synthetic signed update target for Lantern E2E tests. Safe to delete after validation." \
+            fixture-release/artifacts/*

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -40,7 +40,7 @@ jobs:
           cache: true
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -138,7 +138,7 @@ jobs:
           echo "FLUTTER_VERSION=$FLUTTER_VERSION" >> "$GITHUB_ENV"
 
       - name: Install Flutter (amd64)
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         if: ${{ matrix.arch == 'amd64' }}
         with:
           channel: stable

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -34,6 +34,26 @@ on:
         required: false
         type: string
         default: macos-15
+      flutter_target:
+        description: "Optional Flutter entrypoint used to build the app"
+        required: false
+        type: string
+        default: ""
+      flutter_build_mode:
+        description: "Flutter build mode: release or profile"
+        required: false
+        type: string
+        default: release
+      pubspec_artifact:
+        description: "Artifact containing the version-stamped pubspec.yaml"
+        required: false
+        type: string
+        default: pubspec
+      sign_update_artifact:
+        description: "Generate the Sparkle signature published with this DMG"
+        required: false
+        type: boolean
+        default: true
       run_connect_smoke:
         description: "Run the macOS connect/disconnect smoke after building"
         required: false
@@ -79,7 +99,7 @@ jobs:
       - name: Download pubspec.yaml
         uses: actions/download-artifact@v4
         with:
-          name: pubspec
+          name: ${{ inputs.pubspec_artifact }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -230,10 +250,21 @@ jobs:
           echo "::notice title=macOS payment smoke diagnostics::$ARTIFACT_URL"
           echo "[Download the macOS payment smoke screenshot and diagnostics]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Build macOS release
-        run: make macos-release-ci
+      - name: Build macOS app
+        shell: bash
+        run: |
+          case "$FLUTTER_BUILD_MODE" in
+            release) make macos-release-ci ;;
+            profile) make macos-profile-ci ;;
+            *)
+              printf 'Unsupported macOS Flutter build mode: %s\n' "$FLUTTER_BUILD_MODE" >&2
+              exit 2
+              ;;
+          esac
         env:
           BUILD_TYPE: ${{ inputs.build_type }}
+          FLUTTER_BUILD_MODE: ${{ inputs.flutter_build_mode }}
+          FLUTTER_TARGET: ${{ inputs.flutter_target }}
           VERSION: ${{ inputs.version }}
           INSTALLER_NAME: ${{ inputs.installer_base_name }}
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
@@ -259,7 +290,7 @@ jobs:
           ditto -c -k --keepParent "$APP_PATH" "$RUNNER_TEMP/Lantern.app.zip"
 
       - name: Sign macOS update
-        if: ${{ inputs.build_type != 'nightly' }}
+        if: ${{ inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
         shell: bash
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
@@ -284,7 +315,7 @@ jobs:
           retention-days: 2
 
       - name: Upload macOS update signature
-        if: ${{ inputs.build_type != 'nightly' }}
+        if: ${{ inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
         uses: actions/upload-artifact@v4
         with:
           name: lantern-installer-dmg-signature

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -135,7 +135,7 @@ jobs:
             ${{ runner.os }}-macos-pods-          
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -54,6 +54,11 @@ on:
         required: false
         type: boolean
         default: true
+      auto_update_e2e:
+        description: "Build a fixture that reads the isolated staging appcast"
+        required: false
+        type: boolean
+        default: false
       run_connect_smoke:
         description: "Run the macOS connect/disconnect smoke after building"
         required: false
@@ -263,6 +268,7 @@ jobs:
           esac
         env:
           BUILD_TYPE: ${{ inputs.build_type }}
+          AUTO_UPDATE_E2E: ${{ inputs.auto_update_e2e }}
           FLUTTER_BUILD_MODE: ${{ inputs.flutter_build_mode }}
           FLUTTER_TARGET: ${{ inputs.flutter_target }}
           VERSION: ${{ inputs.version }}

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -21,6 +21,36 @@ on:
       installer_base_name:
         required: true
         type: string
+      flutter_target:
+        description: "Optional Flutter entrypoint used to build the app"
+        required: false
+        type: string
+        default: ""
+      flutter_build_mode:
+        description: "Flutter build mode: release or profile"
+        required: false
+        type: string
+        default: release
+      pubspec_artifact:
+        description: "Artifact containing the version-stamped pubspec.yaml"
+        required: false
+        type: string
+        default: pubspec
+      sign_update_artifact:
+        description: "Generate the Sparkle signature published with this installer"
+        required: false
+        type: boolean
+        default: true
+      auto_update_e2e:
+        description: "Build a fixture that reads the isolated staging appcast"
+        required: false
+        type: boolean
+        default: false
+      run_installer_smoke:
+        description: "Install the packaged app and run the Windows smoke suite"
+        required: false
+        type: boolean
+        default: true
       skip_signing:
         description: "Skip code signing (e.g. for nightly builds)"
         required: false
@@ -79,7 +109,7 @@ jobs:
       - name: Download pubspec.yaml
         uses: actions/download-artifact@v4
         with:
-          name: pubspec
+          name: ${{ inputs.pubspec_artifact }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -171,11 +201,22 @@ jobs:
 
       - name: Build Windows binaries
         shell: pwsh
+        env:
+          AUTO_UPDATE_E2E: ${{ inputs.auto_update_e2e }}
+          FLUTTER_BUILD_MODE: ${{ inputs.flutter_build_mode }}
+          FLUTTER_TARGET: ${{ inputs.flutter_target }}
         run: |
           dart pub global activate fastforge
-          make windows-release
+          switch ($env:FLUTTER_BUILD_MODE) {
+            'release' { make windows-release }
+            'profile' { make windows-profile-ci }
+            default {
+              Write-Error "Unsupported Windows Flutter build mode: $env:FLUTTER_BUILD_MODE"
+              exit 2
+            }
+          }
           if ($LASTEXITCODE -ne 0) {
-            Write-Error "make windows-release failed with exit code $LASTEXITCODE"
+            Write-Error "Windows build failed with exit code $LASTEXITCODE"
             exit $LASTEXITCODE
           }
 
@@ -306,6 +347,7 @@ jobs:
           Move-Item "dist/$env:APP_VERSION/$env:APP_NAME-$env:APP_VERSION-windows-setup.exe" "$env:FULL_INSTALLER_NAME.exe"
 
       - name: Windows installer smoke suite
+        if: ${{ inputs.run_installer_smoke }}
         shell: pwsh
         timeout-minutes: 30
         env:
@@ -354,7 +396,7 @@ jobs:
             -Description "Installer - GitHub Actions build ${{ inputs.version }}"
 
       - name: Sign Windows update
-        if: ${{ inputs.build_type != 'nightly' }}
+        if: ${{ inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
         shell: pwsh
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
@@ -372,7 +414,7 @@ jobs:
           retention-days: 2
 
       - name: Upload Windows update signature
-        if: ${{ inputs.build_type != 'nightly' }}
+        if: ${{ inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
         uses: actions/upload-artifact@v4
         with:
           name: lantern-installer-exe-signature

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -46,6 +46,11 @@ on:
         required: false
         type: boolean
         default: false
+      package_installer:
+        description: "Package and upload the Windows installer"
+        required: false
+        type: boolean
+        default: true
       run_installer_smoke:
         description: "Install the packaged app and run the Windows smoke suite"
         required: false
@@ -326,7 +331,17 @@ jobs:
         run: |
           Write-Host "Skipping embedded and installer signing for this run."
 
+      - name: Upload signed Windows app fixture
+        if: ${{ !inputs.package_installer }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: lantern-windows-app-fixture
+          path: build/windows/x64/runner/Release
+          if-no-files-found: error
+          retention-days: 2
+
       - name: Package installer
+        if: ${{ inputs.package_installer }}
         shell: pwsh
         env:
           FULL_INSTALLER_NAME: ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}
@@ -347,7 +362,7 @@ jobs:
           Move-Item "dist/$env:APP_VERSION/$env:APP_NAME-$env:APP_VERSION-windows-setup.exe" "$env:FULL_INSTALLER_NAME.exe"
 
       - name: Windows installer smoke suite
-        if: ${{ inputs.run_installer_smoke }}
+        if: ${{ inputs.package_installer && inputs.run_installer_smoke }}
         shell: pwsh
         timeout-minutes: 30
         env:
@@ -381,7 +396,7 @@ jobs:
           flutter test integration_test/auth/auth_smoke_test.dart -d windows --reporter=expanded --dart-define=DISABLE_SYSTEM_TRAY=true
 
       - name: Sign installer
-        if: ${{ !inputs.skip_signing }}
+        if: ${{ inputs.package_installer && !inputs.skip_signing }}
         shell: pwsh
         env:
           SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
@@ -396,7 +411,7 @@ jobs:
             -Description "Installer - GitHub Actions build ${{ inputs.version }}"
 
       - name: Sign Windows update
-        if: ${{ inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
+        if: ${{ inputs.package_installer && inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
         shell: pwsh
         env:
           SPARKLE_ED_PRIVATE_KEY: ${{ secrets.SPARKLE_ED_PRIVATE_KEY }}
@@ -407,6 +422,7 @@ jobs:
             -SignaturePath "$env:RUNNER_TEMP\$env:FULL_INSTALLER_NAME.exe.sparkle-signature"
 
       - name: Upload Windows installer
+        if: ${{ inputs.package_installer }}
         uses: actions/upload-artifact@v4
         with:
           name: lantern-installer-exe
@@ -414,7 +430,7 @@ jobs:
           retention-days: 2
 
       - name: Upload Windows update signature
-        if: ${{ inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
+        if: ${{ inputs.package_installer && inputs.build_type != 'nightly' && inputs.sign_update_artifact }}
         uses: actions/upload-artifact@v4
         with:
           name: lantern-installer-exe-signature

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -142,11 +142,21 @@ jobs:
       - name: Set up MinGW
         run: choco install mingw -y
 
+      - name: Read pinned Flutter version
+        id: flutter-version
+        shell: pwsh
+        run: |
+          $match = Select-String -Path '.github/flutter-version.yaml' -Pattern '^\s*flutter:\s*["'']?([^"'']+)["'']?\s*$'
+          if (-not $match) {
+            throw 'Unable to read the pinned Flutter version'
+          }
+          "version=$($match.Matches[0].Groups[1].Value.Trim())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
-          flutter-version-file: .github/flutter-version.yaml
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
 
       - name: Enable Flutter Desktop Support
         run: |
@@ -159,15 +169,8 @@ jobs:
           fileDir: ${{ github.workspace }}
           encodedString: ${{ secrets.APP_ENV }}
 
-      - name: Cache Dart pub global cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.pub-cache
-          key: ${{ runner.os }}-dart-pub-cache-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-dart-pub-cache-
-
       - name: Install Inno Setup 6
+        if: ${{ inputs.package_installer }}
         shell: pwsh
         # The runner image preinstalls Inno Setup (currently 6.7.1). A bare
         # --version=6.5.0 now fails ("a newer version is already installed; use
@@ -178,6 +181,7 @@ jobs:
         run: choco install -y innosetup --version=6.7.1 --allow-downgrade
 
       - name: Install unofficial Inno Setup translations
+        if: ${{ inputs.package_installer }}
         shell: pwsh
         # Chinese Simplified and Farsi/Persian are not bundled Inno translations;
         # copy the vendored .isl files into Inno's Languages dir so inno_setup.iss
@@ -211,7 +215,6 @@ jobs:
           FLUTTER_BUILD_MODE: ${{ inputs.flutter_build_mode }}
           FLUTTER_TARGET: ${{ inputs.flutter_target }}
         run: |
-          dart pub global activate fastforge
           switch ($env:FLUTTER_BUILD_MODE) {
             'release' { make windows-release }
             'profile' { make windows-profile-ci }
@@ -346,6 +349,7 @@ jobs:
         env:
           FULL_INSTALLER_NAME: ${{ inputs.installer_base_name }}${{ inputs.build_type != 'production' && format('-{0}', inputs.build_type) || '' }}
         run: |
+          dart pub global activate fastforge
           fastforge package `
             --platform=windows `
             --targets=exe `

--- a/.github/workflows/firebase-test-lab.yml
+++ b/.github/workflows/firebase-test-lab.yml
@@ -107,7 +107,7 @@ jobs:
           make android-env >> "$GITHUB_ENV"
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml

--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -51,7 +51,7 @@ jobs:
             ${{ runner.os }}-flutter-
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml

--- a/.github/workflows/macos-auto-update-smoke.yml
+++ b/.github/workflows/macos-auto-update-smoke.yml
@@ -1,0 +1,192 @@
+name: macOS auto-update smoke
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-auto-update-smoke
+  cancel-in-progress: false
+
+jobs:
+  resolve-target:
+    name: Resolve live beta target
+    runs-on: ubuntu-latest
+    outputs:
+      display_version: ${{ steps.target.outputs.display_version }}
+      fixture_build: ${{ steps.target.outputs.fixture_build }}
+      target_build: ${{ steps.target.outputs.target_build }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements.txt
+
+      - name: Install appcast parser dependency
+        run: python -m pip install -r scripts/requirements.txt
+
+      - name: Test target resolver
+        run: python -m unittest scripts/ci/resolve_macos_update_target_test.py
+
+      - name: Resolve live beta target
+        id: target
+        shell: bash
+        env:
+          TARGET_DIR: ${{ runner.temp }}/macos-auto-update-target
+        run: |
+          set -o pipefail
+          mkdir -p "$TARGET_DIR/pubspec"
+          python scripts/ci/resolve_macos_update_target.py \
+            --appcast-output "$TARGET_DIR/appcast.xml" \
+            --target-output "$TARGET_DIR/target.json" \
+            --pubspec-input pubspec.yaml \
+            --pubspec-output "$TARGET_DIR/pubspec/pubspec.yaml" \
+            --github-output "$GITHUB_OUTPUT" \
+            2>&1 | tee "$TARGET_DIR/resolve.log"
+
+      - name: Summarize target
+        if: ${{ steps.target.outcome == 'success' }}
+        shell: bash
+        env:
+          DISPLAY_VERSION: ${{ steps.target.outputs.display_version }}
+          FIXTURE_BUILD: ${{ steps.target.outputs.fixture_build }}
+          TARGET_BUILD: ${{ steps.target.outputs.target_build }}
+        run: |
+          {
+            echo "### macOS auto-update target"
+            echo
+            echo "- Live beta: \`$DISPLAY_VERSION\` build \`$TARGET_BUILD\`"
+            echo "- Unpublished fixture: \`$DISPLAY_VERSION\` build \`$FIXTURE_BUILD\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload target diagnostics
+        if: ${{ always() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-auto-update-target
+          path: |
+            ${{ runner.temp }}/macos-auto-update-target/appcast.xml
+            ${{ runner.temp }}/macos-auto-update-target/target.json
+            ${{ runner.temp }}/macos-auto-update-target/resolve.log
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Upload lower-build pubspec
+        if: ${{ steps.target.outcome == 'success' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-auto-update-pubspec
+          path: ${{ runner.temp }}/macos-auto-update-target/pubspec/pubspec.yaml
+          if-no-files-found: error
+          retention-days: 2
+
+  build-fixture:
+    name: Build signed lower fixture
+    needs: resolve-target
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-macos.yml
+    secrets: inherit
+    with:
+      version: ${{ needs.resolve-target.outputs.display_version }}
+      build_type: beta
+      installer_base_name: lantern-autoupdate-fixture
+      runner_label: lantern-macos-smoke
+      flutter_target: integration_test/auto_update/macos_auto_update_smoke_test.dart
+      flutter_build_mode: profile
+      pubspec_artifact: macos-auto-update-pubspec
+      sign_update_artifact: false
+      run_connect_smoke: false
+      run_payment_checkout_smoke: false
+
+  exercise-update:
+    name: Install and update through Sparkle
+    needs:
+      - resolve-target
+      - build-fixture
+    runs-on:
+      - self-hosted
+      - lantern-macos-smoke
+    timeout-minutes: 30
+    env:
+      LANTERN_AUTO_UPDATE_SMOKE: "true"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Download fixture pubspec
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-auto-update-pubspec
+
+      - name: Install Flutter
+        uses: subosito/flutter-action@v2.22.0
+        with:
+          channel: stable
+          flutter-version-file: .github/flutter-version.yaml
+
+      - name: Resolve Flutter dependencies
+        run: flutter pub get
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: scripts/requirements.txt
+
+      - name: Install appcast parser dependency
+        run: python -m pip install -r scripts/requirements.txt
+
+      - name: Download lower fixture
+        uses: actions/download-artifact@v4
+        with:
+          name: lantern-installer-dmg
+          path: ${{ runner.temp }}/macos-auto-update-fixture
+
+      - name: Download resolved target
+        uses: actions/download-artifact@v4
+        with:
+          name: macos-auto-update-target
+          path: ${{ runner.temp }}/macos-auto-update-target
+
+      - name: Run Flutter-led auto-update smoke
+        shell: bash
+        env:
+          APPCAST_XML: ${{ runner.temp }}/macos-auto-update-target/appcast.xml
+          ARTIFACT_DIR: ${{ runner.temp }}/macos-auto-update-smoke
+          FIXTURE_DMG: ${{ runner.temp }}/macos-auto-update-fixture/lantern-autoupdate-fixture-beta.dmg
+          TARGET_JSON: ${{ runner.temp }}/macos-auto-update-target/target.json
+        run: bash ./.github/scripts/macos_auto_update_smoke.sh
+
+      - name: Upload auto-update diagnostics
+        if: ${{ always() }}
+        id: diagnostics
+        uses: actions/upload-artifact@v4
+        with:
+          name: macos-auto-update-smoke
+          path: ${{ runner.temp }}/macos-auto-update-smoke
+          if-no-files-found: warn
+          retention-days: 7
+
+      - name: Link diagnostics
+        if: ${{ always() && steps.diagnostics.outputs.artifact-url != '' }}
+        shell: bash
+        env:
+          ARTIFACT_URL: ${{ steps.diagnostics.outputs.artifact-url }}
+        run: |
+          echo "::notice title=macOS auto-update diagnostics::$ARTIFACT_URL"
+          echo "[Download macOS auto-update diagnostics]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/macos-auto-update-smoke.yml
+++ b/.github/workflows/macos-auto-update-smoke.yml
@@ -144,16 +144,6 @@ jobs:
       - name: Resolve Flutter dependencies
         run: flutter pub get
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: scripts/requirements.txt
-
-      - name: Install appcast parser dependency
-        run: python -m pip install -r scripts/requirements.txt
-
       - name: Download lower fixture
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/macos-auto-update-smoke.yml
+++ b/.github/workflows/macos-auto-update-smoke.yml
@@ -136,7 +136,7 @@ jobs:
           name: macos-auto-update-pubspec
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml

--- a/.github/workflows/windows-auto-update-smoke.yml
+++ b/.github/workflows/windows-auto-update-smoke.yml
@@ -139,11 +139,21 @@ jobs:
         with:
           name: windows-auto-update-pubspec
 
+      - name: Read pinned Flutter version
+        id: flutter-version
+        shell: pwsh
+        run: |
+          $match = Select-String -Path '.github/flutter-version.yaml' -Pattern '^\s*flutter:\s*["'']?([^"'']+)["'']?\s*$'
+          if (-not $match) {
+            throw 'Unable to read the pinned Flutter version'
+          }
+          "version=$($match.Matches[0].Groups[1].Value.Trim())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
+        uses: subosito/flutter-action@v2.23.0
         with:
           channel: stable
-          flutter-version-file: .github/flutter-version.yaml
+          flutter-version: ${{ steps.flutter-version.outputs.version }}
 
       - name: Resolve Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/windows-auto-update-smoke.yml
+++ b/.github/workflows/windows-auto-update-smoke.yml
@@ -1,4 +1,4 @@
-name: macOS auto-update smoke
+name: Windows auto-update smoke
 
 on:
   workflow_dispatch:
@@ -8,7 +8,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: macos-auto-update-smoke
+  group: windows-auto-update-smoke
   cancel-in-progress: false
 
 jobs:
@@ -42,12 +42,12 @@ jobs:
         id: target
         shell: bash
         env:
-          TARGET_DIR: ${{ runner.temp }}/macos-auto-update-target
+          TARGET_DIR: ${{ runner.temp }}/windows-auto-update-target
         run: |
           set -o pipefail
           mkdir -p "$TARGET_DIR/pubspec"
           python scripts/ci/resolve_desktop_update_target.py \
-            --platform macos \
+            --platform windows \
             --appcast-url "https://update.staging.iantem.io/update/lantern/appcast.xml?channel=beta" \
             --appcast-output "$TARGET_DIR/appcast.xml" \
             --target-output "$TARGET_DIR/target.json" \
@@ -65,7 +65,7 @@ jobs:
           TARGET_BUILD: ${{ steps.target.outputs.target_build }}
         run: |
           {
-            echo "### macOS auto-update target"
+            echo "### Windows auto-update target"
             echo
             echo "- Live beta: \`$DISPLAY_VERSION\` build \`$TARGET_BUILD\`"
             echo "- Unpublished fixture: \`$DISPLAY_VERSION\` build \`$FIXTURE_BUILD\`"
@@ -75,11 +75,11 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: macos-auto-update-target
+          name: windows-auto-update-target
           path: |
-            ${{ runner.temp }}/macos-auto-update-target/appcast.xml
-            ${{ runner.temp }}/macos-auto-update-target/target.json
-            ${{ runner.temp }}/macos-auto-update-target/resolve.log
+            ${{ runner.temp }}/windows-auto-update-target/appcast.xml
+            ${{ runner.temp }}/windows-auto-update-target/target.json
+            ${{ runner.temp }}/windows-auto-update-target/resolve.log
           if-no-files-found: warn
           retention-days: 7
 
@@ -87,8 +87,8 @@ jobs:
         if: ${{ steps.target.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
-          name: macos-auto-update-pubspec
-          path: ${{ runner.temp }}/macos-auto-update-target/pubspec/pubspec.yaml
+          name: windows-auto-update-pubspec
+          path: ${{ runner.temp }}/windows-auto-update-target/pubspec/pubspec.yaml
           if-no-files-found: error
           retention-days: 2
 
@@ -98,29 +98,30 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: ./.github/workflows/build-macos.yml
+    uses: ./.github/workflows/build-windows.yml
     secrets: inherit
     with:
       version: ${{ needs.resolve-target.outputs.display_version }}
       build_type: beta
       installer_base_name: lantern-autoupdate-fixture
-      runner_label: lantern-macos-smoke
       flutter_target: integration_test/auto_update/desktop_auto_update_smoke_test.dart
       flutter_build_mode: profile
-      pubspec_artifact: macos-auto-update-pubspec
+      pubspec_artifact: windows-auto-update-pubspec
       sign_update_artifact: false
       auto_update_e2e: true
+      run_installer_smoke: false
       run_connect_smoke: false
+      run_split_tunnel_website_smoke: false
+      run_config_url_smoke: false
+      run_auth_smoke: false
       run_payment_checkout_smoke: false
 
   exercise-update:
-    name: Install and update through Sparkle
+    name: Install and update through WinSparkle
     needs:
       - resolve-target
       - build-fixture
-    runs-on:
-      - self-hosted
-      - lantern-macos-smoke
+    runs-on: windows-latest
     timeout-minutes: 30
     env:
       LANTERN_AUTO_UPDATE_SMOKE: "true"
@@ -133,7 +134,7 @@ jobs:
       - name: Download fixture pubspec
         uses: actions/download-artifact@v4
         with:
-          name: macos-auto-update-pubspec
+          name: windows-auto-update-pubspec
 
       - name: Install Flutter
         uses: subosito/flutter-action@v2.22.0
@@ -157,39 +158,40 @@ jobs:
       - name: Download lower fixture
         uses: actions/download-artifact@v4
         with:
-          name: lantern-installer-dmg
-          path: ${{ runner.temp }}/macos-auto-update-fixture
+          name: lantern-installer-exe
+          path: ${{ runner.temp }}/windows-auto-update-fixture
 
       - name: Download resolved target
         uses: actions/download-artifact@v4
         with:
-          name: macos-auto-update-target
-          path: ${{ runner.temp }}/macos-auto-update-target
+          name: windows-auto-update-target
+          path: ${{ runner.temp }}/windows-auto-update-target
 
       - name: Run Flutter-led auto-update smoke
-        shell: bash
+        shell: pwsh
         env:
-          APPCAST_XML: ${{ runner.temp }}/macos-auto-update-target/appcast.xml
-          ARTIFACT_DIR: ${{ runner.temp }}/macos-auto-update-smoke
-          FIXTURE_DMG: ${{ runner.temp }}/macos-auto-update-fixture/lantern-autoupdate-fixture-beta.dmg
-          TARGET_JSON: ${{ runner.temp }}/macos-auto-update-target/target.json
-        run: bash ./.github/scripts/macos_auto_update_smoke.sh
+          APPCAST_XML: ${{ runner.temp }}/windows-auto-update-target/appcast.xml
+          ARTIFACT_DIR: ${{ runner.temp }}/windows-auto-update-smoke
+          FIXTURE_INSTALLER: ${{ runner.temp }}/windows-auto-update-fixture/lantern-autoupdate-fixture-beta.exe
+          TARGET_JSON: ${{ runner.temp }}/windows-auto-update-target/target.json
+        run: ./.github/scripts/windows_auto_update_smoke.ps1
 
       - name: Upload auto-update diagnostics
         if: ${{ always() }}
         id: diagnostics
         uses: actions/upload-artifact@v4
         with:
-          name: macos-auto-update-smoke
-          path: ${{ runner.temp }}/macos-auto-update-smoke
+          name: windows-auto-update-smoke
+          path: ${{ runner.temp }}/windows-auto-update-smoke
           if-no-files-found: warn
           retention-days: 7
 
       - name: Link diagnostics
         if: ${{ always() && steps.diagnostics.outputs.artifact-url != '' }}
-        shell: bash
+        shell: pwsh
         env:
           ARTIFACT_URL: ${{ steps.diagnostics.outputs.artifact-url }}
         run: |
-          echo "::notice title=macOS auto-update diagnostics::$ARTIFACT_URL"
-          echo "[Download macOS auto-update diagnostics]($ARTIFACT_URL)" >> "$GITHUB_STEP_SUMMARY"
+          Write-Host "::notice title=Windows auto-update diagnostics::$env:ARTIFACT_URL"
+          "[Download Windows auto-update diagnostics]($env:ARTIFACT_URL)" |
+            Out-File -FilePath $env:GITHUB_STEP_SUMMARY -Append -Encoding utf8

--- a/.github/workflows/windows-auto-update-smoke.yml
+++ b/.github/workflows/windows-auto-update-smoke.yml
@@ -109,6 +109,9 @@ jobs:
       pubspec_artifact: windows-auto-update-pubspec
       sign_update_artifact: false
       auto_update_e2e: true
+      # Exercise WinSparkle's target installer without rebuilding the signed
+      # profile fixture through Fastforge's installer packaging step.
+      package_installer: false
       run_installer_smoke: false
       run_connect_smoke: false
       run_split_tunnel_website_smoke: false
@@ -145,20 +148,10 @@ jobs:
       - name: Resolve Flutter dependencies
         run: flutter pub get
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-          cache: pip
-          cache-dependency-path: scripts/requirements.txt
-
-      - name: Install appcast parser dependency
-        run: python -m pip install -r scripts/requirements.txt
-
-      - name: Download lower fixture
+      - name: Download signed lower fixture
         uses: actions/download-artifact@v4
         with:
-          name: lantern-installer-exe
+          name: lantern-windows-app-fixture
           path: ${{ runner.temp }}/windows-auto-update-fixture
 
       - name: Download resolved target
@@ -172,7 +165,7 @@ jobs:
         env:
           APPCAST_XML: ${{ runner.temp }}/windows-auto-update-target/appcast.xml
           ARTIFACT_DIR: ${{ runner.temp }}/windows-auto-update-smoke
-          FIXTURE_INSTALLER: ${{ runner.temp }}/windows-auto-update-fixture/lantern-autoupdate-fixture-beta.exe
+          FIXTURE_APP_DIR: ${{ runner.temp }}/windows-auto-update-fixture
           TARGET_JSON: ${{ runner.temp }}/windows-auto-update-target/target.json
         run: ./.github/scripts/windows_auto_update_smoke.ps1
 

--- a/Makefile
+++ b/Makefile
@@ -102,6 +102,8 @@ DARWIN_LIB_BUILD := $(BIN_DIR)/macos/$(DARWIN_LIB)
 DARWIN_RELEASE_DIR := $(BUILD_DIR)/macos/Build/Products/Release
 DARWIN_DEBUG_BUILD := $(BUILD_DIR)/macos/Build/Products/Debug/$(DARWIN_APP_NAME)
 DARWIN_RELEASE_BUILD := $(DARWIN_RELEASE_DIR)/$(DARWIN_APP_NAME)
+DARWIN_PROFILE_DIR := $(BUILD_DIR)/macos/Build/Products/Profile
+DARWIN_PROFILE_BUILD := $(DARWIN_PROFILE_DIR)/$(DARWIN_APP_NAME)
 MACOS_ENTITLEMENTS := macos/Runner/Release.entitlements
 MACOS_INSTALLER := $(INSTALLER_NAME)$(if $(filter-out production,$(BUILD_TYPE)),-$(BUILD_TYPE)).dmg
 MACOS_DIR := macos/
@@ -269,6 +271,7 @@ get-command = $(shell which="$$(which $(1) 2> /dev/null)" && if [[ ! -z "$$which
 APPDMG    := $(call get-command,appdmg)
 
 DART_DEFINES := --dart-define=BUILD_TYPE=$(BUILD_TYPE) $(if $(VERSION),--dart-define=VERSION=$(VERSION),)
+FLUTTER_TARGET_ARG := $(if $(FLUTTER_TARGET),--target=$(FLUTTER_TARGET),)
 STEALTH_NOVPN_BUILD_VARS := BUILD_TYPE=stealth-novpn STEALTH_MODE=stealth-novpn STEALTH_LEAKAGE_MODE=stealth-novpn
 STEALTH_VPN_BUILD_VARS   := BUILD_TYPE=stealth-vpn  STEALTH_MODE=stealth-vpn  STEALTH_LEAKAGE_MODE=stealth-vpn
 STEALTH_ICON_SEED ?=
@@ -522,9 +525,25 @@ macos-unit-tests: $(MACOS_FRAMEWORK_OUTPUT) $(MAYBE_STEALTH_PROFILE)
 $(DARWIN_RELEASE_BUILD): $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for macOS..."
 	rm -vf $(MACOS_INSTALLER)
-	flutter build macos --release $(DART_DEFINES) $(STEALTH_DART_DEFINES)
+	flutter build macos --release $(FLUTTER_TARGET_ARG) $(DART_DEFINES) $(STEALTH_DART_DEFINES)
 
 build-macos-release: $(DARWIN_RELEASE_BUILD)
+
+$(DARWIN_PROFILE_BUILD): $(MAYBE_STEALTH_PROFILE)
+	@echo "Building Flutter app (profile) for macOS..."
+	rm -vf $(MACOS_INSTALLER)
+	flutter build macos --profile $(FLUTTER_TARGET_ARG) $(DART_DEFINES) $(STEALTH_DART_DEFINES)
+
+.PHONY: build-macos-profile stage-macos-profile
+build-macos-profile: $(DARWIN_PROFILE_BUILD)
+
+# Keep packaging and signing on the established Release staging path. The
+# profile fixture is test-only, but it still goes through the same Developer ID
+# signing, DMG packaging, and notarization steps as a release artifact.
+stage-macos-profile: build-macos-profile
+	rm -rf $(DARWIN_RELEASE_BUILD)
+	mkdir -p $(DARWIN_RELEASE_DIR)
+	ditto $(DARWIN_PROFILE_BUILD) $(DARWIN_RELEASE_BUILD)
 
 .PHONY: notarize-darwin
 notarize-darwin: require-ac-username require-ac-password
@@ -572,6 +591,9 @@ macos-release: clean macos pubget gen build-macos-release sign-app package-macos
 
 .PHONY: macos-release-ci
 macos-release-ci: macos pubget gen build-macos-release sign-app package-macos notarize-darwin
+
+.PHONY: macos-profile-ci
+macos-profile-ci: macos pubget gen stage-macos-profile sign-app package-macos notarize-darwin
 
 # Linux Build
 .PHONY: install-linux-deps

--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,10 @@ WINDOWS_LIB_AMD64    := $(BIN_DIR)/windows-amd64/$(WINDOWS_LIB)
 WINDOWS_LIB_ARM64    := $(BIN_DIR)/windows-arm64/$(WINDOWS_LIB)
 WINDOWS_LIB_BUILD    := $(BIN_DIR)/windows/$(WINDOWS_LIB)
 WINDOWS_DEBUG_DIR    := $(BUILD_DIR)/windows/x64/runner/Debug
+WINDOWS_PROFILE_DIR  := $(BUILD_DIR)/windows/x64/runner/Profile
 WINDOWS_RELEASE_DIR  := $(BUILD_DIR)/windows/x64/runner/Release
+LANTERND_WINDOWS_PROFILE := $(WINDOWS_PROFILE_DIR)/$(LANTERND).exe
+LANTERND_WINDOWS_PROFILE_ARM64 := $(WINDOWS_PROFILE_DIR)/arm64/$(LANTERND).exe
 LANTERND_WINDOWS_RELEASE := $(WINDOWS_RELEASE_DIR)/$(LANTERND).exe
 LANTERND_WINDOWS_RELEASE_ARM64 := $(WINDOWS_RELEASE_DIR)/arm64/$(LANTERND).exe
 
@@ -270,7 +273,8 @@ SIGN_ID="Developer ID Application: Brave New Software Project, Inc (ACZRKC3LQ9)"
 get-command = $(shell which="$$(which $(1) 2> /dev/null)" && if [[ ! -z "$$which" ]]; then printf %q "$$which"; fi)
 APPDMG    := $(call get-command,appdmg)
 
-DART_DEFINES := --dart-define=BUILD_TYPE=$(BUILD_TYPE) $(if $(VERSION),--dart-define=VERSION=$(VERSION),)
+AUTO_UPDATE_E2E_DART_DEFINE := $(if $(filter true 1 yes,$(AUTO_UPDATE_E2E)),--dart-define=AUTO_UPDATE_E2E=true,)
+DART_DEFINES := --dart-define=BUILD_TYPE=$(BUILD_TYPE) $(if $(VERSION),--dart-define=VERSION=$(VERSION),) $(AUTO_UPDATE_E2E_DART_DEFINE)
 FLUTTER_TARGET_ARG := $(if $(FLUTTER_TARGET),--target=$(FLUTTER_TARGET),)
 STEALTH_NOVPN_BUILD_VARS := BUILD_TYPE=stealth-novpn STEALTH_MODE=stealth-novpn STEALTH_LEAKAGE_MODE=stealth-novpn
 STEALTH_VPN_BUILD_VARS   := BUILD_TYPE=stealth-vpn  STEALTH_MODE=stealth-vpn  STEALTH_LEAKAGE_MODE=stealth-vpn
@@ -760,11 +764,25 @@ copy-lanternd-debug: $(LANTERND_WINDOWS_AMD64)
 	$(call MKDIR_P,$(WINDOWS_DEBUG_DIR))
 	$(call COPY_FILE,$(LANTERND_WINDOWS_AMD64),$(WINDOWS_DEBUG_DIR)/$(LANTERND).exe)
 
+copy-lanternd-profile: $(LANTERND_WINDOWS_AMD64)
+	$(call MKDIR_P,$(WINDOWS_PROFILE_DIR))
+	$(call COPY_FILE,$(LANTERND_WINDOWS_AMD64),$(LANTERND_WINDOWS_PROFILE))
+
+copy-lanternd-profile-arm64: $(LANTERND_WINDOWS_ARM64)
+	$(call MKDIR_P,$(dir $(LANTERND_WINDOWS_PROFILE_ARM64)))
+	$(call COPY_FILE,$(LANTERND_WINDOWS_ARM64),$(LANTERND_WINDOWS_PROFILE_ARM64))
+
 .PHONY: prepare-windows-release
 prepare-windows-release: lanternd-windows-amd64 lanternd-windows-arm64
 	$(MAKE) copy-lanternd-release
 	$(MAKE) copy-lanternd-release-arm64
 	$(call WRITE_TEXT_FILE,$(LANTERND_SERVICE_LOG_LEVEL),$(WINDOWS_RELEASE_DIR)/lanternd-log-level)
+
+.PHONY: prepare-windows-profile
+prepare-windows-profile: lanternd-windows-amd64 lanternd-windows-arm64
+	$(MAKE) copy-lanternd-profile
+	$(MAKE) copy-lanternd-profile-arm64
+	$(call WRITE_TEXT_FILE,$(LANTERND_SERVICE_LOG_LEVEL),$(WINDOWS_PROFILE_DIR)/lanternd-log-level)
 
 .PHONY: windows-debug
 windows-debug: windows $(MAYBE_STEALTH_PROFILE)
@@ -774,10 +792,23 @@ windows-debug: windows $(MAYBE_STEALTH_PROFILE)
 .PHONY: build-windows-release
 build-windows-release: $(MAYBE_STEALTH_PROFILE)
 	@echo "Building Flutter app (release) for Windows..."
-	flutter build windows --release --verbose $(DART_DEFINES) $(STEALTH_DART_DEFINES)
+	flutter build windows --release --verbose $(FLUTTER_TARGET_ARG) $(DART_DEFINES) $(STEALTH_DART_DEFINES)
+
+.PHONY: build-windows-profile stage-windows-profile
+build-windows-profile: $(MAYBE_STEALTH_PROFILE)
+	@echo "Building Flutter app (profile) for Windows..."
+	flutter build windows --profile --verbose $(FLUTTER_TARGET_ARG) $(DART_DEFINES) $(STEALTH_DART_DEFINES)
+
+# Fastforge packages the Release directory. Stage the test-only profile build
+# there after its native service binaries have been added.
+stage-windows-profile: build-windows-profile prepare-windows-profile
+	$(PS) "if (Test-Path '$(WINDOWS_RELEASE_DIR)') { Remove-Item -Recurse -Force -LiteralPath '$(WINDOWS_RELEASE_DIR)' }; New-Item -ItemType Directory -Force -Path '$(WINDOWS_RELEASE_DIR)' | Out-Null; Copy-Item -Recurse -Force -Path '$(WINDOWS_PROFILE_DIR)\\*' -Destination '$(WINDOWS_RELEASE_DIR)'"
 
 .PHONY: windows-release
 windows-release: clean windows pubget gen build-windows-release prepare-windows-release
+
+.PHONY: windows-profile-ci
+windows-profile-ci: clean windows pubget gen stage-windows-profile
 
 .PHONY: install-gomobile
 install-gomobile:

--- a/integration_test/auto_update/auto_update_robot.dart
+++ b/integration_test/auto_update/auto_update_robot.dart
@@ -1,0 +1,88 @@
+import 'dart:convert';
+import 'dart:io';
+import 'dart:ui' as ui;
+
+import 'package:flutter/rendering.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/utils/storage_utils.dart';
+import 'package:package_info_plus/package_info_plus.dart';
+
+import '../utils/app_robot.dart';
+import '../utils/widget_wait_utils.dart';
+
+const autoUpdateHandoffPath =
+    '/Users/Shared/Lantern/E2E/auto-update-handoff.json';
+
+/// Drives Lantern up to the native Sparkle boundary.
+class AutoUpdateRobot {
+  AutoUpdateRobot(this.tester) : app = AppRobot(tester);
+
+  final WidgetTester tester;
+  final AppRobot app;
+
+  final Finder checkForUpdates = find.byKey(
+    const Key('setting.check_for_updates_tile'),
+  );
+
+  Future<void> triggerUpdateCheck() async {
+    e2eLog('Opening Settings for the auto-update smoke');
+    await app.openSettings();
+    await WidgetWaitUtils.waitForFinder(
+      tester,
+      checkForUpdates,
+      timeout: const Duration(seconds: 30),
+      reason:
+          'Check for Updates did not appear. '
+          'Visible keys: ${app.visibleKeys().join(', ')}',
+    );
+    await tester.ensureVisible(checkForUpdates);
+    await _captureScreenshot('auto-update-before');
+
+    e2eLog('Triggering Check for Updates');
+    await app.tap(checkForUpdates, name: 'Check for Updates', settle: false);
+  }
+
+  Future<void> _captureScreenshot(String name) async {
+    try {
+      final renderView = tester.binding.renderViews.first;
+      final layer = renderView.debugLayer;
+      if (layer is! OffsetLayer) {
+        e2eLog('Screenshot $name skipped: root layer is not capturable');
+        return;
+      }
+      final image = await layer.toImage(renderView.paintBounds);
+      try {
+        final data = await image.toByteData(format: ui.ImageByteFormat.png);
+        if (data == null) {
+          e2eLog('Screenshot $name skipped: no image data');
+          return;
+        }
+        final directory = Directory(
+          '${await AppStorageUtils.getAppLogDirectory()}/screenshots',
+        );
+        await directory.create(recursive: true);
+        final file = File('${directory.path}/$name.png');
+        await file.writeAsBytes(data.buffer.asUint8List(), flush: true);
+        e2eLog('Screenshot saved: ${file.path}');
+      } finally {
+        image.dispose();
+      }
+    } catch (error) {
+      e2eLog('Screenshot $name failed: $error');
+    }
+  }
+
+  Future<void> writeNativeHandoff() async {
+    final packageInfo = await PackageInfo.fromPlatform();
+    final handoff = File(autoUpdateHandoffPath);
+    final payload = {
+      'pid': pid,
+      'display_version': packageInfo.version,
+      'build_number': packageInfo.buildNumber,
+      'created_at': DateTime.now().toUtc().toIso8601String(),
+    };
+    await handoff.parent.create(recursive: true);
+    await handoff.writeAsString('${jsonEncode(payload)}\n', flush: true);
+    e2eLog('Native Sparkle handoff ready at ${handoff.path}');
+  }
+}

--- a/integration_test/auto_update/auto_update_robot.dart
+++ b/integration_test/auto_update/auto_update_robot.dart
@@ -10,8 +10,19 @@ import 'package:package_info_plus/package_info_plus.dart';
 import '../utils/app_robot.dart';
 import '../utils/widget_wait_utils.dart';
 
-const autoUpdateHandoffPath =
-    '/Users/Shared/Lantern/E2E/auto-update-handoff.json';
+String get autoUpdateHandoffPath {
+  if (Platform.isMacOS) {
+    return '/Users/Shared/Lantern/E2E/auto-update-handoff.json';
+  }
+  if (Platform.isWindows) {
+    final programData = Platform.environment['ProgramData'];
+    if (programData == null || programData.isEmpty) {
+      throw StateError('ProgramData is unavailable for the update handoff');
+    }
+    return '$programData\\Lantern\\E2E\\auto-update-handoff.json';
+  }
+  throw UnsupportedError('Auto-update handoff is desktop-only');
+}
 
 /// Drives Lantern up to the native Sparkle boundary.
 class AutoUpdateRobot {
@@ -83,6 +94,6 @@ class AutoUpdateRobot {
     };
     await handoff.parent.create(recursive: true);
     await handoff.writeAsString('${jsonEncode(payload)}\n', flush: true);
-    e2eLog('Native Sparkle handoff ready at ${handoff.path}');
+    e2eLog('Native updater handoff ready at ${handoff.path}');
   }
 }

--- a/integration_test/auto_update/desktop_auto_update_smoke_test.dart
+++ b/integration_test/auto_update/desktop_auto_update_smoke_test.dart
@@ -12,14 +12,23 @@ void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
   testWidgets(
-    'lower signed beta fixture hands off the native Sparkle prompt',
+    'lower signed beta fixture hands off the native update prompt',
     (tester) async {
-      expect(Platform.isMacOS, isTrue, reason: 'This smoke is macOS-only');
+      expect(
+        Platform.isMacOS || Platform.isWindows,
+        isTrue,
+        reason: 'This smoke is desktop-only',
+      );
       expect(kProfileMode, isTrue, reason: 'The fixture must be a profile app');
+      expect(
+        AppBuildInfo.autoUpdateE2E,
+        isTrue,
+        reason: 'The fixture must use the isolated staging appcast',
+      );
       expect(
         AppBuildInfo.buildType,
         'beta',
-        reason: 'The fixture must use the live beta appcast',
+        reason: 'The fixture must use the beta update channel',
       );
 
       await app.main();

--- a/integration_test/auto_update/macos_auto_update_smoke_test.dart
+++ b/integration_test/auto_update/macos_auto_update_smoke_test.dart
@@ -1,0 +1,32 @@
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:lantern/core/common/app_build_info.dart';
+import 'package:lantern/main.dart' as app;
+
+import 'auto_update_robot.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets(
+    'lower signed beta fixture hands off the native Sparkle prompt',
+    (tester) async {
+      expect(Platform.isMacOS, isTrue, reason: 'This smoke is macOS-only');
+      expect(kProfileMode, isTrue, reason: 'The fixture must be a profile app');
+      expect(
+        AppBuildInfo.buildType,
+        'beta',
+        reason: 'The fixture must use the live beta appcast',
+      );
+
+      await app.main();
+      final robot = AutoUpdateRobot(tester);
+      await robot.triggerUpdateCheck();
+      await robot.writeNativeHandoff();
+    },
+    timeout: const Timeout(Duration(minutes: 3)),
+  );
+}

--- a/integration_test/utils/app_robot.dart
+++ b/integration_test/utils/app_robot.dart
@@ -10,7 +10,6 @@ import 'widget_wait_utils.dart';
 void e2eLog(String message) => debugPrint('[E2E] $message');
 
 /// Drives the app shell during integration tests, independent of any feature.
-/// Android-only for now; other platforms still use `vpn/vpn_smoke_helpers.dart`.
 class AppRobot {
   AppRobot(this.tester);
 
@@ -20,6 +19,9 @@ class AppRobot {
   final Finder onboardingScreen = find.byKey(const Key('onboarding.screen'));
   final Finder onboardingSkip = find.byKey(const Key('onboarding.skip'));
   final Finder onboardingPrimary = find.byKey(const Key('onboarding.primary'));
+  final Finder macosExtensionScreen = find.byKey(
+    const Key('macos_extension.screen'),
+  );
 
   /// String-valued widget keys currently in the tree, sorted — a lightweight
   /// "what's on screen" dump for failure diagnostics. `Key('foo')` is a
@@ -52,7 +54,7 @@ class AppRobot {
   /// Opens Settings through the UI: home menu button.
   Future<void> openSettings() async {
     await waitForHomeReady();
-    await _tap(
+    await tap(
       find.byKey(const Key('home.menu_button')),
       name: 'Home menu button',
     );
@@ -61,7 +63,7 @@ class AppRobot {
   /// Opens the Language screen through the UI: Settings -> Language.
   Future<void> openLanguage() async {
     await openSettings();
-    await _tap(
+    await tap(
       find.byKey(const Key('setting.language_tile')),
       name: 'Settings language tile',
     );
@@ -78,7 +80,7 @@ class AppRobot {
   /// same list.
   Future<void> openAppearance() async {
     await openSettings();
-    await _tap(
+    await tap(
       find.byKey(const Key('setting.appearance_tile')),
       name: 'Settings appearance tile',
     );
@@ -100,7 +102,7 @@ class AppRobot {
       e2eLog('No upgrade button on Settings — account is Pro');
       return false;
     }
-    await _tap(upgrade, name: 'Upgrade to Pro button');
+    await tap(upgrade, name: 'Upgrade to Pro button');
     await WidgetWaitUtils.waitForFinder(
       tester,
       find.byKey(const Key('plans.list')),
@@ -115,11 +117,11 @@ class AppRobot {
   /// home menu -> Settings -> Support -> Report an issue.
   Future<void> openReportIssue() async {
     await openSettings();
-    await _tap(
+    await tap(
       find.byKey(const Key('setting.support_tile')),
       name: 'Settings support tile',
     );
-    await _tap(
+    await tap(
       find.byKey(const Key('support.report_issue_tile')),
       name: 'Support report-issue tile',
     );
@@ -180,8 +182,12 @@ class AppRobot {
     reason: 'None of ${finders.keys.join(', ')} appeared within $timeout',
   );
 
-  /// Waits for [target], taps it, and lets the navigation settle.
-  Future<void> _tap(Finder target, {required String name}) async {
+  /// Waits for [target] and taps it. Native handoffs can skip settling.
+  Future<void> tap(
+    Finder target, {
+    required String name,
+    bool settle = true,
+  }) async {
     e2eLog('Tapping $name');
     await WidgetWaitUtils.waitForFinder(
       tester,
@@ -191,7 +197,11 @@ class AppRobot {
     );
     await tester.ensureVisible(target);
     await tester.tap(target);
-    await tester.pumpAndSettle();
+    if (settle) {
+      await tester.pumpAndSettle();
+    } else {
+      await tester.pump(const Duration(milliseconds: 300));
+    }
   }
 
   /// Waits for the home screen after launch. Does not touch onboarding.
@@ -244,6 +254,42 @@ class AppRobot {
     return true;
   }
 
+  /// Closes the macOS extension screen when a non-VPN smoke starts fresh.
+  Future<bool> dismissMacOSExtensionScreenIfShown() async {
+    if (macosExtensionScreen.evaluate().isEmpty) {
+      return false;
+    }
+    e2eLog('macOS system extension screen shown — dismissing');
+
+    final close = find
+        .descendant(
+          of: macosExtensionScreen,
+          matching: find.byType(CloseButton),
+        )
+        .hitTestable();
+    final deadline = DateTime.now().add(const Duration(seconds: 5));
+    while (DateTime.now().isBefore(deadline)) {
+      if (macosExtensionScreen.evaluate().isEmpty) {
+        return true;
+      }
+      if (close.evaluate().isNotEmpty) {
+        await tester.tap(close);
+        await tester.pump(const Duration(milliseconds: 400));
+        break;
+      }
+      await tester.pump(const Duration(milliseconds: 200));
+    }
+
+    await WidgetWaitUtils.waitForFinderToDisappear(
+      tester,
+      macosExtensionScreen,
+      timeout: const Duration(seconds: 10),
+      reason: 'macOS system extension screen did not close after dismiss',
+    );
+    e2eLog('macOS system extension screen dismissed');
+    return true;
+  }
+
   /// Waits until [control] is hit-testable — the app-ready gate — clearing
   /// onboarding that appears while waiting. Home renders before onboarding is
   /// pushed on top of it, so we first spend up to [onboardingGrace] letting
@@ -266,6 +312,10 @@ class AppRobot {
     while (DateTime.now().isBefore(end)) {
       if (onboardingScreen.evaluate().isNotEmpty) {
         await dismissOnboardingIfShown();
+        continue;
+      }
+      if (macosExtensionScreen.evaluate().isNotEmpty) {
+        await dismissMacOSExtensionScreenIfShown();
         continue;
       }
 

--- a/lib/core/common/app_build_info.dart
+++ b/lib/core/common/app_build_info.dart
@@ -17,6 +17,11 @@ class AppBuildInfo {
     defaultValue: false,
   );
 
+  static const bool autoUpdateE2E = bool.fromEnvironment(
+    'AUTO_UPDATE_E2E',
+    defaultValue: false,
+  );
+
   static const String stealthMode = String.fromEnvironment(
     'STEALTH_MODE',
     defaultValue: 'normal',

--- a/lib/core/common/app_urls.dart
+++ b/lib/core/common/app_urls.dart
@@ -1,3 +1,5 @@
+import 'package:lantern/core/common/app_build_info.dart';
+
 class AppUrls {
   static String lanternOfficial = 'https://lantern.io';
   static String support = 'https://support.lantern.io';
@@ -26,13 +28,19 @@ class AppUrls {
       'https://update.getlantern.org/update/lantern';
   static const appcastProd = '$updateServiceLantern/appcast.xml?channel=stable';
   static const appcastBeta = '$updateServiceLantern/appcast.xml?channel=beta';
+  static const appcastE2E =
+      'https://update.staging.iantem.io/update/lantern/appcast.xml?channel=beta';
   static String manuallyServerSetupURL =
       'https://github.com/getlantern/lantern-server-manager';
   static String digitalOceanBillingUrl =
       'https://cloud.digitalocean.com/account/billing';
   static const androidSideloadUpdateEndpoint = updateServiceLantern;
 
-  static String appcastFor(String buildType) {
+  static String appcastFor(
+    String buildType, {
+    bool autoUpdateE2E = AppBuildInfo.autoUpdateE2E,
+  }) {
+    if (autoUpdateE2E) return appcastE2E;
     switch (buildType) {
       case 'production':
         return appcastProd;

--- a/lib/features/home/home.dart
+++ b/lib/features/home/home.dart
@@ -123,6 +123,7 @@ class _HomeState extends ConsumerState<Home> {
         elevation: 5,
         leading: IconButton(
           key: const Key('home.menu_button'),
+          tooltip: 'settings'.i18n,
           onPressed: () {
             appRouter.push(Setting());
           },

--- a/lib/features/setting/setting.dart
+++ b/lib/features/setting/setting.dart
@@ -194,7 +194,9 @@ class _SettingState extends ConsumerState<Setting>
                       children: [
                         DividerSpace(),
                         AppTile(
+                          tileKey: const Key('setting.check_for_updates_tile'),
                           label: 'check_for_updates'.i18n,
+                          semanticsLabel: 'check_for_updates'.i18n,
                           icon: AppImagePaths.update,
                           onPressed: () async => await settingMenuTap(
                             _SettingType.checkForUpdates,

--- a/scripts/ci/generate_update_metadata.py
+++ b/scripts/ci/generate_update_metadata.py
@@ -8,6 +8,7 @@ import base64
 import binascii
 import hashlib
 import json
+import urllib.parse
 from pathlib import Path
 from typing import Optional, Tuple
 
@@ -72,6 +73,7 @@ def sidecar_for(
     bucket: str,
     signature_dir: Optional[Path] = None,
     sparkle_version: Optional[str] = None,
+    asset_base_url: Optional[str] = None,
 ) -> Optional[dict[str, object]]:
     info = artifact_info(path.name)
     if info is None:
@@ -79,7 +81,10 @@ def sidecar_for(
 
     platform, os_name, arch = info
     channel = release_channel(build_type)
-    url = f"https://s3.amazonaws.com/{bucket}/releases/{build_type}/{version}/{path.name}"
+    if asset_base_url:
+        url = f"{asset_base_url.rstrip('/')}/{urllib.parse.quote(path.name)}"
+    else:
+        url = f"https://s3.amazonaws.com/{bucket}/releases/{build_type}/{version}/{path.name}"
     metadata: dict[str, object] = {
         "schema_version": 1,
         "app": "lantern",
@@ -113,6 +118,10 @@ def main() -> None:
     parser.add_argument("--bucket", required=True)
     parser.add_argument("--output-dir", required=True, type=Path)
     parser.add_argument("--sparkle-signature-dir", required=True, type=Path)
+    parser.add_argument(
+        "--asset-base-url",
+        help="Override the artifact directory URL for synthetic fixture releases",
+    )
     parser.add_argument("artifacts", nargs="+", type=Path)
     args = parser.parse_args()
 
@@ -128,6 +137,7 @@ def main() -> None:
             args.bucket,
             args.sparkle_signature_dir,
             args.sparkle_version,
+            args.asset_base_url,
         )
         if metadata is None:
             continue

--- a/scripts/ci/generate_update_metadata_test.py
+++ b/scripts/ci/generate_update_metadata_test.py
@@ -154,6 +154,33 @@ class GenerateUpdateMetadataTest(TestCase):
             self.assertEqual(metadata["sparkle_version"], "920")
             self.assertEqual(metadata["sparkle_ed_signature"], signature)
 
+    def test_sidecar_can_point_at_a_fixture_release(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            artifact = pathlib.Path(tmp) / "lantern-installer-beta.exe"
+            artifact.write_bytes(b"windows")
+            signature = base64.b64encode(bytes(range(64))).decode("ascii")
+            (pathlib.Path(tmp) / f"{artifact.name}.sparkle-signature").write_text(
+                signature,
+                encoding="ascii",
+            )
+
+            metadata = generate_update_metadata.sidecar_for(
+                artifact,
+                "beta",
+                "9.2.0-beta.e2e.123",
+                "unused-bucket",
+                pathlib.Path(tmp),
+                "123",
+                "https://github.com/getlantern/lantern-update-fixtures/"
+                "releases/download/v9.2.0-beta.e2e.123",
+            )
+
+        self.assertEqual(
+            metadata["url"],
+            "https://github.com/getlantern/lantern-update-fixtures/releases/"
+            "download/v9.2.0-beta.e2e.123/lantern-installer-beta.exe",
+        )
+
     def test_updater_signature_rejects_invalid_base64(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             artifact = pathlib.Path(tmp) / "lantern-installer-beta.exe"

--- a/scripts/ci/resolve_desktop_update_target.py
+++ b/scripts/ci/resolve_desktop_update_target.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Resolve and validate the live macOS beta target for the update smoke test."""
+"""Resolve and validate a desktop beta target for the update smoke test."""
 
 from __future__ import annotations
 
@@ -33,13 +33,14 @@ class TargetError(Exception):
 
 @dataclass(frozen=True)
 class UpdateTarget:
+    platform: str
     appcast_url: str
     appcast_sha256: str
     target_build: int
     fixture_build: int
     display_version: str
-    dmg_url: str
-    dmg_length: int
+    artifact_url: str
+    artifact_length: int
     ed_signature: str
 
     @property
@@ -73,7 +74,8 @@ def fetch_appcast(url: str) -> bytes:
         raise TargetError(f"unable to fetch appcast: {err.reason}") from err
 
 
-def parse_target(xml_data: bytes, appcast_url: str) -> UpdateTarget:
+def parse_target(xml_data: bytes, appcast_url: str, platform: str) -> UpdateTarget:
+    require(platform in {"macos", "windows"}, f"unsupported platform {platform!r}")
     try:
         root = ET.fromstring(xml_data)
     except (DefusedXmlException, ET.ParseError) as err:
@@ -106,50 +108,59 @@ def parse_target(xml_data: bytes, appcast_url: str) -> UpdateTarget:
         "appcast display version must be a valid dotted version",
     )
 
-    mac_enclosures = [
+    platform_name = "macOS" if platform == "macos" else "Windows"
+    platform_enclosures = [
         enclosure
         for enclosure in item.findall("enclosure")
-        if enclosure.attrib.get(f"{{{SPARKLE_NS}}}os") == "macos"
+        if enclosure.attrib.get(f"{{{SPARKLE_NS}}}os") == platform
     ]
-    require(mac_enclosures, "appcast has no macOS enclosure")
-    require(len(mac_enclosures) == 1, "appcast has more than one macOS enclosure")
-    enclosure = mac_enclosures[0]
+    require(platform_enclosures, f"appcast has no {platform_name} enclosure")
+    require(
+        len(platform_enclosures) == 1,
+        f"appcast has more than one {platform_name} enclosure",
+    )
+    enclosure = platform_enclosures[0]
 
-    dmg_url = enclosure.attrib.get("url", "").strip()
-    parsed_url = urllib.parse.urlparse(dmg_url)
+    artifact_url = enclosure.attrib.get("url", "").strip()
+    parsed_url = urllib.parse.urlparse(artifact_url)
     require(
         parsed_url.scheme == "https" and bool(parsed_url.netloc),
-        "macOS update URL must use HTTPS",
+        f"{platform_name} update URL must use HTTPS",
     )
+    expected_suffix = ".dmg" if platform == "macos" else ".exe"
     require(
-        parsed_url.path.lower().endswith(".dmg"),
-        "macOS update URL must point to a DMG",
+        parsed_url.path.lower().endswith(expected_suffix),
+        f"{platform_name} update URL must point to a {expected_suffix.upper()[1:]}",
     )
 
     length_text = enclosure.attrib.get("length", "").strip()
     require(
         length_text.isascii() and length_text.isdigit(),
-        "macOS enclosure length must be numeric",
+        f"{platform_name} enclosure length must be numeric",
     )
-    dmg_length = int(length_text)
-    require(dmg_length > 0, "macOS enclosure length must be positive")
+    artifact_length = int(length_text)
+    require(artifact_length > 0, f"{platform_name} enclosure length must be positive")
 
     signature = enclosure.attrib.get(f"{{{SPARKLE_NS}}}edSignature", "").strip()
-    require(bool(signature), "macOS enclosure is missing an EdDSA signature")
+    require(bool(signature), f"{platform_name} enclosure is missing an EdDSA signature")
     try:
         decoded_signature = base64.b64decode(signature, validate=True)
     except (binascii.Error, ValueError) as err:
-        raise TargetError("macOS EdDSA signature is not valid base64") from err
-    require(len(decoded_signature) == 64, "macOS EdDSA signature must decode to 64 bytes")
+        raise TargetError(f"{platform_name} EdDSA signature is not valid base64") from err
+    require(
+        len(decoded_signature) == 64,
+        f"{platform_name} EdDSA signature must decode to 64 bytes",
+    )
 
     return UpdateTarget(
+        platform=platform,
         appcast_url=appcast_url,
         appcast_sha256=hashlib.sha256(xml_data).hexdigest(),
         target_build=target_build,
         fixture_build=target_build - 1,
         display_version=display_version,
-        dmg_url=dmg_url,
-        dmg_length=dmg_length,
+        artifact_url=artifact_url,
+        artifact_length=artifact_length,
         ed_signature=signature,
     )
 
@@ -185,6 +196,7 @@ def write_github_output(path: pathlib.Path, target: UpdateTarget) -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--platform", required=True, choices=("macos", "windows"))
     parser.add_argument("--appcast-url", default=DEFAULT_APPCAST_URL)
     parser.add_argument("--appcast-output", required=True, type=pathlib.Path)
     parser.add_argument("--target-output", required=True, type=pathlib.Path)
@@ -197,7 +209,7 @@ def main() -> None:
         xml_data = fetch_appcast(args.appcast_url)
         args.appcast_output.parent.mkdir(parents=True, exist_ok=True)
         args.appcast_output.write_bytes(xml_data)
-        target = parse_target(xml_data, args.appcast_url)
+        target = parse_target(xml_data, args.appcast_url, args.platform)
         args.target_output.parent.mkdir(parents=True, exist_ok=True)
         args.target_output.write_text(
             json.dumps(asdict(target), indent=2, sort_keys=True) + "\n",
@@ -207,10 +219,12 @@ def main() -> None:
         if args.github_output is not None:
             write_github_output(args.github_output, target)
     except (OSError, TargetError) as err:
-        raise SystemExit(f"unable to resolve macOS beta update target: {err}") from err
+        raise SystemExit(
+            f"unable to resolve {args.platform} beta update target: {err}"
+        ) from err
 
     print(
-        "[E2E] resolved live beta "
+        f"[E2E] resolved live beta {target.platform} "
         f"{target.display_version} build {target.target_build}; "
         f"fixture build is {target.fixture_build}"
     )

--- a/scripts/ci/resolve_desktop_update_target_test.py
+++ b/scripts/ci/resolve_desktop_update_target_test.py
@@ -10,7 +10,7 @@ import unittest
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 
-import resolve_macos_update_target as resolver
+import resolve_desktop_update_target as resolver
 
 
 SIGNATURE = base64.b64encode(bytes(range(64))).decode("ascii")
@@ -40,19 +40,35 @@ def appcast(
 """.encode()
 
 
-class ResolveMacOSUpdateTargetTest(unittest.TestCase):
+class ResolveDesktopUpdateTargetTest(unittest.TestCase):
     def test_parse_target_accepts_signed_numeric_macos_release(self) -> None:
-        target = resolver.parse_target(appcast(), APPCAST_URL)
+        target = resolver.parse_target(appcast(), APPCAST_URL, "macos")
 
+        self.assertEqual(target.platform, "macos")
         self.assertEqual(target.target_build, 920)
         self.assertEqual(target.fixture_build, 919)
         self.assertEqual(target.display_version, "9.2.0")
         self.assertEqual(target.fixture_pubspec_version, "9.2.0+919")
         self.assertEqual(target.ed_signature, SIGNATURE)
 
+    def test_parse_target_accepts_signed_numeric_windows_release(self) -> None:
+        target = resolver.parse_target(
+            appcast(
+                os_name="windows",
+                url="https://example.com/lantern-installer-beta.exe",
+            ),
+            APPCAST_URL,
+            "windows",
+        )
+
+        self.assertEqual(target.platform, "windows")
+        self.assertEqual(target.artifact_url, "https://example.com/lantern-installer-beta.exe")
+        self.assertEqual(target.artifact_length, 12345)
+        self.assertEqual(target.ed_signature, SIGNATURE)
+
     def test_parse_target_rejects_non_numeric_sparkle_version(self) -> None:
         with self.assertRaises(resolver.TargetError) as raised:
-            resolver.parse_target(appcast(build="9.2.0-beta"), APPCAST_URL)
+            resolver.parse_target(appcast(build="9.2.0-beta"), APPCAST_URL, "macos")
         self.assertEqual(
             str(raised.exception),
             "appcast Sparkle version must be numeric; got '9.2.0-beta'",
@@ -60,21 +76,23 @@ class ResolveMacOSUpdateTargetTest(unittest.TestCase):
 
     def test_parse_target_requires_display_version(self) -> None:
         with self.assertRaisesRegex(resolver.TargetError, "display version"):
-            resolver.parse_target(appcast(display_version=""), APPCAST_URL)
+            resolver.parse_target(appcast(display_version=""), APPCAST_URL, "macos")
         with self.assertRaisesRegex(resolver.TargetError, "display version"):
             resolver.parse_target(
                 appcast(display_version="9.2.0+metadata"),
                 APPCAST_URL,
+                "macos",
             )
 
     def test_parse_target_requires_macos_dmg(self) -> None:
         with self.assertRaisesRegex(resolver.TargetError, "no macOS enclosure"):
-            resolver.parse_target(appcast(os_name="windows"), APPCAST_URL)
+            resolver.parse_target(appcast(os_name="windows"), APPCAST_URL, "macos")
 
         with self.assertRaisesRegex(resolver.TargetError, "point to a DMG"):
             resolver.parse_target(
                 appcast(url="https://example.com/lantern.exe"),
                 APPCAST_URL,
+                "macos",
             )
 
     def test_parse_target_requires_https(self) -> None:
@@ -82,6 +100,7 @@ class ResolveMacOSUpdateTargetTest(unittest.TestCase):
             resolver.parse_target(
                 appcast(url="http://example.com/lantern.dmg"),
                 APPCAST_URL,
+                "macos",
             )
 
     def test_parse_target_requires_valid_signature(self) -> None:
@@ -93,7 +112,7 @@ class ResolveMacOSUpdateTargetTest(unittest.TestCase):
         for signature in signatures:
             with self.subTest(signature=signature):
                 with self.assertRaisesRegex(resolver.TargetError, "signature"):
-                    resolver.parse_target(appcast(signature=signature), APPCAST_URL)
+                    resolver.parse_target(appcast(signature=signature), APPCAST_URL, "macos")
 
     def test_parse_target_rejects_unsafe_xml(self) -> None:
         xml_data = appcast().replace(
@@ -101,10 +120,10 @@ class ResolveMacOSUpdateTargetTest(unittest.TestCase):
             b'<!DOCTYPE rss [<!ENTITY build "920">]><rss version="2.0"',
         ).replace(b">920<", b">&build;<")
         with self.assertRaisesRegex(resolver.TargetError, "unsafe appcast"):
-            resolver.parse_target(xml_data, APPCAST_URL)
+            resolver.parse_target(xml_data, APPCAST_URL, "macos")
 
     def test_write_fixture_pubspec_only_replaces_version(self) -> None:
-        target = resolver.parse_target(appcast(), APPCAST_URL)
+        target = resolver.parse_target(appcast(), APPCAST_URL, "macos")
         with tempfile.TemporaryDirectory() as tmp:
             source = pathlib.Path(tmp) / "source.yaml"
             destination = pathlib.Path(tmp) / "pubspec.yaml"

--- a/scripts/ci/resolve_macos_update_target.py
+++ b/scripts/ci/resolve_macos_update_target.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Resolve and validate the live macOS beta target for the update smoke test."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import pathlib
+import re
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import asdict, dataclass
+
+from defusedxml import ElementTree as ET
+from defusedxml.common import DefusedXmlException
+
+
+SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
+DEFAULT_APPCAST_URL = (
+    "https://update.getlantern.org/update/lantern/appcast.xml?channel=beta"
+)
+DISPLAY_VERSION_RE = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
+
+
+class TargetError(Exception):
+    """Raised when the beta appcast cannot provide a safe update target."""
+
+
+@dataclass(frozen=True)
+class UpdateTarget:
+    appcast_url: str
+    appcast_sha256: str
+    target_build: int
+    fixture_build: int
+    display_version: str
+    dmg_url: str
+    dmg_length: int
+    ed_signature: str
+
+    @property
+    def fixture_pubspec_version(self) -> str:
+        return f"{self.display_version}+{self.fixture_build}"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise TargetError(message)
+
+
+def fetch_appcast(url: str) -> bytes:
+    request = urllib.request.Request(
+        url,
+        headers={"Accept": "application/rss+xml, application/xml;q=0.9"},
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            require(response.status == 200, f"appcast returned HTTP {response.status}")
+            return response.read()
+    except urllib.error.HTTPError as err:
+        body = err.read().decode("utf-8", errors="replace").strip()
+        detail = f": {body}" if body else ""
+        raise TargetError(f"appcast returned HTTP {err.code}{detail}") from err
+    except urllib.error.URLError as err:
+        raise TargetError(f"unable to fetch appcast: {err.reason}") from err
+
+
+def parse_target(xml_data: bytes, appcast_url: str) -> UpdateTarget:
+    try:
+        root = ET.fromstring(xml_data)
+    except (DefusedXmlException, ET.ParseError) as err:
+        raise TargetError(f"invalid or unsafe appcast XML: {err}") from err
+
+    item = root.find("./channel/item")
+    require(item is not None, "appcast has no release item")
+
+    version_node = item.find(f"{{{SPARKLE_NS}}}version")
+    version = (
+        version_node.text.strip()
+        if version_node is not None and version_node.text
+        else ""
+    )
+    require(
+        version.isascii() and version.isdigit(),
+        "appcast Sparkle version must be numeric",
+    )
+    target_build = int(version)
+    require(target_build > 1, "appcast Sparkle build must be greater than 1")
+
+    short_version_node = item.find(f"{{{SPARKLE_NS}}}shortVersionString")
+    display_version = (
+        short_version_node.text.strip()
+        if short_version_node is not None and short_version_node.text
+        else ""
+    )
+    require(
+        DISPLAY_VERSION_RE.fullmatch(display_version) is not None,
+        "appcast display version must be a valid dotted version",
+    )
+
+    mac_enclosures = [
+        enclosure
+        for enclosure in item.findall("enclosure")
+        if enclosure.attrib.get(f"{{{SPARKLE_NS}}}os") == "macos"
+    ]
+    require(mac_enclosures, "appcast has no macOS enclosure")
+    require(len(mac_enclosures) == 1, "appcast has more than one macOS enclosure")
+    enclosure = mac_enclosures[0]
+
+    dmg_url = enclosure.attrib.get("url", "").strip()
+    parsed_url = urllib.parse.urlparse(dmg_url)
+    require(
+        parsed_url.scheme == "https" and bool(parsed_url.netloc),
+        "macOS update URL must use HTTPS",
+    )
+    require(
+        parsed_url.path.lower().endswith(".dmg"),
+        "macOS update URL must point to a DMG",
+    )
+
+    length_text = enclosure.attrib.get("length", "").strip()
+    require(
+        length_text.isascii() and length_text.isdigit(),
+        "macOS enclosure length must be numeric",
+    )
+    dmg_length = int(length_text)
+    require(dmg_length > 0, "macOS enclosure length must be positive")
+
+    signature = enclosure.attrib.get(f"{{{SPARKLE_NS}}}edSignature", "").strip()
+    require(bool(signature), "macOS enclosure is missing an EdDSA signature")
+    try:
+        decoded_signature = base64.b64decode(signature, validate=True)
+    except (binascii.Error, ValueError) as err:
+        raise TargetError("macOS EdDSA signature is not valid base64") from err
+    require(len(decoded_signature) == 64, "macOS EdDSA signature must decode to 64 bytes")
+
+    return UpdateTarget(
+        appcast_url=appcast_url,
+        appcast_sha256=hashlib.sha256(xml_data).hexdigest(),
+        target_build=target_build,
+        fixture_build=target_build - 1,
+        display_version=display_version,
+        dmg_url=dmg_url,
+        dmg_length=dmg_length,
+        ed_signature=signature,
+    )
+
+
+def write_fixture_pubspec(
+    source: pathlib.Path,
+    destination: pathlib.Path,
+    target: UpdateTarget,
+) -> None:
+    original = source.read_text(encoding="utf-8")
+    updated, count = re.subn(
+        r"(?m)^version:\s*[^\r\n]+$",
+        f"version: {target.fixture_pubspec_version}",
+        original,
+        count=1,
+    )
+    require(count == 1, f"could not replace version in {source}")
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(updated, encoding="utf-8")
+
+
+def write_github_output(path: pathlib.Path, target: UpdateTarget) -> None:
+    outputs = {
+        "target_build": str(target.target_build),
+        "fixture_build": str(target.fixture_build),
+        "display_version": target.display_version,
+        "fixture_version": target.fixture_pubspec_version,
+    }
+    with path.open("a", encoding="utf-8") as output:
+        for name, value in outputs.items():
+            output.write(f"{name}={value}\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--appcast-url", default=DEFAULT_APPCAST_URL)
+    parser.add_argument("--appcast-output", required=True, type=pathlib.Path)
+    parser.add_argument("--target-output", required=True, type=pathlib.Path)
+    parser.add_argument("--pubspec-input", required=True, type=pathlib.Path)
+    parser.add_argument("--pubspec-output", required=True, type=pathlib.Path)
+    parser.add_argument("--github-output", type=pathlib.Path)
+    args = parser.parse_args()
+
+    try:
+        xml_data = fetch_appcast(args.appcast_url)
+        args.appcast_output.parent.mkdir(parents=True, exist_ok=True)
+        args.appcast_output.write_bytes(xml_data)
+        target = parse_target(xml_data, args.appcast_url)
+        args.target_output.parent.mkdir(parents=True, exist_ok=True)
+        args.target_output.write_text(
+            json.dumps(asdict(target), indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        write_fixture_pubspec(args.pubspec_input, args.pubspec_output, target)
+        if args.github_output is not None:
+            write_github_output(args.github_output, target)
+    except (OSError, TargetError) as err:
+        raise SystemExit(f"unable to resolve macOS beta update target: {err}") from err
+
+    print(
+        "[E2E] resolved live beta "
+        f"{target.display_version} build {target.target_build}; "
+        f"fixture build is {target.fixture_build}"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/resolve_macos_update_target.py
+++ b/scripts/ci/resolve_macos_update_target.py
@@ -23,6 +23,7 @@ SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
 DEFAULT_APPCAST_URL = (
     "https://update.getlantern.org/update/lantern/appcast.xml?channel=beta"
 )
+USER_AGENT = "LanternAutoUpdateSmoke/1.0"
 DISPLAY_VERSION_RE = re.compile(r"[0-9]+\.[0-9]+\.[0-9]+")
 
 
@@ -54,15 +55,19 @@ def require(condition: bool, message: str) -> None:
 def fetch_appcast(url: str) -> bytes:
     request = urllib.request.Request(
         url,
-        headers={"Accept": "application/rss+xml, application/xml;q=0.9"},
+        headers={
+            "Accept": "application/rss+xml, application/xml;q=0.9",
+            "User-Agent": USER_AGENT,
+        },
     )
     try:
         with urllib.request.urlopen(request, timeout=30) as response:
             require(response.status == 200, f"appcast returned HTTP {response.status}")
             return response.read()
     except urllib.error.HTTPError as err:
-        body = err.read().decode("utf-8", errors="replace").strip()
-        detail = f": {body}" if body else ""
+        content_type = err.headers.get_content_type()
+        body = err.read(256).decode("utf-8", errors="replace").strip()
+        detail = f": {body}" if content_type == "text/plain" and body else ""
         raise TargetError(f"appcast returned HTTP {err.code}{detail}") from err
     except urllib.error.URLError as err:
         raise TargetError(f"unable to fetch appcast: {err.reason}") from err

--- a/scripts/ci/resolve_macos_update_target.py
+++ b/scripts/ci/resolve_macos_update_target.py
@@ -90,7 +90,7 @@ def parse_target(xml_data: bytes, appcast_url: str) -> UpdateTarget:
     )
     require(
         version.isascii() and version.isdigit(),
-        "appcast Sparkle version must be numeric",
+        f"appcast Sparkle version must be numeric; got {version!r}",
     )
     target_build = int(version)
     require(target_build > 1, "appcast Sparkle build must be greater than 1")

--- a/scripts/ci/resolve_macos_update_target_test.py
+++ b/scripts/ci/resolve_macos_update_target_test.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+import base64
+import pathlib
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import resolve_macos_update_target as resolver
+
+
+SIGNATURE = base64.b64encode(bytes(range(64))).decode("ascii")
+APPCAST_URL = "https://update.example.com/appcast.xml?channel=beta"
+
+
+def appcast(
+    *,
+    build: str = "920",
+    display_version: str = "9.2.0",
+    os_name: str = "macos",
+    url: str = "https://example.com/lantern-installer-beta.dmg",
+    length: str = "12345",
+    signature: str = SIGNATURE,
+) -> bytes:
+    return f"""<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:sparkle="{resolver.SPARKLE_NS}">
+  <channel>
+    <item>
+      <sparkle:version>{build}</sparkle:version>
+      <sparkle:shortVersionString>{display_version}</sparkle:shortVersionString>
+      <enclosure url="{url}" sparkle:os="{os_name}" length="{length}"
+                 sparkle:edSignature="{signature}" type="application/octet-stream"/>
+    </item>
+  </channel>
+</rss>
+""".encode()
+
+
+class ResolveMacOSUpdateTargetTest(unittest.TestCase):
+    def test_parse_target_accepts_signed_numeric_macos_release(self) -> None:
+        target = resolver.parse_target(appcast(), APPCAST_URL)
+
+        self.assertEqual(target.target_build, 920)
+        self.assertEqual(target.fixture_build, 919)
+        self.assertEqual(target.display_version, "9.2.0")
+        self.assertEqual(target.fixture_pubspec_version, "9.2.0+919")
+        self.assertEqual(target.ed_signature, SIGNATURE)
+
+    def test_parse_target_rejects_non_numeric_sparkle_version(self) -> None:
+        with self.assertRaisesRegex(resolver.TargetError, "must be numeric"):
+            resolver.parse_target(appcast(build="9.2.0-beta"), APPCAST_URL)
+
+    def test_parse_target_requires_display_version(self) -> None:
+        with self.assertRaisesRegex(resolver.TargetError, "display version"):
+            resolver.parse_target(appcast(display_version=""), APPCAST_URL)
+        with self.assertRaisesRegex(resolver.TargetError, "display version"):
+            resolver.parse_target(
+                appcast(display_version="9.2.0+metadata"),
+                APPCAST_URL,
+            )
+
+    def test_parse_target_requires_macos_dmg(self) -> None:
+        with self.assertRaisesRegex(resolver.TargetError, "no macOS enclosure"):
+            resolver.parse_target(appcast(os_name="windows"), APPCAST_URL)
+
+        with self.assertRaisesRegex(resolver.TargetError, "point to a DMG"):
+            resolver.parse_target(
+                appcast(url="https://example.com/lantern.exe"),
+                APPCAST_URL,
+            )
+
+    def test_parse_target_requires_https(self) -> None:
+        with self.assertRaisesRegex(resolver.TargetError, "must use HTTPS"):
+            resolver.parse_target(
+                appcast(url="http://example.com/lantern.dmg"),
+                APPCAST_URL,
+            )
+
+    def test_parse_target_requires_valid_signature(self) -> None:
+        signatures = (
+            "",
+            "not-base64",
+            base64.b64encode(b"short").decode("ascii"),
+        )
+        for signature in signatures:
+            with self.subTest(signature=signature):
+                with self.assertRaisesRegex(resolver.TargetError, "signature"):
+                    resolver.parse_target(appcast(signature=signature), APPCAST_URL)
+
+    def test_parse_target_rejects_unsafe_xml(self) -> None:
+        xml_data = appcast().replace(
+            b'<rss version="2.0"',
+            b'<!DOCTYPE rss [<!ENTITY build "920">]><rss version="2.0"',
+        ).replace(b">920<", b">&build;<")
+        with self.assertRaisesRegex(resolver.TargetError, "unsafe appcast"):
+            resolver.parse_target(xml_data, APPCAST_URL)
+
+    def test_write_fixture_pubspec_only_replaces_version(self) -> None:
+        target = resolver.parse_target(appcast(), APPCAST_URL)
+        with tempfile.TemporaryDirectory() as tmp:
+            source = pathlib.Path(tmp) / "source.yaml"
+            destination = pathlib.Path(tmp) / "pubspec.yaml"
+            source.write_text("name: lantern\nversion: 1.0.0+1\ndescription: Test\n")
+
+            resolver.write_fixture_pubspec(source, destination, target)
+
+            self.assertEqual(
+                destination.read_text(),
+                "name: lantern\nversion: 9.2.0+919\ndescription: Test\n",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ci/resolve_macos_update_target_test.py
+++ b/scripts/ci/resolve_macos_update_target_test.py
@@ -51,8 +51,12 @@ class ResolveMacOSUpdateTargetTest(unittest.TestCase):
         self.assertEqual(target.ed_signature, SIGNATURE)
 
     def test_parse_target_rejects_non_numeric_sparkle_version(self) -> None:
-        with self.assertRaisesRegex(resolver.TargetError, "must be numeric"):
+        with self.assertRaises(resolver.TargetError) as raised:
             resolver.parse_target(appcast(build="9.2.0-beta"), APPCAST_URL)
+        self.assertEqual(
+            str(raised.exception),
+            "appcast Sparkle version must be numeric; got '9.2.0-beta'",
+        )
 
     def test_parse_target_requires_display_version(self) -> None:
         with self.assertRaisesRegex(resolver.TargetError, "display version"):

--- a/scripts/ci/verify_fixture_update_artifacts.py
+++ b/scripts/ci/verify_fixture_update_artifacts.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Verify signed desktop fixture artifacts and their update sidecars."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import binascii
+import hashlib
+import json
+import pathlib
+import plistlib
+import re
+import subprocess
+import tempfile
+import urllib.parse
+
+
+class VerificationError(Exception):
+    pass
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise VerificationError(message)
+
+
+def public_key(info_plist: pathlib.Path, runner_rc: pathlib.Path) -> bytes:
+    with info_plist.open("rb") as source:
+        mac_key = plistlib.load(source).get("SUPublicEDKey", "")
+    match = re.search(
+        r'EdDSAPub\s+EDDSA\s+\{"([A-Za-z0-9+/=]+)"\}',
+        runner_rc.read_text(encoding="utf-8"),
+    )
+    require(match is not None, "Windows EdDSAPub resource is missing")
+    windows_key = match.group(1)
+    require(mac_key == windows_key, "macOS and Windows update public keys differ")
+    try:
+        decoded = base64.b64decode(mac_key, validate=True)
+    except (binascii.Error, ValueError) as err:
+        raise VerificationError("update public key is not valid base64") from err
+    require(len(decoded) == 32, "Ed25519 public key must decode to 32 bytes")
+    return decoded
+
+
+def sha256(path: pathlib.Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as source:
+        for chunk in iter(lambda: source.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_signature(artifact: pathlib.Path, signature: str, key: bytes) -> None:
+    try:
+        decoded_signature = base64.b64decode(signature, validate=True)
+    except (binascii.Error, ValueError) as err:
+        raise VerificationError(f"invalid signature for {artifact.name}") from err
+    require(len(decoded_signature) == 64, f"invalid signature length for {artifact.name}")
+
+    # SubjectPublicKeyInfo prefix for a raw Ed25519 public key (RFC 8410).
+    spki = bytes.fromhex("302a300506032b6570032100") + key
+    with tempfile.TemporaryDirectory() as temporary_directory:
+        temporary = pathlib.Path(temporary_directory)
+        key_path = temporary / "public-key.der"
+        signature_path = temporary / "signature.bin"
+        key_path.write_bytes(spki)
+        signature_path.write_bytes(decoded_signature)
+        result = subprocess.run(
+            [
+                "openssl",
+                "pkeyutl",
+                "-verify",
+                "-pubin",
+                "-inkey",
+                str(key_path),
+                "-keyform",
+                "DER",
+                "-rawin",
+                "-in",
+                str(artifact),
+                "-sigfile",
+                str(signature_path),
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    require(
+        result.returncode == 0,
+        f"Ed25519 verification failed for {artifact.name}: "
+        f"{result.stderr.strip() or result.stdout.strip()}",
+    )
+
+
+def verify_sidecar(
+    sidecar: pathlib.Path,
+    artifact_directory: pathlib.Path,
+    asset_base_url: str,
+    key: bytes,
+) -> None:
+    metadata = json.loads(sidecar.read_text(encoding="utf-8"))
+    filename = metadata.get("filename", "")
+    require(isinstance(filename, str) and bool(filename), f"invalid filename in {sidecar.name}")
+    artifact = artifact_directory / filename
+    require(artifact.is_file(), f"artifact is missing for {sidecar.name}: {filename}")
+    require(metadata.get("size") == artifact.stat().st_size, f"size mismatch for {filename}")
+    require(metadata.get("sha256") == sha256(artifact), f"checksum mismatch for {filename}")
+    expected_url = f"{asset_base_url.rstrip('/')}/{urllib.parse.quote(filename)}"
+    require(metadata.get("url") == expected_url, f"unexpected fixture URL for {filename}")
+    sparkle_version = str(metadata.get("sparkle_version", ""))
+    require(
+        sparkle_version.isascii() and sparkle_version.isdigit(),
+        f"invalid Sparkle version for {filename}",
+    )
+    verify_signature(artifact, metadata.get("sparkle_ed_signature", ""), key)
+    print(f"verified {filename}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--artifact-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--metadata-dir", required=True, type=pathlib.Path)
+    parser.add_argument("--asset-base-url", required=True)
+    parser.add_argument("--info-plist", default="macos/Runner/Info.plist", type=pathlib.Path)
+    parser.add_argument("--runner-rc", default="windows/runner/Runner.rc", type=pathlib.Path)
+    args = parser.parse_args()
+
+    try:
+        key = public_key(args.info_plist, args.runner_rc)
+        sidecars = sorted(args.metadata_dir.glob("*.update.json"))
+        require(bool(sidecars), "no fixture sidecars found")
+        for sidecar in sidecars:
+            verify_sidecar(sidecar, args.artifact_dir, args.asset_base_url, key)
+    except (OSError, VerificationError, json.JSONDecodeError) as err:
+        raise SystemExit(f"fixture verification failed: {err}") from err
+
+
+if __name__ == "__main__":
+    main()

--- a/test/core/common/app_urls_test.dart
+++ b/test/core/common/app_urls_test.dart
@@ -17,5 +17,12 @@ void main() {
         'https://update.getlantern.org/update/lantern/appcast.xml?channel=stable',
       );
     });
+
+    test('uses the isolated staging feed for E2E fixtures', () {
+      expect(
+        AppUrls.appcastFor('beta', autoUpdateE2E: true),
+        'https://update.staging.iantem.io/update/lantern/appcast.xml?channel=beta',
+      );
+    });
   });
 }

--- a/test_driver/integration_test.dart
+++ b/test_driver/integration_test.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();


### PR DESCRIPTION
Adds a manual Flutter-led macOS test that builds a signed, notarized lower-version fixture, triggers "Check for Updates," installs the live beta, and verifies replacement, relaunch, versions, signatures, and diagnostics

Resolves https://github.com/getlantern/engineering/issues/3806