### PR TITLE
deps: bump radiance for the datacap fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260812194443-f0277e466143
+	github.com/getlantern/radiance v0.0.0-20260812223628-131f92a74900
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260812194443-f0277e466143 h1:1NNdEk0OPVvNChC8R75gKJzLUqVdrUgeVxI+wYI989w=
-github.com/getlantern/radiance v0.0.0-20260812194443-f0277e466143/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
+github.com/getlantern/radiance v0.0.0-20260812223628-131f92a74900 h1:rdM01qwaEpq92fdvOgqpJebO4RWPM/E0P2h67pqZyls=
+github.com/getlantern/radiance v0.0.0-20260812223628-131f92a74900/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Picks up getlantern/radiance#598 (merged), for a new build.

## What it fixes

- **`cap_exhausted` is terminal** — it was being retried; now it stops, and the backoff resets correctly.
- **Slow-poll instead of reconnecting when datacap is disabled** (`d450614`), so a disabled cap no longer drives a reconnect loop.

Derek reported the data cap not working on macOS or Android while working on Windows, in the 9.1.20-beta thread.

## Scope

`go.mod` + `go.sum` only, one module line each: `f0277e466143` → `131f92a74900`. `go build ./...` clean.

Verified the pinned module still carries the iOS jetsam work alongside the new fix:

| fix | marker | present |
|---|---|---|
| #596 — only primary host searches at startup | `if i == 0` in `kindling/smart/client.go` | ✅ |
| #597 — monitor starts before libbox bring-up | `SetExecutor` in `vpn/memmon.go` | ✅ |
| #598 — datacap | `cap_exhausted` in `account/datacap.go` | ✅ |

## Verification note

The iOS memory behaviour was device-verified at the previous pin (`f0277e4`): peak 37.94 MB, plateau 32.77 MB, no jetsam, clean teardown — see #8975. This bump touches `account/` only, so that result should carry, but it has not been re-run on device. Happy to do a connect test before the build if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->