### PR TITLE
One consent covering both sharing modes (follow-up to #8820)

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -748,7 +748,6 @@ msgstr "Manual port cleared — using UPnP"
 msgid "smc_manual_port_saved"
 msgstr "Manual port set to %d"
 
-# SmC disclosure dialog (shown before opting into the residential-proxy mode)
 # Unbounded Settings menu entry (Settings → Unbounded Settings)
 msgid "unbounded_settings_title"
 msgstr "Unbounded Settings"
@@ -1887,6 +1886,7 @@ msgstr "Order Total"
 msgid "smart_routing_mode_description"
 msgstr "Smart Location picks the fastest server and switches automatically as it finds better routes."
 
+# Share consent dialog (shown once before any sharing starts, covers both modes)
 msgid "share_consent_title"
 msgstr "Share your connection?"
 
@@ -1894,7 +1894,7 @@ msgid "share_consent_body_what"
 msgstr "While sharing is on, people in censored countries route their traffic through your connection to reach the open internet."
 
 msgid "share_consent_body_ip"
-msgstr "If your router supports port forwarding, your home connection is used as the exit and your IP address will appear in the destination's logs while you're sharing. Otherwise your traffic is relayed through Lantern's servers and your IP is not exposed that way."
+msgstr "If your router supports port forwarding, your home connection is used as the exit and your IP address will appear in the destination's logs while you're sharing. Otherwise that traffic is relayed through Lantern's servers instead, and your IP is not exposed that way."
 
 msgid "share_consent_body_safety"
 msgstr "In both cases Lantern blocks known-abuse destinations, private network ranges, and abuse-prone ports, rotates credentials, and operates as a \"mere conduit\" under DMCA § 512(a)."

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -749,24 +749,6 @@ msgid "smc_manual_port_saved"
 msgstr "Manual port set to %d"
 
 # SmC disclosure dialog (shown before opting into the residential-proxy mode)
-msgid "smc_disclosure_title"
-msgstr "Use full Share My Connection?"
-
-msgid "smc_disclosure_body_capability"
-msgstr "Your network supports the higher-bandwidth, more block-resistant mode. In this mode, your home internet connection routes traffic for users in censored countries."
-
-msgid "smc_disclosure_body_safety"
-msgstr "Lantern blocks abuse destinations, rotates credentials, and operates as a \"mere conduit\" under DMCA § 512(a) — but your IP address will appear in the destination's logs while you're sharing."
-
-msgid "smc_disclosure_body_alternative"
-msgstr "You can still help by selecting \"Basic mode\" instead, which uses ephemeral WebRTC connections that are not tied to your IP in the same way."
-
-msgid "smc_disclosure_basic"
-msgstr "Basic mode (Unbounded)"
-
-msgid "smc_disclosure_full"
-msgstr "Full mode (SmC)"
-
 # Unbounded Settings menu entry (Settings → Unbounded Settings)
 msgid "unbounded_settings_title"
 msgstr "Unbounded Settings"
@@ -1904,4 +1886,22 @@ msgstr "Order Total"
 
 msgid "smart_routing_mode_description"
 msgstr "Smart Location picks the fastest server and switches automatically as it finds better routes."
+
+msgid "share_consent_title"
+msgstr "Share your connection?"
+
+msgid "share_consent_body_what"
+msgstr "While sharing is on, people in censored countries route their traffic through your connection to reach the open internet."
+
+msgid "share_consent_body_ip"
+msgstr "If your router supports port forwarding, your home connection is used as the exit and your IP address will appear in the destination's logs while you're sharing. Otherwise your traffic is relayed through Lantern's servers and your IP is not exposed that way."
+
+msgid "share_consent_body_safety"
+msgstr "In both cases Lantern blocks known-abuse destinations, private network ranges, and abuse-prone ports, rotates credentials, and operates as a \"mere conduit\" under DMCA § 512(a)."
+
+msgid "share_consent_decline"
+msgstr "Not now"
+
+msgid "share_consent_accept"
+msgstr "Turn on sharing"
 

--- a/lib/features/setting/unbounded_setting.dart
+++ b/lib/features/setting/unbounded_setting.dart
@@ -56,10 +56,10 @@ class UnboundedSetting extends ConsumerWidget {
                   icon: AppImagePaths.share,
                   trailing: SwitchButton(
                     value: autoEnable,
-                    onChanged: notifier.setUnboundedAutoEnable,
+                    onChanged: (v) => _setAutoEnable(context, ref, v),
                   ),
                   onPressed: () =>
-                      notifier.setUnboundedAutoEnable(!autoEnable),
+                      _setAutoEnable(context, ref, !autoEnable),
                 ),
                 DividerSpace(),
                 AppTile(
@@ -87,5 +87,25 @@ class UnboundedSetting extends ConsumerWidget {
         ],
       ),
     );
