### PR TITLE
utils: make the gomobile message guarantee unconditional

### DIFF
--- a/lantern-core/utils/gostack.go
+++ b/lantern-core/utils/gostack.go
@@ -19,16 +19,20 @@ import (
 // If fn panics, the panic is recovered and a zero value + error are returned
 // instead of blocking the caller forever.
 //
-// Returned errors are guaranteed to carry a non-empty, valid-UTF-8 message
-// before crossing back into gomobile's
-// objc bridge. The bridge wraps non-nil Go errors as a Universeerror whose
-// initWithRef calls [NSString initWithBytesNoCopy: ... encoding:UTF8] on the
-// raw error bytes; that returns nil for invalid UTF-8 (e.g. a gzipped 404
-// page, or a binary blob from an upstream LB), and the dictionary literal
-// `@{NSLocalizedDescriptionKey: nil}` then aborts the app with
-// "attempt to insert nil object from objects[0]". Sanitizing here means every
-// gomobile-exported function that funnels through RunOffCgoStack is safe by
-// construction, regardless of what shape of error its callee returns.
+// Returned errors always carry a frozen, valid-UTF-8 message before crossing
+// back into gomobile's objc bridge. The bridge wraps non-nil Go errors as a
+// Universeerror whose initWithRef builds
+// `@{NSLocalizedDescriptionKey: [self error]}`; [self error] calls back into
+// Go, and the result reaches [NSString initWithBytesNoCopy: ... encoding:UTF8],
+// which returns nil for invalid UTF-8 (a gzipped 404 page, a binary blob from
+// an upstream LB). Inserting that nil into the dictionary literal aborts the
+// app with "attempt to insert nil object from objects[0]".
+//
+// Because the bridge calls Error() itself rather than reusing anything checked
+// here, validating a message and then returning the callee's error would only
+// hold for an Error() that answers identically every time. The wrapper is
+// therefore unconditional: it is the frozen message, not the check, that makes
+// this safe by construction.
 func RunOffCgoStack[T any](fn func() (T, error)) (T, error) {
 	type result struct {
 		val T
@@ -63,19 +67,28 @@ type sanitizedError struct {
 func (e *sanitizedError) Error() string { return e.msg }
 func (e *sanitizedError) Unwrap() error { return e.err }
 
-func sanitizeForGomobile(err error) error {
+func sanitizeForGomobile(err error) (safe error) {
 	if err == nil {
 		return nil
 	}
+	// Error() is callee-supplied and runs here, on the cgo-callback goroutine,
+	// outside the recover that guards fn. An interface holding a typed nil
+	// pointer is non-nil but derefs on the call, and an unrecovered panic in
+	// the helper whose job is to keep the bridge safe would take the process
+	// down on the way out.
+	defer func() {
+		if r := recover(); r != nil {
+			slog.Error("panic formatting error for gomobile", "panic", r, "stack", string(debug.Stack()))
+			safe = &sanitizedError{msg: "unknown error"}
+		}
+	}()
 	msg := err.Error()
-	// The overwhelmingly common case: nothing to fix, so hand back the error
-	// itself rather than a copy that merely reads the same.
-	if msg != "" && utf8.ValidString(msg) {
-		return err
-	}
 	if !utf8.ValidString(msg) {
 		msg = strings.ToValidUTF8(msg, "?")
 	}
+	// Not for the bridge's sake — go_seq_to_objc_string returns @"" for an
+	// empty message and never reaches initWithBytesNoCopy. An error whose
+	// text is blank is just useless to whoever reads the crash report.
 	if msg == "" {
 		msg = "unknown error"
 	}

--- a/lantern-core/utils/gostack.go
+++ b/lantern-core/utils/gostack.go
@@ -79,7 +79,11 @@ func sanitizeForGomobile(err error) (safe error) {
 	defer func() {
 		if r := recover(); r != nil {
 			slog.Error("panic formatting error for gomobile", "panic", r, "stack", string(debug.Stack()))
-			safe = &sanitizedError{msg: "unknown error"}
+			// Keep the cause reachable even here. An error whose Error()
+			// panics can still be the sentinel a caller is testing for, and
+			// dropping it would make recovery silently change what errors.Is
+			// answers.
+			safe = &sanitizedError{msg: "unknown error", err: err}
 		}
 	}()
 	msg := err.Error()

--- a/lantern-core/utils/gostack_test.go
+++ b/lantern-core/utils/gostack_test.go
@@ -66,6 +66,49 @@ func TestRunOffCgoStackSanitizesUnsafeMessages(t *testing.T) {
 	}
 }
 
+// mutatingError answers differently on each call, the way an error formatting a
+// buffer another goroutine is still appending to would. The bridge calls
+// Error() itself when it builds NSLocalizedDescriptionKey, so validating a
+// message and handing back the callee's error would let the second answer —
+// the one that actually gets marshalled — be anything at all.
+type mutatingError struct{ calls int }
+
+func (e *mutatingError) Error() string {
+	e.calls++
+	if e.calls == 1 {
+		return "fine"
+	}
+	return "bad\xffbytes"
+}
+
+func TestRunOffCgoStackFreezesTheMessage(t *testing.T) {
+	in := &mutatingError{}
+	_, got := RunOffCgoStack(func() (struct{}, error) { return struct{}{}, in })
+	first := got.Error()
+	if first != "fine" {
+		t.Fatalf("first read: got %q, want %q", first, "fine")
+	}
+	if second := got.Error(); second != first {
+		t.Errorf("message not frozen: bridge would marshal %q after seeing %q", second, first)
+	}
+}
+
+// A nil *typedNilError inside a non-nil error interface derefs on Error().
+type typedNilError struct{ msg string }
+
+func (e *typedNilError) Error() string { return e.msg }
+
+func TestRunOffCgoStackSurvivesTypedNilError(t *testing.T) {
+	var typed *typedNilError
+	_, got := RunOffCgoStack(func() (struct{}, error) { return struct{}{}, typed })
+	if got == nil {
+		t.Fatal("a non-nil error interface must not come back nil")
+	}
+	if got.Error() == "" {
+		t.Error("the bridge needs a non-empty message even for this shape")
+	}
+}
+
 func TestRunOffCgoStackNilErrorStaysNil(t *testing.T) {
 	if _, err := RunOffCgoStack(func() (int, error) { return 7, nil }); err != nil {
 		t.Fatalf("nil error became %v", err)

--- a/lantern-core/utils/gostack_test.go
+++ b/lantern-core/utils/gostack_test.go
@@ -107,6 +107,16 @@ func TestRunOffCgoStackSurvivesTypedNilError(t *testing.T) {
 	if got.Error() == "" {
 		t.Error("the bridge needs a non-empty message even for this shape")
 	}
+	// Recovering from the panic must not quietly cost the caller the cause;
+	// an error that panics while formatting can still be the one they are
+	// testing for.
+	if !errors.Is(got, error(typed)) {
+		t.Error("the recovered error no longer unwraps to the original")
+	}
+	var as *typedNilError
+	if !errors.As(got, &as) {
+		t.Error("errors.As cannot reach the original through the recovery path")
+	}
 }
 
 func TestRunOffCgoStackNilErrorStaysNil(t *testing.T) {


### PR DESCRIPTION
Follow-up to a review of the `sanitizeForGomobile` change that landed with #8819. Two real defects, one of them mine.

## 1. The validity check was advisory, not a guarantee

The previous pass returned the callee's error untouched when its message was already valid UTF-8, on the assumption that the string it checked was the string the bridge would marshal. **It isn't.** From the pinned gomobile:

```go
// bind/genobjc.go:928
self = [super initWithDomain:@"go" code:1 userInfo:@{NSLocalizedDescriptionKey: [self error]}];
```

`[self error]` calls back into Go — the bridge reads `Error()` **again**, and only a deterministic `Error()` answers the same thing twice. An error formatting a buffer another goroutine is still appending to, or holding a partially-read response body, could pass the check here and still hand invalid UTF-8 to `initWithBytesNoCopy`, get `nil`, and abort on the dictionary insert.

It's the frozen message that makes this safe, not the check. So the wrapper is now unconditional. `Unwrap` still preserves `errors.Is`/`errors.As`, which is what the earlier change was protecting.

## 2. Unrecovered panic in the safety helper

`Error()` runs on the caller's goroutine after `<-ch`, outside the `recover()` that guards `fn`. An interface holding a typed nil pointer is non-nil but derefs on the call — taking the process down from inside the helper whose documented job is to be safe "regardless of what shape of error its callee returns". Now recovered. Pre-existing, not introduced by the earlier change.

## 3. A comment that pointed at the wrong failure mode

The empty-message branch is kept, but its rationale was wrong:

```c
// bind/objc/seq_darwin.m.support:140
NSString *go_seq_to_objc_string(nstring str) {
  if (str.len == 0) {  // empty string.
    return @"";
```

An empty message short-circuits and never reaches `initWithBytesNoCopy`, so it cannot cause the abort. It's kept because a blank error is useless in a crash report — not because it's unsafe. Left as-is with an honest comment, since the next person deciding whether that branch is load-bearing would otherwise be misled.

## Testing

Both claims were verified against the vendored gomobile source, not inferred from the comments. New tests:

- `TestRunOffCgoStackFreezesTheMessage` — an error that answers differently on the second call; pins that what the bridge would marshal matches what was validated
- `TestRunOffCgoStackSurvivesTypedNilError` — the typed-nil shape, which panicked before

Existing identity and sanitization tests still pass, as does `TestStartIPCServerReportsLifecycleBusy` — the main-side test whose failure started this whole thread. Full `./lantern-core/...` green, `go vet` clean.

## Known limitation

Unconditional wrapping means a direct type assertion (`err.(net.Error)` to reach `Timeout()`) no longer matches for errors crossing this boundary; `errors.Is`/`errors.As` are unaffected. No current caller does that — every `RunOffCgoStack` site in `mobile/`, `ipc_lifecycle.go`, and `ffi/` forwards the error straight to the bridge — but it's worth knowing before someone adds one.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling to ensure returned errors have stable, valid UTF-8 messages.
  * Added safe fallback messaging when an error is empty, invalid, or cannot provide a message.
  * Preserved non-nil error behavior for typed-nil errors.
* **Tests**
  * Added coverage for changing error messages, invalid error states, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->