### PR TITLE
deps: bump radiance for ordered event delivery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ replace github.com/quic-go/qpack => github.com/quic-go/qpack v0.5.1
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260818193632-397f6e0a2b8d
+	github.com/getlantern/radiance v0.0.0-20260819172740-bb1920aa7ddf
 	github.com/sagernet/sing-box v1.12.22
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0
@@ -169,12 +169,12 @@ require (
 	github.com/getlantern/domainfront v0.0.0-20260722204513-8c1f8acfa715 // indirect
 	github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 // indirect
 	github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7 // indirect
-	github.com/getlantern/lantern-box v0.0.113 // indirect
+	github.com/getlantern/lantern-box v0.0.114 // indirect
 	github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 // indirect
 	github.com/getlantern/osversion v0.0.0-20240418205916-2e84a4a4e175 // indirect
 	github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 // indirect
 	github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b // indirect
-	github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 // indirect
+	github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 // indirect
 	github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb // indirect
 	github.com/getlantern/timezone v0.0.0-20210901200113-3f9de9d360c9 // indirect
 	github.com/go-json-experiment/json v0.0.0-20250103232110-6a9a0fde9288 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3 h1:YPBbuyvd
 github.com/getlantern/keepcurrent v0.0.0-20260616120552-f204338b01a3/go.mod h1:ag5g9aWUw2FJcX5RVRpJ9EBQBy5yJuy2WXDouIn/m4w=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7 h1:uQWqnkaLL5n4BmTly7a+xjySH9bQnz3vB+Gvgs1Bwgw=
 github.com/getlantern/kindling v0.0.0-20260818180827-1583458ab9b7/go.mod h1:ZEPFiB6rH6MtMN1O7b5gE+LJpCsRFzAn4u8lbIxHh3w=
-github.com/getlantern/lantern-box v0.0.113 h1:G48dLWe1SQo8Ec7PC2vDn2FLbwCmlzwztKc7zT10pgI=
-github.com/getlantern/lantern-box v0.0.113/go.mod h1:b+gDOk1Wgd/cEL4Q0cSQJAfZuNQPCqIDwNhxXwLPg8g=
+github.com/getlantern/lantern-box v0.0.114 h1:KlguJNuj3QdEyVTAVZoGN2i880dgzrR1w+n8KgdzTMM=
+github.com/getlantern/lantern-box v0.0.114/go.mod h1:8pVq9ECh1OCZRMSOn5YfLxHwS2OE2BAaXdIKY62y2x4=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9 h1:6seyD2f9tz2am0YQd/Qn+q7LFiiQgnmxgwWFnVceGZw=
 github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9/go.mod h1:s0VKrlJf/z+M0U8IKHFL2hfuflocRw3SINmMacrTlMA=
 github.com/getlantern/lantern-water v0.0.0-20260520145825-958775d51395 h1:grfGavAUp2E9w9ZoJuM3FyWyQ0sCJ64V4ZMKtZKRqTc=
@@ -259,10 +259,10 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260818193632-397f6e0a2b8d h1:Nx1S3lFcj4mspw8oYxxuJMIU0aqnPopApsqPo3YxsvA=
-github.com/getlantern/radiance v0.0.0-20260818193632-397f6e0a2b8d/go.mod h1:k6Id9/1wnBRfuOSEh4Llqfym2GjRqxmzhrP+x4B9Eg4=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830 h1:RZd3CELOtQUEzIE5kPdEO9HYg+7JYbR3OTdC+3P/wng=
-github.com/getlantern/samizdat v0.0.3-0.20260724223841-a5ee9ab56830/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
+github.com/getlantern/radiance v0.0.0-20260819172740-bb1920aa7ddf h1:qBomJ7q43pJTKKFxClsDjI+nj6IgRWaSrQOsvFSXDJo=
+github.com/getlantern/radiance v0.0.0-20260819172740-bb1920aa7ddf/go.mod h1:RxYKJrYTMQig/3zNGs/JyKZtUcJMWPzgSZzrKPGhyCo=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
+github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb/go.mod h1:GkPT5P9JoOTIRXRmFWxYgu1hhXgTFFTNc2hoG7WQc3g=
 github.com/getlantern/sing v0.7.18-lantern h1:QKGgIUA3LwmKYP/7JlQTRkxj9jnP4cX2Q/B+nd8XEjo=


### PR DESCRIPTION
Bumps radiance to `bb1920a` so the ordered event-delivery fix actually reaches a build. The pin was at `397f6e0` (the #609 merge), so everything below was merged but not shipping.

## What this picks up

- **[radiance#610](https://github.com/getlantern/radiance/pull/610) — ordered event delivery.** `events.Emit` spawned a goroutine per callback *per event*, so nothing ordered two `Emit` calls against each other. Consumers that render the newest frame got an arbitrary one: emitting eight events to one subscriber delivered them out of order in **200 of 200 runs**. This is the cause of the share card sitting on "discovering public IP" after the peer had moved on.
- **[radiance#608](https://github.com/getlantern/radiance/pull/608)** — UPnP failure logging, plus a real mapping leak: `MapPort`'s local timeout branch claimed to clean up after itself but the cleanup was gated on `ctx.Err()`, so a timeout with a live context left an untracked forward on the router.
- **radiance#611** — samizdat dial retry.

## Transitive bumps, called out deliberately

radiance moved two of its own deps, so they come along:

| | from | to |
|---|---|---|
| `lantern-box` | v0.0.113 | v0.0.114 |
| `samizdat` | `a5ee9ab` | `ebc7411` |

Flagging rather than burying, because a `lantern-box` bump has silently broken this repo twice: once when v0.0.101 changed the `user_failures` JSON shape and broke Dart deserialization (#8929), and once when a stale `go.sum` let `gomobile bind` resolve an older version than `go.mod` declared, shipping a release with Reflex quietly missing from `supportedProtocols`.

So: `go mod tidy` ran with the bump, `go.mod` and `go.sum` are committed together in one commit, and `go mod verify` reports all modules verified.

## Verification

CI's own commands, run locally with the full tag set:

```
CGO_ENABLED=1 go build -tags with_gvisor,with_quic,with_wireguard,with_utls,with_grpc,with_conntrack ./...   # clean
CGO_ENABLED=1 go test  -tags ... ./...                                                                       # all packages ok
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015MYMwy9Pu5Ji3xpYK8Nzj3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions.
  * No user-visible features or behavior changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->