### PR TITLE
deps: bump radiance for mobile issue-report routing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260814172620-f7470192fa1f
+	github.com/getlantern/radiance v0.0.0-20260814190822-5559a4073bf3
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260814172620-f7470192fa1f h1:Pf4Be7zyYOliUgNQDzqbQ1mZInivd4N6RoPbfAJI6/E=
-github.com/getlantern/radiance v0.0.0-20260814172620-f7470192fa1f/go.mod h1:009XQnEJInnHb8noqUv+IgaO0i+yfd+42jz02CTTtH8=
+github.com/getlantern/radiance v0.0.0-20260814190822-5559a4073bf3 h1:8tSOpL9jRUvbopq94fgOhMvcBLwT0HHJrotcVt9cS60=
+github.com/getlantern/radiance v0.0.0-20260814190822-5559a4073bf3/go.mod h1:009XQnEJInnHb8noqUv+IgaO0i+yfd+42jz02CTTtH8=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Picks up getlantern/radiance#603 (merged) — mobile issue reports are assembled in the calling process rather than over IPC.

## What this fixes

Submitting an issue report from the iOS app **while connected** killed the tunnel (engineering#3820). Reproduced twice on iPhone 16 / iOS 26.6:

```
16:43:15.578  extension healthy — footprint 31.25 MB, available 18.75 MB
16:43:16.142  POST /issue arrives
              ...per-second memory samples stop entirely...
16:43:16      app: Error reporting issue: ipc request POST /issue failed
16:43:21      Disconnecting / Disconnected      <-- unprompted
16:43:22      retry succeeds (tunnel down, so the app assembles the archive)
```

The archive was built entirely in memory — `os.ReadFile` per file into a `bytes.Buffer` zip — inside a process with a **fatal 50 MB** jetsam cap. The log dir on that device held **42 MB** (`lantern.log` 26 MB, `lantern_ios.log` 10 MB). The extension was healthy at 31.25 MB one second before the submit, so this was the archiver, not tunnel memory growth.

Assembling in the calling process puts that work in the app, where the log dir is equally reachable through the shared App Group container and the ceiling is not 50 MB.

This was self-obscuring: you could not file a bug report from iOS while connected, which is exactly when users have something to report. Some earlier iOS submission failures attributed to network errors may have been this.

## Scope

`go.mod` only — radiance `f7470192fa1f` → `5559a4073bf3`. `go mod tidy` run before committing (no `go.sum` change needed beyond the module lines), `go build ./...` and `go vet ./lantern-core/...` clean.

## Related

- radiance#601 bounds what the archiver holds in memory regardless of which process runs it. Still worth having — the app should not read 42 MB either, and `issue.go` then `proto.Marshal`s the bytes, duplicating them again — but this bump removes the crash.
- Streaming the archive to a temp file instead of buffering remains the third piece.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->