### PR TITLE
deps: bump radiance to f59e3fe (Share My Connection peer core)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260814190822-5559a4073bf3
+	github.com/getlantern/radiance v0.0.0-20260814212003-f59e3fe0a53b
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260814190822-5559a4073bf3 h1:8tSOpL9jRUvbopq94fgOhMvcBLwT0HHJrotcVt9cS60=
-github.com/getlantern/radiance v0.0.0-20260814190822-5559a4073bf3/go.mod h1:009XQnEJInnHb8noqUv+IgaO0i+yfd+42jz02CTTtH8=
+github.com/getlantern/radiance v0.0.0-20260814212003-f59e3fe0a53b h1:AZpELfEfZ6CtP1Ys4ePnQqYZOOlKzIgVHP0KE2QHSDA=
+github.com/getlantern/radiance v0.0.0-20260814212003-f59e3fe0a53b/go.mod h1:bRXWxk44ZPox1Bkgb1oiw3QZBTkRr5C36jQPDnaz3l4=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Moves lantern main's radiance pin onto a **main** commit for the first time since the Share My Connection work started.

`5559a407` → `f59e3fe` (`v0.0.0-20260814212003-f59e3fe0a53b`)

## Why now

radiance#589 merged the peer-core stack into radiance main, so there's no longer a feature branch to trail.

The consequential part is what rides along: **radiance#600**, the client-side load report. The server-side per-peer client cap (lantern-cloud#3157, #3174) is already deployed, but it reads `active_clients` from the peer's heartbeat — and no released client sends it. Until this pin ships, lantern-cloud only ever sees the provisional counter it maintains itself, which is reset on every heartbeat. That bounds assignment *rate* (~N per 150s) rather than *concurrency*. This is the half that makes the cap mean what it says.

## Risk

Low, and the peer code ships **dormant**:

- `applyPeerShare` only runs when `peer_share_enabled` appears in a settings diff, and the setting reads false until the user opts in. Nothing here turns a client into a peer.
- The SmC UI lives in the unmerged #8819/#8820 stack, so this changes no user-visible behavior.

## Verification

- `go mod tidy` produced **zero** transitive churn — only the two radiance lines in `go.mod` and their four in `go.sum`
- `go build -tags with_gvisor,with_quic,with_wireguard,with_utls,with_grpc,with_conntrack ./...` → exit 0
- Before merging radiance#589 I trial-merged main into it and ran the SmC packages (`peer`, `unbounded`, `portforward`, `events`, `ipc`, `settings`) — all green; re-ran against the real merge commit on radiance main, also green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version for improved maintenance and compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->