### PR TITLE
Fix stale browser flag, empty-input clear, and dropped await in split tunneling

### DIFF
--- a/lantern-core/apps/browsers_windows.go
+++ b/lantern-core/apps/browsers_windows.go
@@ -171,9 +171,6 @@ func browserCommandExe(cmd string) string {
 // but not byte-identical path.
 func markBrowsers(list []*AppData) {
 	idx := loadBrowserIndexOnce()
-	if len(idx.paths) == 0 && len(idx.basenames) == 0 {
-		return
-	}
 	for _, app := range list {
 		if app == nil {
 			continue

--- a/lib/features/split_tunneling/apps_split_tunneling.dart
+++ b/lib/features/split_tunneling/apps_split_tunneling.dart
@@ -223,8 +223,8 @@ class AppsSplitTunneling extends ConsumerWidget {
 Future<void> _showSelectAllBypassWarning({
   required BuildContext context,
   required String browserName,
-  required VoidCallback onAddAllExceptBrowsers,
-  required VoidCallback onAddAllAnyway,
+  required Future<void> Function() onAddAllExceptBrowsers,
+  required Future<void> Function() onAddAllAnyway,
 }) {
   final textTheme = Theme.of(context).textTheme;
   return AppDialog.customDialog(
@@ -254,16 +254,16 @@ Future<void> _showSelectAllBypassWarning({
     action: [
       PrimaryButton(
         label: 'add_all_except_browsers'.i18n,
-        onPressed: () {
+        onPressed: () async {
           appRouter.pop();
-          onAddAllExceptBrowsers();
+          await onAddAllExceptBrowsers();
         },
       ),
       SecondaryButton(
         label: 'add_all_anyway'.i18n,
-        onPressed: () {
+        onPressed: () async {
           appRouter.pop();
-          onAddAllAnyway();
+          await onAddAllAnyway();
         },
       ),
       Center(

--- a/lib/features/split_tunneling/website_domain_input.dart
+++ b/lib/features/split_tunneling/website_domain_input.dart
@@ -46,6 +46,9 @@ class WebsiteDomainInput extends HookConsumerWidget {
     }
 
     Future<void> addValidatedWebsites(List<Website> added) async {
+      if (added.isEmpty) {
+        return;
+      }
       textController.clear();
 
       final failures = await ref


### PR DESCRIPTION
Follow-up fixes on top of #8970 found during review:

- `browsers_windows.go`: `markBrowsers` returned early before resetting
  `IsBrowser` whenever the registry scan came back empty (permission
  issues, locked-down account, etc.), so a browser flagged `true` from an
  older cache stayed flagged forever, even after uninstall. Removed the
  early return so the reset always runs.
- `website_domain_input.dart`: `addValidatedWebsites` cleared the text
  field unconditionally, even when nothing was actually added (e.g.
  separator-only input like ","). Now it's a no-op when the added list
  is empty.
- `apps_split_tunneling.dart`: the "Add All Except Browsers" / "Add All
  Anyway" buttons on the select-all warning called
  `notifier.selectApps(...)` without awaiting it, so a failure there
  (e.g. FFI command isolate not ready) became an unhandled Future
  rejection instead of surfacing. Now properly awaited.
