### PR TITLE
deps: bump radiance for early memory-monitor start

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260812191437-dd149e2462a6
+	github.com/getlantern/radiance v0.0.0-20260812194443-f0277e466143
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260812191437-dd149e2462a6 h1:y7qc9Vljnzo9HRT+LTUwFM0DX8QlPbsDj0u+YSRCc6c=
-github.com/getlantern/radiance v0.0.0-20260812191437-dd149e2462a6/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
+github.com/getlantern/radiance v0.0.0-20260812194443-f0277e466143 h1:1NNdEk0OPVvNChC8R75gKJzLUqVdrUgeVxI+wYI989w=
+github.com/getlantern/radiance v0.0.0-20260812194443-f0277e466143/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Picks up getlantern/radiance#597, which starts a single memory monitor at the top of tunnel init rather than after libbox bring-up, so the allocation-heavy setup window is no longer unmonitored. It also pins GOMEMLIMIT before libbox setup on iOS, guards `SetExecutor` against a nil executor, and runs the monitor on `t.ctx` so `close()` stops it deterministically.

That window is where the iOS jetsam kills lived: the extension was killed roughly a second after connecting, **before the monitor's first tick**, so nothing observed the burst — which is why memmon looked dead on the failing builds. #597 makes that window observable. The fix for the burst itself was radiance#596, bumped in #8974.

## Device verification

iPhone 16 / iOS 26.6, release build from this pin (no local `replace`), per-second sampling:

| build | radiance | peak | steady | teardown | result |
|---|---|---|---|---|---|
| 9.1.18 (baseline) | — | — | 32–34 MB | — | holds |
| #8974 | `dd149e2` | 35.92 MB | 33.81 MB | 37 ms | holds |
| **this PR** | `f0277e4` | 37.94 MB | **32.77 MB** | 45 ms | **holds** |

54 samples, no jetsam, 17.2 MB headroom at plateau. Connect and a user-initiated disconnect both clean:

```
PacketTunnelProvider stopping, reason: 1
(lantern-tunnel) stopping, reason: NEProviderStopReason(rawValue: 1)
(lantern-tunnel) stopTunnel completed in 0.045 seconds
```

Peak varies run to run (35.9 / 37.9 / 39.9 across builds) with which servers get probed; the plateau is the stable figure and this is the lowest measured so far.

For contrast, the builds this fixes went to the 50 MB cap in under a second:

```
kernel: memorystatus: Tunnel exceeded mem limit: ActiveHard 50 MB (fatal)
ReportSystemMemory: killed by jetsam reason per-process-limit
```

## Scope

`go.mod` + `go.sum` only, one module line each. `go build ./...` clean. Verified the pinned module carries both fixes: `kindling/smart/client.go` has the #596 guard and `vpn/memmon.go` has #597's `SetExecutor`.

Not directly confirmed: that memmon now ticks *during* bring-up. Its ticks go to `lantern.log` on disk rather than os_log, so the device console cannot show them — it would need a log bundle from the app. The memory outcome above is unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->