### PR TITLE
comments: state the NE start budget as measured, not documented

### DIFF
--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -39,10 +39,17 @@ class ExtensionProvider: NEPacketTunnelProvider {
     }
 
     // Bringing the VPN up now waits for the first config, which takes seconds
-    // on a censored network. iOS kills this extension if startTunnel has not
-    // returned by ~7.5s, so the connect runs after we return
+    // on a censored network, so the connect runs after we return: the system
+    // tears the tunnel down while startTunnel is still outstanding
     // (getlantern/engineering#3822). Nothing reached the system from here
     // anyway: startVPN reports its own failures via cancelTunnelWithError.
+    //
+    // That budget is measured, not documented. Apple publishes no startTunnel
+    // completion deadline, and the teardowns never called stopTunnel, so no
+    // NEProviderStopReason was captured. The evidence is 14 system-initiated
+    // teardowns in one CN session, none app-requested, median 7.51s. Returning
+    // promptly does not depend on the figure — only on the budget being finite
+    // and shorter than the work.
     // Returning marks the provider started, but no tunnel settings exist until
     // the connect below applies them, so the system claims no routes and
     // traffic still egresses directly. Reassert until the connect finishes so

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -39,8 +39,9 @@ class ExtensionProvider: NEPacketTunnelProvider {
     }
 
     // Bringing the VPN up now waits for the first config, which takes seconds
