### PR TITLE
deps: bump radiance for the iOS jetsam fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260810184453-2a25d888b977
+	github.com/getlantern/radiance v0.0.0-20260812191437-dd149e2462a6
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260810184453-2a25d888b977 h1:YV1CnZVxT7sIgzNYUdfYXL6i7tMmWnEZ++RSRI7TFQM=
-github.com/getlantern/radiance v0.0.0-20260810184453-2a25d888b977/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
+github.com/getlantern/radiance v0.0.0-20260812191437-dd149e2462a6 h1:y7qc9Vljnzo9HRT+LTUwFM0DX8QlPbsDj0u+YSRCc6c=
+github.com/getlantern/radiance v0.0.0-20260812191437-dd149e2462a6/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Picks up getlantern/radiance#596 (merged), which fixes the iOS beta that "will not stay connected" — reported by two testers on 9.1.20-beta and reproduced on a third device.

## What was wrong

iOS jetsam killed the network extension for exceeding its **fatal 50 MB per-process limit**:

```
kernel: memorystatus: Tunnel [1879] exceeded mem limit: ActiveHard 50 MB (fatal)
kernel: memorystatus: killing_specific_process pid 1879 [Tunnel] ... 51200KB
ReportSystemMemory: Process Tunnel [1879] killed by jetsam reason per-process-limit
```

radiance #575 added a jsDelivr mirror as a second fronted config source, and `NewHTTPClientWithSmartTransport` began a full Outline strategy search for **every** host in its constructor. Each search probes 11 DNS entries x 5 TLS strategies concurrently, with a goroutine, TLS handshake buffers and connection state per probe. One search already peaks near 38.5 MB inside the 50 MB cap; two overran it.

Only the primary host searches up front now — fallbacks search on first use, so the mirror keeps working (raw.githubusercontent.com is blocked in China, which is why it exists).

## Device bisect

All on one phone (iPhone 16 / iOS 26.6), per-second memory sampling:

| radiance commit | footprint | result |
|---|---|---|
| `a602efd` (before #575) | 38.50 MB, settles 35.19 MB | holds |
| `584a056` (#575) | 37.41 MB → 50 MB | killed |
| `612cd2d` (#575 + #579) | 26.95 MB → 50 MB in <1s | killed |
| `dd149e2` (**this bump**) | 39.88 MB peak, settles **36.75 MB** over 29 samples | **holds** |

Note `612cd2d` started *lower* than the build that survived — this is an allocation burst at connect, not a raised resting footprint. (An attempt to fix it by lowering GOMEMLIMIT was tried and closed as ineffective: getlantern/radiance#595.)

Also confirmed by TestFlight bisect that this is ours and not iOS 26.6: 9.1.18 holds on 26.6, 9.1.19 and 9.1.20 both die.

## Scope

`go.mod` + `go.sum` only, one module line each. `go build ./...` clean, and the fix is present in the pinned module (`kindling/smart/client.go:87`).

Worth pairing with #8971 (per-second memory sampling in `PacketTunnelProvider`) before the release — the old 10s interval left exactly one sample in a tunnel that died in ~5s, which is why this looked like anything but memory for two days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer revision.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->