### PR TITLE
smc: fall back to Unbounded on a failed start instead of also reporting it

### DIFF
--- a/lib/features/home/provider/radiance_settings_providers.dart
+++ b/lib/features/home/provider/radiance_settings_providers.dart
@@ -111,10 +111,14 @@ class RadianceSettings extends _$RadianceSettings {
 
   /// Enable/disable the peer-proxy (Share My Connection) radiance
   /// setting. Returns the underlying Either so the caller can react to
-  /// failure — share_my_connection.dart's _start depends on it to
-  /// revert UI state if the setting flip fails before peer.Client
-  /// emits its own phase=error StatusEvent. Internal logging still
-  /// happens on failure for fire-and-forget call sites.
+  /// failure.
+  ///
+  /// That Either carries peer.Client.Start's own failure, not merely a
+  /// failure to flip the setting: radiance runs Start synchronously under
+  /// the settings patch and propagates its error out. So a caller sees the
+  /// same failure twice — here and as a phase=error StatusEvent — and must
+  /// not treat this one as a distinct, earlier class of problem. Internal
+  /// logging still happens on failure for fire-and-forget call sites.
   Future<Either<Failure, Unit>> setPeerProxy(bool value) async {
     final svc = ref.read(lanternServiceProvider);
     final result = await svc.setPeerProxyEnabled(value);

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -392,32 +392,35 @@ class ShareNotifier extends Notifier<ShareState> {
         // bus → core.go listenPeerConnectionEvents → FlutterEvent → our
         // Dart subscription.
         //
-        // Failures AFTER peer.Client.Start surface via a phase=error
-        // StatusEvent that _handlePeerStatus turns into a terminal-
-        // state reset (mode=off, phase=error). Failures BEFORE
-        // Start (IPC error, MissingPluginException, core not
-        // initialized) don't go through that path, so check the
-        // setPeerProxy Either here and revert UI state to
-        // mode=off, phase=error directly.
+        // A failed Start reports itself twice: as a phase=error
+        // StatusEvent, and as the error setPeerProxy returns, since
+        // radiance propagates Start's error out through the settings
+        // patch. Both are handled the same way — fall back to Unbounded
+        // — and _fallbackToUnbounded ignores whichever arrives second.
         final smcRes = await widgetRef
             .read(radianceSettingsProvider.notifier)
             .setPeerProxy(true);
         smcRes.fold(
           (err) {
-            appLogger.error('SmC setPeerProxy failed: ${err.error}');
-            _stopEventSubscription();
-            state = ShareState(
-              active: false,
-              probing: false,
-              mode: ShareMode.off,
-              activeCount: 0,
-              // Preserve lifetime totalCount across a failed Start — the
-              // persisted "Total people helped to date" stat is set
-              // independent of the active session's outcome.
-              totalCount: state.totalCount,
-              phase: SharePhase.error,
-              errorMessage: err.error,
+            // Falls back rather than reporting. setPeerProxy returns
+            // peer.Client.Start's own failure, not just the pre-Start errors
+            // this once assumed, and a router that will not forward a port is
+            // the most common way it fails. Reporting that as terminal put
+            // "Couldn't share: ..." on the card while Unbounded was already
+            // running underneath, so the user saw a failure and a working
+            // session at once.
+            //
+            // radiance rolls PeerShareEnabledKey back before returning, so SmC
+            // is definitively not running and falling back is all that is left
+            // to do. Genuine pre-Start failures (IPC down,
+            // MissingPluginException) land here too and want the same thing:
+            // the user asked to share, and Unbounded is the way that still
+            // works. If it does not either, _fallbackToUnbounded surfaces
+            // that.
+            appLogger.error(
+              'SmC setPeerProxy failed, falling back to Unbounded: ${err.error}',
             );
+            unawaited(_fallbackToUnbounded(widgetRef));
           },
           (_) => null,
         );
@@ -732,6 +735,12 @@ class ShareNotifier extends Notifier<ShareState> {
   // the new (Unbounded) mode. _stop is the only teardown path for the
   // subscription, and the error path doesn't go through _stop.
   Future<void> _fallbackToUnbounded(WidgetRef widgetRef) async {
+    // One failed Start arrives here twice: from the phase=error event and from
+    // setPeerProxy's returned error. Without this guard Unbounded is started
+    // twice and the second call races the first one's state. A plain field
+    // check suffices — both callers run on the main isolate and the mode flip
+    // below is synchronous, so whichever arrives second always observes it.
+    if (state.mode == ShareMode.unbounded) return;
     state = ShareState(
       active: true,
       probing: false,

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -415,8 +415,7 @@ class ShareNotifier extends Notifier<ShareState> {
             // to do. Genuine pre-Start failures (IPC down,
             // MissingPluginException) land here too and want the same thing:
             // the user asked to share, and Unbounded is the way that still
-            // works. If it does not either, _fallbackToUnbounded surfaces
-            // that.
+            // works. If that fails too, _fallbackToUnbounded surfaces it.
             appLogger.error(
               'SmC setPeerProxy failed, falling back to Unbounded: ${err.error}',
             );
@@ -679,6 +678,14 @@ class ShareNotifier extends Notifier<ShareState> {
   // regardless of SmC's outcome, and raw protocol error text never
   // reaches the status card.
   void _handlePeerStatus(String message, WidgetRef widgetRef) {
+    // peer-status describes an SmC session, so it has nothing to say about any
+    // other mode. Dropping it otherwise is what keeps a failed start from
+    // reporting itself after the fallback has already handled it: if
+    // setPeerProxy's error arrives before the phase=error event, mode is
+    // already unbounded by the time that event lands, the SmC branches below
+    // no longer match, and the copyWith at the end would write the SmC error
+    // straight onto the working Unbounded session.
+    if (state.mode != ShareMode.smc) return;
     try {
       final payload = jsonDecode(message) as Map<String, dynamic>;
       final phase = SharePhase.fromWire(payload['phase'] as String?);
@@ -693,14 +700,14 @@ class ShareNotifier extends Notifier<ShareState> {
       //   idle  → clean stop (user toggled off, or radiance
       //           transitioned through stopping → idle). Tear down
       //           the event subscription and return to off.
-      if (phase == SharePhase.error && state.mode == ShareMode.smc) {
+      if (phase == SharePhase.error) {
         appLogger.info(
           'SmC start failed, falling back to Unbounded: ${errMsg ?? ""}',
         );
         unawaited(_fallbackToUnbounded(widgetRef));
         return;
       }
-      if (phase == SharePhase.idle && state.mode == ShareMode.smc) {
+      if (phase == SharePhase.idle) {
         _stopEventSubscription();
         // Preserve totalCount across the radiance-driven idle reset —
         // lifetime running total is persisted via appSettingProvider and


### PR DESCRIPTION
Reported from a nightly: Unbounded is running ("Waiting for connections…") **and** the card shows a failure, with the toggle off.

> Couldn't share: PlatformException(SET_PEER_PROXY_ERROR, ipc: status 500: start peer share: Your router accepted the port mapping but isn't forwarding traffic to this computer.…)

Both things are true at once because **a failed SmC start reports itself twice, and only one of the two handlers did the right thing.**

## The two paths

`setPeerProxy` returns `peer.Client.Start`'s own error — radiance runs `Start` synchronously under the settings patch and propagates it out (`backend/peer_share.go:95-104`). But `_start` assumed that `Either` only ever carried *pre-Start* failures (IPC down, missing plugin), and treated it as terminal. Its own comment said so:

> Failures AFTER peer.Client.Start surface via a phase=error StatusEvent… Failures BEFORE Start (IPC error, MissingPluginException, core not initialized) don't go through that path

That was wrong, so the terminal branch ran for the failure it was never meant to see — while the `phase=error` event separately did the intended thing and fell back.

```mermaid
sequenceDiagram
    autonumber
    participant U as user
    participant T as toggle<br/>share_my_connection.dart
    participant S as _start<br/>share_my_connection.dart
    participant H as _handlePeerStatus<br/>share_my_connection.dart
    participant R as applyPeerShare<br/>backend/peer_share.go
    participant P as Client.Start<br/>peer/peer.go

    U->>T: tap share
    T->>T: share_my_connection.dart:343<br/>probeUPnP() → true ✅
    Note over T: share_my_connection.dart:351<br/>UPnP looks usable, so mode = smc ⚠️
    T->>S: _start(mode: smc)
    S->>R: setPeerProxy(true)
    R->>P: peer_share.go:95<br/>Start(ctx) — synchronous
    P->>P: peer.go:427<br/>verify → 422, router never forwarded
    P-->>H: peer.go:351<br/>emitError(port_unreachable)
    H->>H: :696 phase=error + mode=smc<br/>_fallbackToUnbounded() ✅
    Note over H: Unbounded starts —<br/>"Waiting for connections…"
    P-->>R: error
    R-->>S: peer_share.go:104<br/>"start peer share: …"
    rect rgba(255, 200, 200, 0.3)
        Note over S: :404 fold(err) treats it as a<br/>pre-Start failure → mode=off,<br/>phase=error, message on card 🐛
    end
    S-->>U: a failure, next to a working session
```

The ordering is why both artifacts are visible: the event lands during the `await`, so the fallback runs first and the terminal reset overwrites its state afterwards.

## Why this is the common case, not an edge case

`toggle` picks the mode from `probeUPnP()`, which only asks whether a usable IGD *answers* (`share_my_connection.dart:343`). A router can answer discovery, accept `AddPortMapping`, and still not forward — and that is only discoverable at verify, long after the mode was chosen. So the failure that took the terminal path is the single most likely way SmC fails.

## What changed

- **Both handlers now fall back.** `fold(err)` calls `_fallbackToUnbounded` instead of reporting. By the time it returns, radiance has already rolled `PeerShareEnabledKey` back, so SmC is definitively not running and falling back is all that is left to do. Genuine pre-Start failures land here too and want the same thing — the user asked to share, and Unbounded is the way that still works. If *that* fails, the existing nested error path surfaces it.
- **`_fallbackToUnbounded` ignores a second arrival.** Nothing previously stopped one failure from starting Unbounded twice, with the second call racing the first one's state. A plain field check is enough: both callers run on the main isolate and the mode flip is synchronous.
- **Dropped `_stopEventSubscription()` from that branch.** It was tearing down the subscription the Unbounded session needs — `_fallbackToUnbounded` documents that it deliberately keeps it.
- **Two comments asserting the old contract are corrected**, including `setPeerProxy`'s docstring, which claimed the same thing and sent me looking in the wrong place first.

## Found in review: the opposite ordering had the same bug

The first version of this fix only closed one of the two orderings. If `setPeerProxy`'s error arrives *before* the `phase=error` event, `_fallbackToUnbounded` flips `mode` to `unbounded` synchronously — so when that event lands, both SmC branches fail to match and the trailing `copyWith` writes the SmC error straight onto the working Unbounded session. The card shows the failure again, which is precisely what this PR set out to stop.

`_handlePeerStatus` now drops any `peer-status` event unless `mode == smc`. That event describes an SmC session and has nothing to say about another mode, so this is the shape of the invariant rather than a patch for one ordering — and it makes the per-branch `&& state.mode == ShareMode.smc` checks redundant, so the invariant now lives in one place.

With both guards, whichever path arrives second is inert: event-first is absorbed by `_fallbackToUnbounded`'s re-entry check, error-first by this one.

## Not a radiance regression

Worth stating, since the message in the report is new: the readable text comes from radiance#609, but the double-handling predates it. Before that change the same two paths ran and produced the same inconsistent state — the card just showed a four-deep wrapped error instead of a sentence. #609 made a pre-existing bug legible rather than causing it. The last functional change to this file (#8820) is older than either.

## Tests

**None, and that is a real gap.** There are no tests for this file today, and covering this needs `get_it` registration, a `SharedPreferencesWithCache` mock, and a widget test purely to obtain a `WidgetRef` — the notifier's start path is private and reached through `toggle(BuildContext, WidgetRef)`. Worth building, but not while a nightly is showing users a failure for a session that works.

A test would drive: consent pre-acked, `getPeerManualPort` → non-zero (skips the probe), `setPeerProxyEnabled` → `Left`, then assert `errorMessage == null`, `mode == unbounded`, and `setUnboundedEnabled` called exactly once — that last one being the guard.

Verified by `flutter analyze` (clean on both changed directories; the one reported issue is pre-existing `unnecessary_import` in `home_notifier.dart`, untouched here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sharing now automatically falls back to an unbounded connection when startup encounters a proxy failure.

* **Bug Fixes**
  * Prevented duplicate failure signals from triggering multiple fallback attempts.
  * Sharing no longer incorrectly resets to an off/error state after certain startup failures.

* **Documentation**
  * Clarified how proxy startup failures are reported, including possible duplicate notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
