### PR TITLE
deps: bump radiance for the iOS peer-share gate

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260814212003-f59e3fe0a53b
+	github.com/getlantern/radiance v0.0.0-20260816070116-e0df3f4b8c1d
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -259,8 +259,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260814212003-f59e3fe0a53b h1:AZpELfEfZ6CtP1Ys4ePnQqYZOOlKzIgVHP0KE2QHSDA=
-github.com/getlantern/radiance v0.0.0-20260814212003-f59e3fe0a53b/go.mod h1:bRXWxk44ZPox1Bkgb1oiw3QZBTkRr5C36jQPDnaz3l4=
+github.com/getlantern/radiance v0.0.0-20260816070116-e0df3f4b8c1d h1:n/iYiFPJbFzGd9C1qi5UPrQgS5RO9T0n8WBn3/Ohq7c=
+github.com/getlantern/radiance v0.0.0-20260816070116-e0df3f4b8c1d/go.mod h1:bRXWxk44ZPox1Bkgb1oiw3QZBTkRr5C36jQPDnaz3l4=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
 github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
`f59e3fe` → `e0df3f4` (`v0.0.0-20260816070116-e0df3f4b8c1d`)

Picks up radiance#605, which makes the backend refuse to serve as a peer on iOS.

## Why it matters now

#8819 landed the SmC screen on main along with the UI-side gate, so an iOS user cannot select the peer-proxy mode. But until this bump, that was the **only** layer — main's pinned radiance had no backend gate at all.

The UI gate covers the case where the UI is the one asking. It does not cover `resumePeerShareIfEnabled`, which reads the persisted `peer_share_enabled` at launch and calls `applyPeerShare` directly. A setting persisted before the platform was excluded, or arriving from another device, would take that path on every launch with nothing to stop it. This bump closes that.

It also clears the stale setting on the way through, so the state self-heals on first launch rather than retrying forever.

## Verification

- `go mod tidy` in the same commit; only the radiance lines moved in `go.mod`/`go.sum`, no transitive churn
- `go build` with lantern's tags → exit 0
- Full `./lantern-core/...` suite green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an internal dependency to a newer version for improved compatibility and maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->