+  }
+
+  /// Turning auto-start on is a start path like any other, so it collects the
+  /// same consent. Without this, enabling it here would let autoStart share on
+  /// the next launch for a user who was never shown the disclosure — and
+  /// autoStart itself cannot prompt.
+  Future<void> _setAutoEnable(
+    BuildContext context,
+    WidgetRef ref,
+    bool enabled,
+  ) async {
+    final notifier = ref.read(appSettingProvider.notifier);
+    if (!enabled) {
+      notifier.setUnboundedAutoEnable(false);
+      return;
+    }
+    final consented =
+        await ref.read(shareProvider.notifier).ensureConsent(context);
+    if (!consented) return;
+    notifier.setUnboundedAutoEnable(true);
   }
 }

--- a/lib/features/setting/unbounded_setting.dart
+++ b/lib/features/setting/unbounded_setting.dart
@@ -56,10 +56,12 @@ class UnboundedSetting extends ConsumerWidget {
                   icon: AppImagePaths.share,
                   trailing: SwitchButton(
                     value: autoEnable,
-                    onChanged: (v) => _setAutoEnable(context, ref, v),
+                    onChanged: (v) =>
+                        ref.read(shareProvider.notifier).setAutoEnable(context, v),
                   ),
-                  onPressed: () =>
-                      _setAutoEnable(context, ref, !autoEnable),
+                  onPressed: () => ref
+                      .read(shareProvider.notifier)
+                      .setAutoEnable(context, !autoEnable),
                 ),
                 DividerSpace(),
                 AppTile(
@@ -87,25 +89,5 @@ class UnboundedSetting extends ConsumerWidget {
         ],
       ),
     );
