### PR TITLE
lazily initialize the desktop auto-updater

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -278,6 +278,7 @@ jobs:
 
       - name: Linux config URL connect/disconnect integration
         if: ${{ inputs.run_config_url_smoke }}
+        timeout-minutes: 20
         shell: bash
         env:
           LANG: en_US.UTF-8

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -36,6 +36,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_config_url_smoke:
+        description: "Run Linux config URL API and UI smoke tests"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: "read"
@@ -232,9 +237,6 @@ jobs:
         env:
           LANG: en_US.UTF-8
           LC_ALL: en_US.UTF-8
-          JOIN_SERVER_CONFIG_URLS: ${{ secrets.JOIN_SERVER_CONFIG_URLS }}
-          JOIN_SERVER_CONFIG_SERVER_NAME: ${{ vars.JOIN_SERVER_CONFIG_SERVER_NAME }}
-          JOIN_SERVER_CONFIG_SKIP_CERT_VERIFICATION: "true"
         run: |
           set -euxo pipefail
           TEST_START_UTC="$(date -u '+%Y-%m-%d %H:%M:%S')"
@@ -274,7 +276,16 @@ jobs:
             exit 1
           fi
 
-          bash .github/scripts/linux_config_url_smoke.sh
+      - name: Linux config URL connect/disconnect integration
+        if: ${{ inputs.run_config_url_smoke }}
+        shell: bash
+        env:
+          LANG: en_US.UTF-8
+          LC_ALL: en_US.UTF-8
+          JOIN_SERVER_CONFIG_URLS: ${{ secrets.JOIN_SERVER_CONFIG_URLS }}
+          JOIN_SERVER_CONFIG_SERVER_NAME: ${{ vars.JOIN_SERVER_CONFIG_SERVER_NAME }}
+          JOIN_SERVER_CONFIG_SKIP_CERT_VERIFICATION: "true"
+        run: bash .github/scripts/linux_config_url_smoke.sh
 
       - name: Linux UI auth smoke integration
         if: ${{ inputs.run_auth_smoke }}

--- a/integration_test/vpn/config_url_connect_smoke_harness.dart
+++ b/integration_test/vpn/config_url_connect_smoke_harness.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lantern/core/common/app_eum.dart';
+import 'package:lantern/core/common/common.dart' show appRouter;
 import 'package:lantern/core/widgets/custom_app_bar.dart' as lantern_widgets;
 
 import 'config_url_test_env.dart';
@@ -69,13 +70,13 @@ Future<bool> _tryGoBack(WidgetTester tester) async {
     return true;
   }
 
