### PR TITLE
build: bump radiance for samizdat dial retry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260818193632-397f6e0a2b8d
+	github.com/getlantern/radiance v0.0.0-20260819172740-bb1920aa7ddf
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -169,12 +169,12 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7 // indirect
-	github.com/getlantern/lantern-box v0.0.113 // indirect
+	github.com/getlantern/lantern-box v0.0.114 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b // indirect
-	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 // indirect
+	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 // indirect
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb // indirect
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7 h1:uQWqnkaLL5n4BmTly7a+xjySH9bQnz3vB+Gvgs1Bwgw=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.113 h1:G48dLWe1SQo8Ec7PC2vDn2FLbwCmlzwztKc7zT10pgI=
-github.com/getlantern/lantern-box v0.0.113/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
+github.com/getlantern/lantern-box v0.0.114 h1:KlguJNuj3QdEyVTAVZoGN2i880dgzrR1w+n8KgdzTMM=
+github.com/getlantern/lantern-box v0.0.114/go.mod h1:8pVq9ECh1OCZRMSOn5YfLxHwS2OE2BAaXdIKY62y2x4=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
@@ -259,10 +259,10 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260818193632-397f6e0a2b8d h1:Nx1S3lFcj4mspw8oYxxuJMIU0aqnPopApsqPo3YxsvA=
-github.com/getlantern/radiance v0.0.0-20260818193632-397f6e0a2b8d/go.mod h1:k6Id9/1wnBRfuOSEh4Llqfym2GjRqxmzhrP+x4B9Eg4=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
+github.com/getlantern/radiance v0.0.0-20260819172740-bb1920aa7ddf h1:qBomJ7q43pJTKKFxClsDjI+nj6IgRWaSrQOsvFSXDJo=
+github.com/getlantern/radiance v0.0.0-20260819172740-bb1920aa7ddf/go.mod h1:RxYKJrYTMQig/3zNGs/JyKZtUcJMWPzgSZzrKPGhyCo=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
## What

Final link in the samizdat dial-retry chain. Bumps `radiance` to `v0.0.0-20260819172740-bb1920aa7ddf`, which carries:

| module | from | to | |
|---|---|---|---|
| `getlantern/radiance` | `20260818193632-397f6e0a2b8d` | `20260819172740-bb1920aa7ddf` | direct |
| `getlantern/lantern-box` | `v0.0.113` | `v0.0.114` | indirect |
| `getlantern/samizdat` | `20260724223841-a5ee9ab56830` | `20260819153658-ebc74116a064` | indirect |

Dependency bump only — no lantern code changes.

## Why

Closes out [getlantern/samizdat#15](https://github.com/getlantern/samizdat/pull/15) → [lantern-box#308](https://github.com/getlantern/lantern-box/pull/308) → [radiance#611](https://github.com/getlantern/radiance/pull/611).

On adversarial ISPs, DPI resets the shared TLS+H2 conn to a Samizdat server. `connPool.getTransport` could hand back a pooled transport whose conn was already dead but not yet marked closed; `openTunnel` then failed conn-fatally and retired it, but `Client.DialContext` reported a hard dial failure even though the next `getTransport` would have produced a working transport. The user-visible effect was sustained bursts of `use of closed network connection` dial failures against otherwise-healthy servers. `DialContext` now redials on a fresh transport, bounded at 3 attempts; caller cancellation and non-200 CONNECT responses still fail immediately.

## Verification

```
go mod tidy      # exit 0, no incidental churn — diff is exactly the 3 module lines + go.sum hashes
go build ./...   # exit 0
go test ./...    # exit 0, 6 packages ok
```

Because this repo ships through `gomobile bind`, I also checked the **resolved** module graph rather than trusting `go.mod` — this is the check that would have caught the 2026-04-13 stale-`go.sum` regression, where a release binary compiled in `lantern-box@v0.0.58` despite `go.mod` declaring `v0.0.65`:

```
$ go list -m github.com/getlantern/radiance github.com/getlantern/lantern-box github.com/getlantern/samizdat
github.com/getlantern/radiance   v0.0.0-20260819172740-bb1920aa7ddf
github.com/getlantern/lantern-box v0.0.114
github.com/getlantern/samizdat   v0.0.3-0.20260819153658-ebc74116a064
```

`go.sum` carries exactly two entries each for `samizdat` and `lantern-box` (`h1:` + `/go.mod`) with no stale prior versions left behind, so there's no older hash-valid version for the toolchain to fall back to.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies to newer versions.
  * No user-facing functionality or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->