### PR TITLE
build: drop .dart_tool in make clean so Flutter regenerates its outputs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1155,7 +1155,14 @@ pubget:
 find-duplicate-translations:
 	grep -oE 'msgid\s+"[^"]+"' assets/locales/en.po | sort | uniq -d
 
+# flutter clean is what drops .dart_tool, where Flutter keeps its build stamps.
+# Removing the outputs under $(BUILD_DIR) without it leaves Flutter believing
+# those targets are still satisfied, so it skips regenerating them: the
+# native-assets hook stops running and the macOS build dies in the Xcode phase
+# looking for a framework NativeAssetsManifest.json still references. Every
+# target depending on clean re-runs pubget, so dropping .dart_tool is safe.
 clean:
+	flutter clean
 	rm -rf $(BUILD_DIR)/*
 	rm -rf $(BIN_DIR)/*
 	rm -rf $(MACOS_FRAMEWORK_DIR)/*

--- a/Makefile
+++ b/Makefile
@@ -1161,6 +1161,7 @@ find-duplicate-translations:
 # native-assets hook stops running and the macOS build dies in the Xcode phase
 # looking for a framework NativeAssetsManifest.json still references. Every
 # target depending on clean re-runs pubget, so dropping .dart_tool is safe.
+.PHONY: clean
 clean:
 	flutter clean
 	rm -rf $(BUILD_DIR)/*


### PR DESCRIPTION
## The bug

`make clean` deletes the build outputs but never runs `flutter clean`, so Flutter's build stamps under `.dart_tool/` survive. Flutter reads those stamps, concludes its targets are still satisfied, and skips regenerating them — including the native-assets hook that produces `build/native_assets/macos/objective_c.framework`.

The Xcode phase then fails looking for what the hook didn't build:

```
Exception: The native assets specification at .../NativeAssetsManifest.json
references objective_c, which was not found in .../build/native_assets/macos/
```

It reads like a dependency or pub problem, which is what makes it costly — it isn't. It's stale state.

## Reproducing

Any `make macos-release` from a tree that has built before. Observed directly:

```
stamps before:                3 dirs in .dart_tool/flutter_build/
native assets before:         1 entry  (objective_c.framework)
--- old clean: rm -rf build/* ---
stamps after:                 3 dirs   <- survive, causing the skip
native assets after:          0         <- deleted
```

Next build skips the hook, and the Xcode phase dies. A plain `flutter clean` clears it and the build succeeds immediately — that's the whole fix.

It is not release-specific: `flutter build macos --debug` fails identically once the tree is in this state.

## The fix

Add `flutter clean` to the `clean` target.

Every target that depends on `clean` — `macos-release`, `linux-release`, `windows-release`, `android-release`, `android-release-obfuscated`, `ios-release` — already re-runs `pubget` afterwards, so dropping `.dart_tool` costs one `pub get` and nothing else. I checked each one rather than assuming; `linux-release` reaches it via `linux-release-ci: linux pubget gen`.

`macos-release-ci` has no `clean` prerequisite and is unaffected.

## Testing

- `make -n clean` parses and emits the expected recipe
- Reproduced the stamp survival above, and confirmed `flutter clean` fixes it end to end: the native-assets step ran, `objective_c.framework` was produced, and the release build completed and notarized

The comment sits above the target rather than inside the recipe — an indented `#` line would be handed to the shell and echoed on every run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced the clean command to run Flutter’s cleanup process before removing generated build artifacts and platform-specific outputs.
  * Ensures Flutter-generated build metadata and files are fully cleared, helping provide a clean starting point for subsequent builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->