-    // on a censored network, so the connect runs after we return: the system
-    // tears the tunnel down while startTunnel is still outstanding
+    // on a censored network, so the connect is dispatched rather than awaited —
+    // it may begin before this returns, it just cannot delay the return. The
+    // system tears the tunnel down while startTunnel is still outstanding
     // (getlantern/engineering#3822). Nothing reached the system from here
     // anyway: startVPN reports its own failures via cancelTunnelWithError.
     //

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -45,11 +45,12 @@ class ExtensionProvider: NEPacketTunnelProvider {
     // anyway: startVPN reports its own failures via cancelTunnelWithError.
     //
     // That budget is measured, not documented. Apple publishes no startTunnel
-    // completion deadline, and the teardowns never called stopTunnel, so no
+    // completion deadline, and the teardowns never called stopTunnel(with:), so no
     // NEProviderStopReason was captured. The evidence is 14 system-initiated
     // teardowns in one CN session, none app-requested, median 7.51s. Returning
     // promptly does not depend on the figure — only on the budget being finite
     // and shorter than the work.
+    //
     // Returning marks the provider started, but no tunnel settings exist until
     // the connect below applies them, so the system claims no routes and
     // traffic still egresses directly. Reassert until the connect finishes so

--- a/lantern-core/mobile/ipc_lifecycle.go
+++ b/lantern-core/mobile/ipc_lifecycle.go
@@ -239,7 +239,7 @@ func publishIPCResources(generation uint64, resources ipcResources) error {
 	//
 	// The deadline that killed it is unconfirmed — measured, not documented.
 	// Apple publishes no startTunnel completion budget, and the teardowns never
-	// called stopTunnel, so no NEProviderStopReason was ever captured. What the
+	// called stopTunnel(with:), so no NEProviderStopReason was ever captured. What the
 	// logs show is 14 system-initiated teardowns, none app-requested, median
 	// 7.51s. Detaching does not depend on the number: it only depends on some
 	// finite budget shorter than the bootstrap. radiance#607 removed that

--- a/lantern-core/mobile/ipc_lifecycle.go
+++ b/lantern-core/mobile/ipc_lifecycle.go
@@ -234,11 +234,17 @@ func publishIPCResources(generation uint64, resources ipcResources) error {
 	}
 	// Launch the bootstrap only now, on the one path where the resources go
 	// live. Start runs detached so the caller never inherits its cost: it used
-	// to block ~6.6s on a censored network rebuilding kindling, which killed
-	// the iOS caller outright — a NEPacketTunnelProvider iOS stops at ~7.5s
-	// (getlantern/engineering#3822). radiance#607 removed that rebuild, but
-	// detaching keeps the deadline independent of whatever Start grows into.
-	// The app process has always run it this way.
+	// to block ~6.6s on a censored network rebuilding kindling, and the system
+	// tore the tunnel down before it finished (getlantern/engineering#3822).
+	//
+	// The deadline that killed it is unconfirmed — measured, not documented.
+	// Apple publishes no startTunnel completion budget, and the teardowns never
+	// called stopTunnel, so no NEProviderStopReason was ever captured. What the
+	// logs show is 14 system-initiated teardowns, none app-requested, median
+	// 7.51s. Detaching does not depend on the number: it only depends on some
+	// finite budget shorter than the bootstrap. radiance#607 removed that
+	// rebuild, but detaching keeps this independent of whatever Start grows
+	// into. The app process has always run it this way.
 	ipcLifecycle.bootstrapped = bootstrapBackend(resources.backend)
 	ipcLifecycle.backend = resources.backend
 	ipcLifecycle.server = resources.server

--- a/macos/PacketTunnel/SingBox/ExtensionProvider.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionProvider.swift
@@ -39,10 +39,11 @@ public class ExtensionProvider: NEPacketTunnelProvider {
     }
 
     // Bringing the VPN up now waits for the first config, which takes seconds
-    // on a censored network, so it runs after startTunnel returns rather than
-    // holding the system's start call open (getlantern/engineering#3822).
-    // Nothing reached the system from here anyway: startVPN reports its own
-    // failures via cancelTunnelWithError.
+    // on a censored network, so the connect is dispatched rather than awaited —
+    // it may begin before this returns, it just cannot hold the system's start
+    // call open (getlantern/engineering#3822). Nothing reached the system from
+    // here anyway: startVPN reports its own failures via cancelTunnelWithError.
+    //
     // Returning marks the provider started, but no tunnel settings exist until
     // the connect below applies them, so the system claims no routes and
     // traffic still egresses directly. Reassert until the connect finishes so


### PR DESCRIPTION
## Why

#8993 and its issue described the iOS start budget as "~7.5s", in code comments and prose, as though it were a documented Apple constant. It isn't, and it should not be recorded that way in the tree.

Re-derived from ticket #181617's own `flutter.log` rather than taken from the diagnosis:

| | |
|---|---|
| Teardowns measured | 14 |
| App-requested | **0** — no state-change request within 3s of any of them |
| Median `Connecting → Disconnecting` | **7.51s** |
| Within 6.5–8.6s | 11 of 14 |
| Outliers | 2.53s, 5.31s, 11.95s |

So the teardown being **system-initiated** is well supported: Dart only ever logs `hop=dart_applied` (applying a status it received), never a disconnect request, and nothing in our own code is near that interval — the closest is `runBlockingTimeout = 15s`.

What is *not* supported is naming the timer. Apple publishes no `startTunnel` completion deadline for `NEPacketTunnelProvider`; `stopTunnel(with:)` was never called in any of the 14 cycles, so no `NEProviderStopReason` was ever captured; and the three outliers do not fit a hard constant — the 11.95s one is the single launch that reached `IPC server started`, i.e. it got further and lived longer.

## What changed

Comments only, no behavior change. Both sites now say what was measured and note the mechanism is unconfirmed:

- `lantern-core/mobile/ipc_lifecycle.go` (`publishIPCResources`)
- `ios/Tunnel/SingBox/ExtensionProvider.swift` (`startTunnel`)

Each also records that the fix never depended on the figure — only on the budget being finite and shorter than the bootstrap, which the data does establish.

## Why bother

Left as a bare number it reads as an Apple constant. If the real budget differs by iOS version or device — and the outliers hint it may not be a single fixed value — that framing sends the next reader looking in the wrong place. The same caveat is going on getlantern/engineering#3822, which is closed and would otherwise read as settled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SkKS8hGeHM5g4BDPvxcamg


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified mobile and desktop VPN tunnel startup and teardown behavior based on observed system behavior.
  * Documented that connection setup begins asynchronously while startup continues independently.
  * Added context explaining that startup work must fit within the system’s available time window.
  * Clarified how startup failures are reported through tunnel cancellation.
  * No user-facing functionality or runtime behavior changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->