-  }
-
-  /// Turning auto-start on is a start path like any other, so it collects the
-  /// same consent. Without this, enabling it here would let autoStart share on
-  /// the next launch for a user who was never shown the disclosure — and
-  /// autoStart itself cannot prompt.
-  Future<void> _setAutoEnable(
-    BuildContext context,
-    WidgetRef ref,
-    bool enabled,
-  ) async {
-    final notifier = ref.read(appSettingProvider.notifier);
-    if (!enabled) {
-      notifier.setUnboundedAutoEnable(false);
-      return;
-    }
-    final consented =
-        await ref.read(shareProvider.notifier).ensureConsent(context);
-    if (!consented) return;
-    notifier.setUnboundedAutoEnable(true);
   }
 }

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -188,6 +188,7 @@ class ShareNotifier extends Notifier<ShareState> {
   // case, which is the stronger of the two, so that ack carries forward rather
   // than re-prompting them.
   static const _legacySmcAckKey = 'smc_disclosure_acked';
+  Future<bool>? _consentInFlight;
   LocalStorageService get _storage => sl<LocalStorageService>();
   bool get _consentAcked =>
       _storage.containsKey(_consentAckKey) ||
@@ -199,11 +200,19 @@ class ShareNotifier extends Notifier<ShareState> {
   /// short-circuits without showing anything.
   ///
   /// Both modes route other people's traffic through the user's connection, so
-  /// one disclosure covers both; it is worded for the worse case (SmC, where
+  /// one disclosure covers both; it is worded for the worst case (SmC, where
   /// the user's own IP is the exit) because the mode isn't known until the
   /// UPnP probe runs, after consent.
-  Future<bool> ensureConsent(BuildContext context) async {
-    if (_consentAcked) return true;
+  Future<bool> ensureConsent(BuildContext context) {
+    if (_consentAcked) return Future.value(true);
+    // The toggle, the tab's auto-enable card and its checkbox, and the
+    // Settings row can all reach this before the first dialog closes. Sharing
+    // one future keeps that to a single dialog and a single ack write.
+    return _consentInFlight ??= _showConsentDialog(context)
+        .whenComplete(() => _consentInFlight = null);
+  }
+
+  Future<bool> _showConsentDialog(BuildContext context) async {
     final accepted = await showDialog<bool>(
       context: context,
       barrierDismissible: false,
@@ -296,10 +305,10 @@ class ShareNotifier extends Notifier<ShareState> {
     }
 
     // Consent gates every start path, before the mode is even known.
-    if (!await ensureConsent(context)) {
-      state = state.copyWith(probing: false);
-      return;
-    }
+    if (!await ensureConsent(context)) return;
+    // Showing it is async, so re-check: another surface — or a second tap on
+    // this one — can have started sharing while the dialog was up.
+    if (state.active || state.probing) return;
 
     state = state.copyWith(probing: true);
 
@@ -1890,7 +1899,7 @@ class _ManualPortField extends HookConsumerWidget {
 
 /// One disclosure for both sharing modes. The user is not asked to pick a
 /// mode — that follows from whether their router supports port forwarding —
-/// so the copy describes the worse case (their own IP as the exit) and the
+/// so the copy describes the worst case (their own IP as the exit) and the
 /// relayed case, and the single choice is whether to share at all.
 class ShareConsentDialog extends StatelessWidget {
   const ShareConsentDialog({super.key});

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -180,13 +180,39 @@ class _PeerArc {
 }
 
 class ShareNotifier extends Notifier<ShareState> {
-  // Disclosure ack persists across launches via LocalStorageService
+  // Consent ack persists across launches via LocalStorageService
   // (SharedPreferences). Key-presence is the signal — the value is
   // arbitrary. Cleared by deleteAll() in the existing reset flow.
-  static const _smcAckKey = 'smc_disclosure_acked';
+  static const _consentAckKey = 'share_consent_acked';
+  // Anyone who accepted the old SmC-only disclosure consented to the exit-node
+  // case, which is the stronger of the two, so that ack carries forward rather
+  // than re-prompting them.
+  static const _legacySmcAckKey = 'smc_disclosure_acked';
   LocalStorageService get _storage => sl<LocalStorageService>();
-  bool get _smcAck => _storage.containsKey(_smcAckKey);
-  Future<void> _persistSmcAck() => _storage.setString(_smcAckKey, '1');
+  bool get _consentAcked =>
+      _storage.containsKey(_consentAckKey) ||
+      _storage.containsKey(_legacySmcAckKey);
+  Future<void> _persistConsentAck() => _storage.setString(_consentAckKey, '1');
+
+  /// Prompts for sharing consent if it hasn't been given, and reports whether
+  /// sharing may proceed. Safe to call when consent already exists — it
+  /// short-circuits without showing anything.
+  ///
+  /// Both modes route other people's traffic through the user's connection, so
+  /// one disclosure covers both; it is worded for the worse case (SmC, where
+  /// the user's own IP is the exit) because the mode isn't known until the
+  /// UPnP probe runs, after consent.
+  Future<bool> ensureConsent(BuildContext context) async {
+    if (_consentAcked) return true;
+    final accepted = await showDialog<bool>(
+      context: context,
+      barrierDismissible: false,
+      builder: (_) => const ShareConsentDialog(),
+    );
+    if (accepted != true) return false;
+    await _persistConsentAck();
+    return true;
+  }
 
   StreamSubscription? _appEventSub;
   int _workerSeq = 0;
@@ -246,12 +272,16 @@ class ShareNotifier extends Notifier<ShareState> {
       return;
     }
 
+    // Consent gates every start path, before the mode is even known.
+    if (!await ensureConsent(context)) {
+      state = state.copyWith(probing: false);
+      return;
+    }
+
     state = state.copyWith(probing: true);
 
-    // Manual port forward bypasses both the UPnP probe and the SmC
-    // disclosure dialog. Configuring a port in Advanced is an explicit
-    // user-driven SmC opt-in — they wouldn't have set it up if they
-    // weren't sure they wanted to share via the residential-IP path.
+    // Manual port forward skips the UPnP probe: configuring a port by hand is
+    // an explicit request for the residential-IP path.
     final manualPortRes =
         await widgetRef.read(lanternServiceProvider).getPeerManualPort();
     final manualPort = manualPortRes.fold((_) => 0, (p) => p);
@@ -275,33 +305,7 @@ class ShareNotifier extends Notifier<ShareState> {
       return;
     }
 
-    if (_smcAck) {
-      await _start(widgetRef, ShareMode.smc);
-      return;
-    }
-
-    if (!context.mounted) {
-      state = state.copyWith(probing: false);
-      return;
-    }
-
-    final accepted = await showDialog<bool>(
-      context: context,
-      barrierDismissible: false,
-      builder: (_) => const SmcDisclosureDialog(),
-    );
-
-    if (accepted == null) {
-      // User dismissed without choosing — leave off.
-      state = state.copyWith(probing: false);
-      return;
-    }
-    if (accepted) {
-      await _persistSmcAck();
-      await _start(widgetRef, ShareMode.smc);
-    } else {
-      await _start(widgetRef, ShareMode.unbounded);
-    }
+    await _start(widgetRef, ShareMode.smc);
   }
 
   /// Programmatic entry point used by the Home shell's auto-enable
@@ -309,15 +313,17 @@ class ShareNotifier extends Notifier<ShareState> {
   /// "Auto-enable Unbounded" Settings toggle.
   ///
   /// Always starts Unbounded mode regardless of UPnP capability or
-  /// manual-port configuration. SmC requires the explicit-disclosure
-  /// dialog enforced by toggle(); auto-enabling SmC would silently
-  /// turn the user's device into a residential exit they never
-  /// agreed to act as. The auto path is the low-friction Unbounded
-  /// surface only.
+  /// manual-port configuration. SmC would make the user's device a
+  /// residential exit, and this path has no UI to disclose that, so it stays
+  /// on the relayed surface even for a user who has consented.
   ///
-  /// No-ops if already active or in flight.
+  /// No-ops if already active or in flight, or if consent has never been
+  /// given — this path cannot prompt, so refusing to start is the only safe
+  /// direction. Consent is collected by toggle() or by enabling auto-start in
+  /// Unbounded Settings, both of which have a BuildContext.
   Future<void> autoStart(WidgetRef widgetRef) async {
     if (state.active || state.probing) return;
+    if (!_consentAcked) return;
     state = state.copyWith(probing: true);
     await _start(widgetRef, ShareMode.unbounded);
   }
@@ -1859,31 +1865,29 @@ class _ManualPortField extends HookConsumerWidget {
 
 // ─── Disclosure dialog ───────────────────────────────────────────────────────
 
-class SmcDisclosureDialog extends StatelessWidget {
-  const SmcDisclosureDialog({super.key});
+/// One disclosure for both sharing modes. The user is not asked to pick a
+/// mode — that follows from whether their router supports port forwarding —
+/// so the copy describes the worse case (their own IP as the exit) and the
+/// relayed case, and the single choice is whether to share at all.
+class ShareConsentDialog extends StatelessWidget {
+  const ShareConsentDialog({super.key});
 
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
     return AlertDialog(
-      title: Text('smc_disclosure_title'.i18n),
+      title: Text('share_consent_title'.i18n),
       content: SingleChildScrollView(
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           mainAxisSize: MainAxisSize.min,
           children: [
-            Text(
-              'smc_disclosure_body_capability'.i18n,
-              style: textTheme.bodyMedium,
-            ),
+            Text('share_consent_body_what'.i18n, style: textTheme.bodyMedium),
+            const SizedBox(height: 12),
+            Text('share_consent_body_ip'.i18n, style: textTheme.bodyMedium),
             const SizedBox(height: 12),
             Text(
-              'smc_disclosure_body_safety'.i18n,
-              style: textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 12),
-            Text(
-              'smc_disclosure_body_alternative'.i18n,
+              'share_consent_body_safety'.i18n,
               style: textTheme.bodyMedium?.copyWith(
                 color: Theme.of(context).hintColor,
               ),
@@ -1894,11 +1898,11 @@ class SmcDisclosureDialog extends StatelessWidget {
       actions: [
         TextButton(
           onPressed: () => Navigator.of(context).pop(false),
-          child: Text('smc_disclosure_basic'.i18n),
+          child: Text('share_consent_decline'.i18n),
         ),
         FilledButton(
           onPressed: () => Navigator.of(context).pop(true),
-          child: Text('smc_disclosure_full'.i18n),
+          child: Text('share_consent_accept'.i18n),
         ),
       ],
     );

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -265,21 +265,30 @@ class ShareNotifier extends Notifier<ShareState> {
     // and the persisted value via setUnboundedTotalHelped.
     final persistedTotal =
         ref.read(appSettingProvider).unboundedTotalHelped;
+    // Reconcile an auto-enable preference stored before consent existed.
+    // Earlier builds defaulted it to true and wrote it with no disclosure, so
+    // after an upgrade the toggle would read as on while autoStart refuses to
+    // run for want of an ack — enabled in the UI, silently never starting.
+    // Clear it rather than grandfather consent nobody gave; re-enabling
+    // prompts. Deferred because build() must not mutate another provider.
+    if (!_consentAcked && ref.read(appSettingProvider).unboundedAutoEnable) {
+      Future.microtask(
+        () =>
+            ref.read(appSettingProvider.notifier).setUnboundedAutoEnable(false),
+      );
+    }
     return ShareState(totalCount: persistedTotal);
   }
 
   /// Toggle entry point. Caller passes its BuildContext so we can show the
-  /// disclosure modal inline, and a WidgetRef so we can drive the radiance
+  /// consent modal inline, and a WidgetRef so we can drive the radiance
   /// peer-share toggle.
   ///
-  /// Resolution order on enable:
-  ///   1. If the user has set a manual port in Advanced settings, that
-  ///      is an explicit opt-in — go straight to SmC mode. No UPnP
-  ///      probe, no disclosure (user already crossed that line by
-  ///      configuring the port forward on their router).
-  ///   2. Otherwise probe UPnP. If UPnP works AND the user accepts
-  ///      the SmC disclosure, run SmC. Decline → Unbounded.
-  ///   3. UPnP unavailable → Unbounded fallback.
+  /// Consent is collected first and covers both modes. The mode itself is not
+  /// the user's choice — it follows from the network:
+  ///   1. A manual port set in Unbounded Settings means the user has already
+  ///      forwarded a port, so use it and skip the probe.
+  ///   2. Otherwise probe UPnP: available → SmC, unavailable → Unbounded.
   Future<void> toggle(BuildContext context, WidgetRef widgetRef) async {
     if (state.active || state.probing) {
       await _stop(widgetRef);

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -214,6 +214,20 @@ class ShareNotifier extends Notifier<ShareState> {
     return true;
   }
 
+  /// Persists the auto-start preference, collecting consent first when turning
+  /// it on. Every surface that offers the toggle routes through here:
+  /// autoStart refuses to run without an ack, so a preference written without
+  /// one would read as enabled and then silently never start.
+  Future<void> setAutoEnable(BuildContext context, bool enabled) async {
+    final settings = ref.read(appSettingProvider.notifier);
+    if (!enabled) {
+      settings.setUnboundedAutoEnable(false);
+      return;
+    }
+    if (!await ensureConsent(context)) return;
+    settings.setUnboundedAutoEnable(true);
+  }
+
   StreamSubscription? _appEventSub;
   int _workerSeq = 0;
   // Per-peer arc + active-stream count. samizdat multiplexes many H2 streams
@@ -1048,7 +1062,7 @@ class _AutoEnableCard extends ConsumerWidget {
     final textTheme = Theme.of(context).textTheme;
     final autoEnable =
         ref.watch(appSettingProvider.select((s) => s.unboundedAutoEnable));
-    final notifier = ref.read(appSettingProvider.notifier);
+    final notifier = ref.read(shareProvider.notifier);
     return Container(
       decoration: BoxDecoration(
         color: Theme.of(context).cardColor,
@@ -1057,7 +1071,7 @@ class _AutoEnableCard extends ConsumerWidget {
       ),
       child: InkWell(
         borderRadius: BorderRadius.circular(12),
-        onTap: () => notifier.setUnboundedAutoEnable(!autoEnable),
+        onTap: () => notifier.setAutoEnable(context, !autoEnable),
         child: Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
           child: Row(
@@ -1079,7 +1093,7 @@ class _AutoEnableCard extends ConsumerWidget {
               const SizedBox(width: 8),
               Checkbox(
                 value: autoEnable,
-                onChanged: (v) => notifier.setUnboundedAutoEnable(v ?? false),
+                onChanged: (v) => notifier.setAutoEnable(context, v ?? false),
                 activeColor: AppColors.blue10,
                 shape: RoundedRectangleBorder(
                   borderRadius: BorderRadius.circular(4),


### PR DESCRIPTION
Follow-up to #8820. Stacked on `fisk/unbounded-tab`.

## Why

Unbounded and SmC both route other people's traffic through the user's connection. Splitting the disclosure by mode asked for consent twice for the same underlying act, while leaving the *lower*-risk mode with no disclosure at all — Unbounded could start with nothing shown, and auto-enable started it with no consent whatsoever.

The modes do differ, but in *where the user's IP appears*, not in whether traffic flows:

| | Exit | Inbound port | Destination sees |
|---|---|---|---|
| Unbounded | Lantern egress | none (outbound WebRTC) | Lantern's IP |
| SmC | the user's own connection | open, forwarded | **the user's IP** |

That's an argument about what the disclosure must *say*, not about needing two of them.

## What changed

One `ShareConsentDialog`, collected before any sharing starts, worded for the worse case: with port forwarding your connection is the exit and your IP reaches the destination's logs; without it traffic is relayed through Lantern's servers. The user no longer picks a mode — that follows from whether the router supports port forwarding, which isn't known until the UPnP probe runs, *after* consent.

Every start path is gated on one ack:

- `toggle()` prompts, then selects the mode as before
- enabling auto-start (either the tab card or Unbounded Settings) prompts, and only persists once consent is given
- `autoStart()` refuses without a stored ack. It has no UI to prompt with, so refusing is the only safe direction — and it stays Unbounded-only regardless of consent, since nothing on that path discloses the exit-node case

An existing `smc_disclosure_acked` carries forward: those users accepted the exit-node case, the stronger of the two, so they aren't re-prompted.

`unboundedAutoEnable` now has exactly one write path (`ShareNotifier.setAutoEnable`), so a surface can't be added later that forgets the gate.

## Upgrade behaviour

Earlier builds defaulted `unboundedAutoEnable` to **true** and wrote it with no disclosure, so existing installs carry it with no consent key. On init, that preference is cleared when no ack is present — otherwise it would upgrade into a silent dead state where the toggle reads as on and `autoStart` never runs. Re-enabling prompts.

## Pre-PR review (local Codex gate)
- Rounds: 3 — final: `CODEX GATE: verdict=approve critical=0 important=0 minor=0`
- Exit: `approve`
- Fixed:
  - `share_my_connection.dart:1060,1082` — the tab's auto-enable card wrote the preference directly, bypassing the gate the Settings copy used; a user could tick it, see it persist, and have `autoStart` silently refuse forever. Both surfaces now share one consent-aware write path.
  - `share_my_connection.dart:266` — existing installs with `unboundedAutoEnable == true` and no consent key would upgrade into that same silent dead state. Confirmed against a real install's prefs before fixing. Now reconciled on init.
- Dismissed: none

## Testing
- `dart analyze` clean on all touched files
- `flutter test` — 150 passed
- Not yet exercised in a running build; the dialog copy and the upgrade reconciliation are worth a manual pass before merge.


## PR review round (Copilot)
Reviewed at `0279c869`, 4 comments, all fixed in `e8f35c572`; clean re-review at `e8f35c572`.

One was a behaviour fix rather than a nit: `ensureConsent` had no dedupe, and consent is awaited *before* `probing` is set — so a second tap during the dialog re-entered `toggle()`, saw `active=false/probing=false`, and fell through to the stop branch. It now shares one in-flight future across all surfaces and re-checks `active || probing` after the dialog returns. The other three were copy/comment accuracy (`worse`→`worst case`, "your traffic" reading as the user's own browsing, an orphaned `.po` section header).
