### PR TITLE
ios: sample tunnel memory every second and log the stop reason first

### DIFF
--- a/ios/Tunnel/PacketTunnelProvider.swift
+++ b/ios/Tunnel/PacketTunnelProvider.swift
@@ -22,6 +22,18 @@ class PacketTunnelProvider: ExtensionProvider {
   private static let memoryEagerSamples = 10
   private static let memoryLogInterval: TimeInterval = 10
 
+  // The kernel's pressure source only fires on a transition, so a provider that
+  // starts already tight would sit on the normal-pressure heartbeat until one
+  // arrives. Treat scarce headroom as elevated too. A healthy tunnel plateaus
+  // around 13 MB free of the 50 MB cap and the killed ones were under 10 MB, so
+  // this trips only when genuinely close.
+  private static let lowHeadroomBytes = 10 * 1024 * 1024
+
+  // Every logger field is confined to this serial queue, and both dispatch
+  // sources fire on it. cancel() does not interrupt a handler already running,
+  // so teardown joins the queue rather than assuming sampling has stopped.
+  private let memoryQueue = DispatchQueue(label: "org.getlantern.lantern.tunnel.memory")
+
   override func startTunnel(options: [String: NSObject]?) async throws {
     try await super.startTunnel(options: options)
     startMemoryLogger()
@@ -31,7 +43,7 @@ class PacketTunnelProvider: ExtensionProvider {
     // Record the reason and a final sample before any teardown work: an outright
     // kill never reaches this at all, so its absence is itself the signal.
     appLogger.info("PacketTunnelProvider stopping, reason: \(reason.rawValue)")
-    logMemoryUsage()
+    memoryQueue.sync { _ = logMemoryUsage() }
     stopMemoryLogger()
     try? await super.stopTunnel(with: reason)
   }
@@ -40,7 +52,7 @@ class PacketTunnelProvider: ExtensionProvider {
   {
     stopMemoryLogger()
     startMemoryPressureMonitor()
-    let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
+    let timer = DispatchSource.makeTimerSource(queue: memoryQueue)
     timer.schedule(deadline: .now(), repeating: interval)
     timer.setEventHandler { [weak self] in
       self?.sampleMemory()
@@ -54,21 +66,31 @@ class PacketTunnelProvider: ExtensionProvider {
     memoryLogTimer = nil
     memoryPressureSource?.cancel()
     memoryPressureSource = nil
-    currentMemoryPressure = .normal
-    memorySampleCount = 0
-    lastMemoryLog = nil
+    // A handler already in flight when cancel() lands still runs to completion;
+    // draining the queue first keeps it from resetting state after this does, or
+    // logging a sample once the tunnel is gone.
+    memoryQueue.sync {
+      currentMemoryPressure = .normal
+      memorySampleCount = 0
+      lastMemoryLog = nil
+    }
   }
 
   // Logs every early sample so a fast pre-kill climb is visible, every sample
-  // once the kernel reports pressure, and a 10s heartbeat otherwise.
+  // once memory is tight, and a 10s heartbeat otherwise. Runs on memoryQueue.
   private func sampleMemory() {
+    let now = Date()
     memorySampleCount += 1
     let elevated = currentMemoryPressure != .normal
+      || os_proc_available_memory() < Self.lowHeadroomBytes
     let heartbeatDue =
-      lastMemoryLog.map { Date().timeIntervalSince($0) >= Self.memoryLogInterval } ?? true
+      lastMemoryLog.map { now.timeIntervalSince($0) >= Self.memoryLogInterval } ?? true
     guard memorySampleCount <= Self.memoryEagerSamples || elevated || heartbeatDue else { return }
-    lastMemoryLog = Date()
-    logMemoryUsage()
+    // Only a sample that actually read the counters may start the next heartbeat,
+    // or a failed read would suppress logging for the following ten seconds.
+    if logMemoryUsage() {
+      lastMemoryLog = now
+    }
   }
 
   // Subscribes to kernel memory-pressure notifications. The OS publishes one
@@ -77,7 +99,7 @@ class PacketTunnelProvider: ExtensionProvider {
   private func startMemoryPressureMonitor() {
     let source = DispatchSource.makeMemoryPressureSource(
       eventMask: [.normal, .warning, .critical],
-      queue: .global(qos: .utility)
+      queue: memoryQueue
     )
     source.setEventHandler { [weak self, weak source] in
       guard let self = self, let source = source else { return }
@@ -88,7 +110,10 @@ class PacketTunnelProvider: ExtensionProvider {
   }
 
 
-  private func logMemoryUsage() {
+  // Returns whether the counters were read, so a failed sample doesn't count as
+  // a heartbeat. Runs on memoryQueue.
+  @discardableResult
+  private func logMemoryUsage() -> Bool {
     var info = task_vm_info_data_t()
     var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<integer_t>.size)
     let kerr = withUnsafeMutablePointer(to: &info) {
@@ -98,7 +123,7 @@ class PacketTunnelProvider: ExtensionProvider {
     }
     guard kerr == KERN_SUCCESS else {
       appLogger.error("PacketTunnelProvider failed to read memory info: \(kerr)")
-      return
+      return false
     }
     let mb = 1024.0 * 1024.0
     let footprintMB = Double(info.phys_footprint) / mb
@@ -126,6 +151,7 @@ class PacketTunnelProvider: ExtensionProvider {
       pressureLabel, footprintMB, availableMB, residentMB, peakMB, dirtyMB, compressedMB, virtualMB
     )
     appLogger.info("\(message)")
+    return true
   }
 
   public override func handleAppMessage(_ messageData: Data, completionHandler: ((Data?) -> Void)?)

--- a/ios/Tunnel/PacketTunnelProvider.swift
+++ b/ios/Tunnel/PacketTunnelProvider.swift
@@ -12,6 +12,15 @@ class PacketTunnelProvider: ExtensionProvider {
   private var memoryLogTimer: DispatchSourceTimer?
   private var memoryPressureSource: DispatchSourceMemoryPressure?
   private var currentMemoryPressure: DispatchSource.MemoryPressureEvent = .normal
+  private var memorySampleCount = 0
+  private var lastMemoryLog: Date?
+
+  // A tunnel torn down seconds after start used to leave a single sample, so a
+  // footprint climbing toward the jetsam cap was indistinguishable from a flat
+  // one. Sample every second and throttle the log instead (cf. radiance memmon).
+  private static let memorySampleInterval: TimeInterval = 1
+  private static let memoryEagerSamples = 10
+  private static let memoryLogInterval: TimeInterval = 10
 
   override func startTunnel(options: [String: NSObject]?) async throws {
     try await super.startTunnel(options: options)
@@ -19,17 +28,22 @@ class PacketTunnelProvider: ExtensionProvider {
   }
 
   override func stopTunnel(with reason: NEProviderStopReason) async {
+    // Record the reason and a final sample before any teardown work: an outright
+    // kill never reaches this at all, so its absence is itself the signal.
+    appLogger.info("PacketTunnelProvider stopping, reason: \(reason.rawValue)")
+    logMemoryUsage()
     stopMemoryLogger()
     try? await super.stopTunnel(with: reason)
   }
 
-  private func startMemoryLogger(interval: TimeInterval = 10) {
+  private func startMemoryLogger(interval: TimeInterval = PacketTunnelProvider.memorySampleInterval)
+  {
     stopMemoryLogger()
     startMemoryPressureMonitor()
     let timer = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
     timer.schedule(deadline: .now(), repeating: interval)
     timer.setEventHandler { [weak self] in
-      self?.logMemoryUsage()
+      self?.sampleMemory()
     }
     memoryLogTimer = timer
     timer.resume()
@@ -41,6 +55,20 @@ class PacketTunnelProvider: ExtensionProvider {
     memoryPressureSource?.cancel()
     memoryPressureSource = nil
     currentMemoryPressure = .normal
+    memorySampleCount = 0
+    lastMemoryLog = nil
+  }
+
+  // Logs every early sample so a fast pre-kill climb is visible, every sample
+  // once the kernel reports pressure, and a 10s heartbeat otherwise.
+  private func sampleMemory() {
+    memorySampleCount += 1
+    let elevated = currentMemoryPressure != .normal
+    let heartbeatDue =
+      lastMemoryLog.map { Date().timeIntervalSince($0) >= Self.memoryLogInterval } ?? true
+    guard memorySampleCount <= Self.memoryEagerSamples || elevated || heartbeatDue else { return }
+    lastMemoryLog = Date()
+    logMemoryUsage()
   }
 
   // Subscribes to kernel memory-pressure notifications. The OS publishes one


### PR DESCRIPTION
Diagnosing the iOS jetsam kills behind "the latest beta will not stay connected" was slowed by two gaps in `PacketTunnelProvider.swift`. Both are fixed here.

Root cause of the underlying bug, for context — the kernel, from a reproducing device:

```
kernel: memorystatus: Tunnel [1509] exceeded mem limit: ActiveHard 50 MB (fatal)
ReportSystemMemory: Process Tunnel [1509] killed by jetsam reason per-process-limit
```

The memory fix itself is getlantern/radiance#595. This PR is purely about being able to see it next time.

## 1. The 10s sample interval could not observe the failure

`startMemoryLogger` fired immediately and then every 10 seconds. The extension was dying **~5 seconds** after connecting, so every log bundle contained exactly one sample — taken at `t=0`, before the climb.

Both testers' bundles therefore read `pressure=normal, footprint 26–31 MB` for a process that died at the 50 MB cap. That is the single biggest reason memory was ruled out early and the investigation went looking for a code crash instead.

Now: sample every second, and throttle the **log** rather than the sample —
- every one of the first 10 samples, so a fast pre-kill climb is visible;
- every sample once the kernel reports non-normal pressure;
- otherwise a 10s heartbeat.

This mirrors how radiance's memmon rate-limits its own per-tick log (`normalTickLogInterval` / `elevatedTickLogInterval`), so a long connected session stays about as quiet as it is today while the interesting window gets real resolution.

Worth noting the value of this: on the phone where this was finally caught, the immediate `t=0` sample happened to land at `pressure=critical, footprint 40.22 MB, available 9.78 MB` — 330 ms before the kill. That one line is what identified the cause. The change makes that observation reliable rather than lucky.

## 2. The stop reason was recorded after teardown had begun

`stopTunnel` called `stopMemoryLogger()` first and only reached the superclass — which logs the reason — afterwards.

Now the `NEProviderStopReason` and a final memory sample are written before any other teardown work. This matters specifically because **a jetsam kill never reaches `stopTunnel` at all**: its absence is what distinguishes "killed by the OS" from "stopped with reason X". That distinction is only usable if the reason is written before anything that can be cut short.

For reference, `ios/Shared/Logger.swift` writes unbuffered (open → seek → write → close per line), so absence of a line is genuine evidence that the code path did not run.

## Verification

`swiftc -parse -target arm64-apple-ios15.6` clean. Not yet exercised on device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved memory monitoring during tunnel operation with efficient sampling and reduced diagnostic noise.
  * Enhanced reporting when memory pressure or limited available memory is detected.
  * Added clearer shutdown diagnostics, including the tunnel stop reason and a final memory reading.
  * Reset monitoring state cleanly when the tunnel stops or restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->