-  try {
-    await tester.pageBack();
-    await tester.pump(const Duration(milliseconds: 250));
+  final poppedWithRouter = await appRouter.maybePop();
+  if (poppedWithRouter) {
+    await tester.pump(const Duration(milliseconds: 400));
     return true;
-  } catch (_) {
-    return false;
   }
+
+  return false;
 }
 
 Future<void> _openServerSelectionFromHome(
@@ -128,22 +129,16 @@ Future<void> _openJoinPrivateServerScreen(
 
 Future<void> _returnToServerSelection(
   WidgetTester tester, {
-  required Finder serverSelectionScreen,
-  required Finder joinPrivateServerScreen,
+  required Finder serverSelectionControl,
 }) async {
-  if (serverSelectionScreen.evaluate().isNotEmpty) {
+  if (serverSelectionControl.hitTestable().evaluate().isNotEmpty) {
     return;
   }
 
   final end = DateTime.now().add(const Duration(seconds: 20));
   while (DateTime.now().isBefore(end)) {
-    if (serverSelectionScreen.evaluate().isNotEmpty) {
+    if (serverSelectionControl.hitTestable().evaluate().isNotEmpty) {
       return;
-    }
-
-    if (joinPrivateServerScreen.evaluate().isNotEmpty) {
-      await _tryGoBack(tester);
-      continue;
     }
 
     if (await _tryGoBack(tester)) {
@@ -161,15 +156,15 @@ Future<void> _returnToServerSelection(
 
 Future<void> _returnToHome(
   WidgetTester tester, {
-  required Finder homeScreen,
+  required Finder homeControl,
 }) async {
-  if (homeScreen.evaluate().isNotEmpty) {
+  if (homeControl.hitTestable().evaluate().isNotEmpty) {
     return;
   }
 
   final end = DateTime.now().add(const Duration(seconds: 20));
   while (DateTime.now().isBefore(end)) {
-    if (homeScreen.evaluate().isNotEmpty) {
+    if (homeControl.hitTestable().evaluate().isNotEmpty) {
       return;
     }
 
@@ -180,6 +175,12 @@ Future<void> _returnToHome(
     await tester.pump(const Duration(milliseconds: 250));
   }
 
+  appRouter.popUntilRoot();
+  await tester.pump(const Duration(milliseconds: 400));
+  if (homeControl.hitTestable().evaluate().isNotEmpty) {
+    return;
+  }
+
   fail(
     'Failed to return to home screen. '
     'Visible keyed widgets: ${collectVisibleSmokeDebugKeys(tester)}',
@@ -188,14 +189,14 @@ Future<void> _returnToHome(
 
 Future<bool> _tapJoinedServerFromServerSelection(
   WidgetTester tester, {
-  required Finder serverSelectionScreen,
+  required Finder serverSelectionControl,
   required Finder privateServersTab,
   required Finder joinedServerTileByKey,
   required Duration timeout,
 }) async {
   final end = DateTime.now().add(timeout);
   while (DateTime.now().isBefore(end)) {
-    if (serverSelectionScreen.evaluate().isEmpty) {
+    if (serverSelectionControl.hitTestable().evaluate().isEmpty) {
       return false;
     }
 
@@ -323,20 +324,19 @@ Future<void> runConfigUrlConnectSmokeHarness(
 
   await _returnToServerSelection(
     tester,
-    serverSelectionScreen: serverSelectionScreen,
-    joinPrivateServerScreen: joinPrivateServerScreen,
+    serverSelectionControl: serverSelectionMoreOptions,
   );
 
   var selected = await _tapJoinedServerFromServerSelection(
     tester,
-    serverSelectionScreen: serverSelectionScreen,
+    serverSelectionControl: serverSelectionMoreOptions,
     privateServersTab: serverSelectionPrivateTab,
     joinedServerTileByKey: joinedServerTileByKey,
     timeout: const Duration(seconds: 75),
   );
 
   if (!selected) {
-    await _returnToHome(tester, homeScreen: finders.homeScreen);
+    await _returnToHome(tester, homeControl: homeLocationSetting);
     await _openServerSelectionFromHome(
       tester,
       locationSettingTile: homeLocationSetting,
@@ -345,7 +345,7 @@ Future<void> runConfigUrlConnectSmokeHarness(
 
     selected = await _tapJoinedServerFromServerSelection(
       tester,
-      serverSelectionScreen: serverSelectionScreen,
+      serverSelectionControl: serverSelectionMoreOptions,
       privateServersTab: serverSelectionPrivateTab,
       joinedServerTileByKey: joinedServerTileByKey,
       timeout: const Duration(seconds: 45),

--- a/integration_test/vpn/config_url_connect_smoke_harness.dart
+++ b/integration_test/vpn/config_url_connect_smoke_harness.dart
@@ -176,9 +176,12 @@ Future<void> _returnToHome(
   }
 
   appRouter.popUntilRoot();
-  await tester.pump(const Duration(milliseconds: 400));
-  if (homeControl.hitTestable().evaluate().isNotEmpty) {
-    return;
+  final rootEnd = DateTime.now().add(const Duration(seconds: 20));
+  while (DateTime.now().isBefore(rootEnd)) {
+    await tester.pump(const Duration(milliseconds: 100));
+    if (homeControl.hitTestable().evaluate().isNotEmpty) {
+      return;
+    }
   }
 
   fail(

--- a/lib/core/updater/updater.dart
+++ b/lib/core/updater/updater.dart
@@ -22,12 +22,12 @@ class Updater with UpdaterListener {
     Future<void> Function()? quitForUpdate,
   }) : _androidSideloadUpdater =
            androidSideloadUpdater ?? AndroidSideloadUpdater(),
-       _autoUpdater = autoUpdater ?? AutoUpdater.instance,
+       _autoUpdater = autoUpdater,
        _isWindowsPlatform = isWindows ?? (!kIsWeb && Platform.isWindows),
        _quitForUpdate = quitForUpdate;
 
   final AndroidSideloadUpdater _androidSideloadUpdater;
-  final AutoUpdater _autoUpdater;
+  AutoUpdater? _autoUpdater;
   final bool _isWindowsPlatform;
   final Future<void> Function()? _quitForUpdate;
 
@@ -39,6 +39,11 @@ class Updater with UpdaterListener {
 
   bool get _isSupportedPlatform =>
       !kIsWeb && (Platform.isMacOS || Platform.isWindows || Platform.isAndroid);
+
+  // AutoUpdater opens its native event channel as soon as the singleton is
+  // created. Keep that initialization off Linux and Android, where the
+  // desktop plugin is not registered.
+  AutoUpdater get _desktopAutoUpdater => _autoUpdater ??= AutoUpdater.instance;
 
   Future<void> init() => _initialization ??= _initialize();
 
@@ -77,8 +82,9 @@ class Updater with UpdaterListener {
     try {
       final buildType = AppBuildInfo.buildType;
       final feedUrl = AppUrls.appcastFor(buildType);
+      final autoUpdater = _desktopAutoUpdater;
       if (!_listenerRegistered) {
-        _autoUpdater.addListener(this);
+        autoUpdater.addListener(this);
         _listenerRegistered = true;
       }
       if (Platform.isWindows) {
@@ -89,15 +95,15 @@ class Updater with UpdaterListener {
           appLogger.warning('Failed to set WinSparkle build version', e, st);
         }
       }
-      await _autoUpdater.setFeedURL(feedUrl);
-      await _autoUpdater.setScheduledCheckInterval(3600);
+      await autoUpdater.setFeedURL(feedUrl);
+      await autoUpdater.setScheduledCheckInterval(3600);
 
       // Background check after startup (avoid modal immediately on launch)
       const firstPromptDelay = Duration(seconds: 45);
       unawaited(
         Future<void>.delayed(firstPromptDelay, () async {
           try {
-            await _autoUpdater.checkForUpdates(inBackground: true);
+            await autoUpdater.checkForUpdates(inBackground: true);
           } catch (e, st) {
             appLogger.error('Failed to check for auto-updates', e, st);
           }
@@ -131,7 +137,7 @@ class Updater with UpdaterListener {
       );
       return;
     }
-    await _autoUpdater.checkForUpdates();
+    await _desktopAutoUpdater.checkForUpdates();
   }
 
   @override

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -1220,7 +1220,8 @@ class _GlobeViewState extends ConsumerState<_GlobeView> {
       t.cancel();
     }
     _pendingRemovals.clear();
-    _globeController.dispose();
+    // RotatingGlobe owns and disposes the controller's rotation animation.
+    // Disposing the parent controller here would dispose it a second time.
     super.dispose();
   }
 

--- a/test/core/updater/updater_test.dart
+++ b/test/core/updater/updater_test.dart
@@ -1,10 +1,33 @@
 import 'dart:async';
 
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lantern/core/updater/updater.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  test(
+    'constructing the updater does not initialize desktop channels',
+    () async {
+      const eventChannel = MethodChannel(
+        'dev.leanflutter.plugins/auto_updater_event',
+      );
+      final messenger =
+          TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+      var channelCalls = 0;
+      messenger.setMockMethodCallHandler(eventChannel, (_) async {
+        channelCalls++;
+        return null;
+      });
+      addTearDown(() => messenger.setMockMethodCallHandler(eventChannel, null));
+
+      Updater();
+      await Future<void>.delayed(Duration.zero);
+
+      expect(channelCalls, 0);
+    },
+  );
 
   group('WinSparkle shutdown', () {
     test('quits when WinSparkle is ready to install', () async {


### PR DESCRIPTION
Lazily creates AutoUpdater only on macOS and Windows, preventing Linux and Android from subscribing to an unsupported native event channel.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved updater startup behavior by deferring desktop update initialization until needed.
  * Prevented unnecessary desktop event-channel activity during updater creation.
  * Preserved reliable desktop update checks and background scheduling.
  * Improved configuration URL connection reliability, including server selection and navigation recovery.
  * Prevented potential cleanup issues when leaving the connection-sharing screen.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->