### PR TITLE
deps: bump radiance for the auto-select probe optimization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260812223628-131f92a74900
+	github.com/getlantern/radiance v0.0.0-20260814172620-f7470192fa1f
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -171,7 +171,7 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 // indirect
-	github.com/getlantern/lantern-box v0.0.111 // indirect
+	github.com/getlantern/lantern-box v0.0.112 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464 h1:vZtMtKDsGO0ccBr+aQRRDKgcwFTg4psy13HtMttuBVQ=
 github.com/getlantern/kindling v0.0.0-20260727211028-573c1ef64464/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.111 h1:1DNrhaxpn9mRE7qMX/efi1I4wYx4FoBh7stVFIEPcYU=
-github.com/getlantern/lantern-box v0.0.111/go.mod h1:avZOnXNHLNT/d/Mrkjqn8i02HB1C805Dk7EtcWYq9lw=
+github.com/getlantern/lantern-box v0.0.112 h1:GuXFs4ZFFszGkw2jX6OfC4nV6PwHlMLxJG48I931pjk=
+github.com/getlantern/lantern-box v0.0.112/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260812223628-131f92a74900 h1:rdM01qwaEpq92fdvOgqpJebO4RWPM/E0P2h67pqZyls=
-github.com/getlantern/radiance v0.0.0-20260812223628-131f92a74900/go.mod h1:h5kq0DGFlmIBy8gUW3oBwtEWY8rkfjxAAIn0R49fOvg=
+github.com/getlantern/radiance v0.0.0-20260814172620-f7470192fa1f h1:Pf4Be7zyYOliUgNQDzqbQ1mZInivd4N6RoPbfAJI6/E=
+github.com/getlantern/radiance v0.0.0-20260814172620-f7470192fa1f/go.mod h1:009XQnEJInnHb8noqUv+IgaO0i+yfd+42jz02CTTtH8=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Picks up getlantern/radiance#602 (merged), which pins lantern-box v0.0.112 for getlantern/lantern-box#298 — freshness-filtered external probes with a bounded worker pool.

## Device measurement

iPhone 16 / iOS 26.6, six connect/disconnect cycles per build, same phone and config, ~40 minutes apart:

| build | peak under cycling | steady |
|---|---|---|
| without #298 | **44.33 MB** | ~31 MB |
| **with #298** | **38.88 MB** | ~31 MB |

**5.45 MB off the peak (~12%)**, taking headroom from ~5.7 MB to ~11 MB against the extension's fatal 50 MB jetsam cap. Steady state was already healthy and is unchanged — the win is in the churn case, which is where the jetsam kills happened.

Caveat: single run per build, and peak varies run to run (37.9–46.1 MB observed on unchanged code). The direction matches what the change does, but a repeat would firm it up.

## Scope

`go.mod` + `go.sum` only: radiance `131f92a74900` → `f7470192fa1f`, with `lantern-box v0.0.111 → v0.0.112` following as an indirect. `go mod tidy` run before committing; `go build ./...` clean.

Verified the whole chain is present in the pinned modules rather than trusting version strings:

| fix | marker | |
|---|---|---|
| lantern-box #298 | freshness / worker-pool markers in `mutableautoselect.go` | ✅ |
| radiance #596 | `if i == 0` in `kindling/smart/client.go` | ✅ |
| radiance #597 | `SetExecutor` in `vpn/memmon.go` | ✅ |
| radiance #598 | `cap_exhausted` in `account/datacap.go` | ✅ |

## Still outstanding

- engineering#3816 / radiance#599 — clients still receive **120 outbounds**; that cap is on hold and would compound with this rather than overlap.
- engineering#3820 / radiance#601 — submitting an issue report while connected kills the tunnel; the archiver bound is up for review, and moving archive-building out of the extension is the better follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->