### PR TITLE
Fix Unbounded UI to match Figma spec

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -639,6 +639,9 @@ msgstr "Status"
 msgid "smc_status_off"
 msgstr "Off"
 
+msgid "smc_status_configuring"
+msgstr "Configuring network"
+
 msgid "smc_status_probing"
 msgstr "Probing your network…"
 
@@ -764,7 +767,7 @@ msgid "hide_unbounded"
 msgstr "Hide Unbounded"
 
 msgid "hide_unbounded_subtitle"
-msgstr "Removes Unbounded from the top of this screen"
+msgstr "Removes Unbounded from the UI"
 
 msgid "vpn_connected"
 msgstr "Lantern is now connected."

--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -760,7 +760,7 @@ msgid "auto_enable_unbounded"
 msgstr "Auto-enable Unbounded"
 
 msgid "auto_enable_unbounded_subtitle"
-msgstr "Turn on automatically when Lantern is open"
+msgstr "Turns on when Lantern opens"
 
 # Hide Unbounded toggle (collapses the Unbounded tab on the Home shell)
 msgid "hide_unbounded"

--- a/lib/core/widgets/vpn_status_indicator.dart
+++ b/lib/core/widgets/vpn_status_indicator.dart
@@ -8,28 +8,38 @@ class VPNStatusIndicator extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    late String indicator;
     switch (status) {
       case VPNStatus.connected:
-        indicator = AppImagePaths.vpnConnected;
-        break;
+        return const StatusDot(active: true);
       case VPNStatus.disconnected:
-        indicator = AppImagePaths.vpnDisconnected;
-        break;
+        return const StatusDot(active: false);
       case VPNStatus.connecting:
-        indicator = AppImagePaths.vpnConnecting;
-        break;
       case VPNStatus.missingPermission:
       case VPNStatus.error:
       case VPNStatus.disconnecting:
-        indicator = AppImagePaths.vpnConnecting;
-        break;
+        return const AppImage(
+          path: AppImagePaths.vpnConnecting,
+          useThemeColor: false,
+        );
     }
+  }
+}
 
+/// Green/grey status light shared by every "is this feature running" surface
+/// in the app (VPN status row, VPN/Unbounded tab strip) so they all read the
+/// same on/off signal the same way. Reuses the exact assets and grey-tint
+/// trick VPNStatusIndicator uses for its connected/disconnected states.
+class StatusDot extends StatelessWidget {
+  final bool active;
+
+  const StatusDot({super.key, required this.active});
+
+  @override
+  Widget build(BuildContext context) {
     return AppImage(
-      path: indicator,
+      path: active ? AppImagePaths.vpnConnected : AppImagePaths.vpnDisconnected,
       useThemeColor: false,
-      color: status == VPNStatus.disconnected ? AppColors.gray3 : null,
+      color: active ? null : AppColors.gray3,
     );
   }
 }

--- a/lib/features/home/home.dart
+++ b/lib/features/home/home.dart
@@ -5,6 +5,7 @@ import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lantern/core/common/app_text_styles.dart';
 import 'package:lantern/core/models/feature_flags.dart';
 import 'package:lantern/core/utils/pro_utils.dart';
+import 'package:lantern/core/widgets/vpn_status_indicator.dart';
 import 'package:lantern/features/home/provider/app_event_notifier.dart';
 import 'package:lantern/features/home/provider/app_setting_notifier.dart';
 import 'package:lantern/features/home/provider/feature_flag_notifier.dart';
@@ -214,6 +215,11 @@ class Home extends HookConsumerWidget {
                 width: 149,
               )
             : LanternLogo(isPro: isUserPro, color: context.textPrimary),
+        // bg/elevated (white in light mode) per the Figma spec — the Home
+        // shell's app bar + tab strip render on a white surface, distinct
+        // from every other screen's app bar which uses the app-wide
+        // bg/surface grey from AppTheme.appBarTheme.
+        backgroundColor: context.bgElevated,
         elevation: 5,
         leading: IconButton(
           key: const Key('home.menu_button'),
@@ -251,32 +257,46 @@ class Home extends HookConsumerWidget {
             ? null
             : TabBar(
                 controller: tabController,
-                // Pill-shaped selection rather than the Material underline,
-                // per the Figma spec. indicatorPadding insets the fill so the
-                // pill floats inside the tab instead of filling it edge to
-                // edge; the strip carries no divider in the spec.
-                indicatorSize: TabBarIndicatorSize.tab,
-                indicator: BoxDecoration(
-                  color: AppColors.blue1, // action/tabbar/tabbar-bg
-                  borderRadius: BorderRadius.circular(9999),
-                  border: Border.all(
-                    color: AppColors.blue2, // action/tabbar/tabbar-border
-                  ),
-                ),
-                indicatorPadding:
-                    const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+                // The pill is drawn by each _TabLabel itself (hugging its
+                // own content with 24px side padding, per spec) rather than
+                // through TabBar's indicator geometry, which can only size
+                // itself to the tab's full flex slot or its label's
+                // intrinsic size — neither hugs content with extra padding
+                // the way the spec wants. The indicator here is fully
+                // transparent; splashBorderRadius still rounds the
+                // hover/press overlay into a pill instead of a square.
+                indicator: const BoxDecoration(),
+                labelPadding: EdgeInsets.zero,
+                splashBorderRadius: BorderRadius.circular(9999),
+                overlayColor: WidgetStateProperty.resolveWith((states) {
+                  if (states.contains(WidgetState.hovered) ||
+                      states.contains(WidgetState.pressed)) {
+                    return context.bgHover; // action/bg-hover
+                  }
+                  return null;
+                }),
                 dividerColor: Colors.transparent,
-                labelColor: AppColors.blue10, // tabbar-selected-text
-                unselectedLabelColor: AppColors.gray6, // tabbar-disabled-text
+                labelColor:
+                    context.actionTabbarSelectedText, // tabbar-selected-text
+                unselectedLabelColor:
+                    context.actionTabbarDisabledText, // tabbar-disabled-text
+                labelStyle: Theme.of(context).textTheme.titleSmall, // subtitle/small
+                unselectedLabelStyle: Theme.of(context).textTheme.titleSmall,
                 tabs: [
                   _TabLabel(
-                      label: 'vpn'.i18n,
-                      iconPath: AppImagePaths.key,
-                      active: vpnStatus == VPNStatus.connected),
+                    label: 'vpn'.i18n,
+                    iconOutlined: Icons.vpn_key_outlined,
+                    iconFilled: Icons.vpn_key,
+                    selected: !onUnboundedTab.value,
+                    active: vpnStatus == VPNStatus.connected,
+                  ),
                   _TabLabel(
-                      label: 'unbounded'.i18n,
-                      iconPath: AppImagePaths.unbounded,
-                      active: shareActive),
+                    label: 'unbounded'.i18n,
+                    iconOutlined: Icons.handshake_outlined,
+                    iconFilled: Icons.handshake,
+                    selected: onUnboundedTab.value,
+                    active: shareActive,
+                  ),
                 ],
               ),
       ),
@@ -293,18 +313,23 @@ class Home extends HookConsumerWidget {
   }
 }
 
-/// Tab label with the leading feature icon and green/grey status dot from the
-/// Figma spec. The dot reflects whether the feature is running, which is
-/// independent of which tab is selected.
+/// Tab label with the leading feature icon and the shared status dot
+/// ([StatusDot], reused from the VPN status panel) from the Figma spec. The
+/// dot reflects whether the feature is running, independent of which tab is
+/// selected; the icon itself flips outline → filled when its tab is selected.
 class _TabLabel extends StatelessWidget {
   const _TabLabel({
     required this.label,
-    required this.iconPath,
+    required this.iconOutlined,
+    required this.iconFilled,
+    required this.selected,
     required this.active,
   });
 
   final String label;
-  final String iconPath;
+  final IconData iconOutlined;
+  final IconData iconFilled;
+  final bool selected;
   final bool active;
 
   @override
@@ -314,27 +339,38 @@ class _TabLabel extends StatelessWidget {
     // two in step without plumbing the selected index down here.
     final labelColor = DefaultTextStyle.of(context).style.color;
     return Tab(
-      child: Row(
-        mainAxisAlignment: MainAxisAlignment.center,
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          AppImage(path: iconPath, width: 24, height: 24, color: labelColor),
-          const SizedBox(width: 8),
-          Text(label),
-          const SizedBox(width: 8),
-          Container(
-            width: 10,
-            height: 10,
-            decoration: BoxDecoration(
-              shape: BoxShape.circle,
-              color: active ? AppColors.green6 : AppColors.gray5,
-              border: Border.all(
-                color: active ? AppColors.green3 : AppColors.gray3,
-                width: 2,
-              ),
+      height: 40,
+      child: Container(
+        height: 40,
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        decoration: selected
+            ? BoxDecoration(
+                color: context.actionTabbarBg, // action/tabbar/tabbar-bg
+                borderRadius: BorderRadius.circular(9999),
+                border: Border.all(
+                  color: context.actionTabbarBorder, // tabbar-border
+                ),
+              )
+            : null,
+        child: Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(
+              selected ? iconFilled : iconOutlined,
+              size: 24,
+              color: labelColor,
             ),
-          ),
-        ],
+            const SizedBox(width: 8),
+            Text(label),
+            const SizedBox(width: 8),
+            SizedBox(
+              width: 24,
+              height: 24,
+              child: Center(child: StatusDot(active: active)),
+            ),
+          ],
+        ),
       ),
     );
   }

--- a/lib/features/setting/setting.dart
+++ b/lib/features/setting/setting.dart
@@ -153,7 +153,7 @@ class _SettingState extends ConsumerState<Setting>
                   DividerSpace(),
                   AppTile(
                     label: 'unbounded_settings_title'.i18n,
-                    icon: AppImagePaths.share,
+                    icon: Icons.handshake_outlined,
                     onPressed: () =>
                         settingMenuTap(_SettingType.unboundedSetting),
                   ),

--- a/lib/features/setting/unbounded_setting.dart
+++ b/lib/features/setting/unbounded_setting.dart
@@ -53,7 +53,7 @@ class UnboundedSetting extends ConsumerWidget {
                       letterSpacing: 0.0,
                     ),
                   ),
-                  icon: AppImagePaths.share,
+                  icon: Icons.auto_mode,
                   trailing: SwitchButton(
                     value: autoEnable,
                     onChanged: (v) =>
@@ -73,7 +73,7 @@ class UnboundedSetting extends ConsumerWidget {
                       letterSpacing: 0.0,
                     ),
                   ),
-                  icon: const Icon(Icons.visibility_off_outlined),
+                  icon: Icons.visibility_off_outlined,
                   trailing: SwitchButton(
                     value: hidden,
                     onChanged: notifier.setUnboundedHidden,

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -1477,10 +1477,12 @@ class _ArrivalToastState extends ConsumerState<_ArrivalToast> {
     // does not mean nobody is connected. The idle pill has to key off the live
     // peer count or it claims we are waiting for connections directly above a
     // stat reporting several active ones. It also only makes sense while
-    // Unbounded is actually on — otherwise "waiting for connections" shows
-    // over an inert globe with the toggle off.
+    // Unbounded (not SmC) is actually on — the copy is Unbounded-specific
+    // (unbounded_waiting_for_connections), and shareState.active is also true
+    // during an SmC session, which has no such pill in the spec.
     final hasPeers = shareState.activeCount > 0;
-    final showWaiting = shareState.active && !hasPeers;
+    final showWaiting =
+        shareState.mode == ShareMode.unbounded && shareState.active && !hasPeers;
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 280),
       transitionBuilder: (child, anim) => FadeTransition(

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -29,6 +29,7 @@ import 'package:lantern/features/home/provider/app_setting_notifier.dart';
 import 'package:lantern/core/services/geo_lookup_service.dart';
 import 'package:lantern/core/services/injection_container.dart' show sl;
 import 'package:lantern/core/services/local_storage_service.dart';
+import 'package:lantern/core/widgets/info_row.dart';
 import 'package:lantern/core/widgets/switch_button.dart';
 import 'package:lantern/features/home/provider/radiance_settings_providers.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
@@ -847,34 +848,17 @@ class UnboundedTab extends HookConsumerWidget {
         child: Column(
           children: [
             const SizedBox(height: 12),
-            Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).cardColor,
-                borderRadius: BorderRadius.circular(12),
-                border: Border.all(color: Colors.black12),
-              ),
-              padding: const EdgeInsets.all(12),
-              child: Row(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Tappable despite reading as a static glyph: it is the only
-                  // way back into the welcome dialog once it has been seen.
-                  IconButton(
-                    icon: const Icon(Icons.info_outline, size: 20),
-                    visualDensity: VisualDensity.compact,
-                    padding: EdgeInsets.zero,
-                    constraints: const BoxConstraints(),
-                    tooltip: 'about_unbounded'.i18n,
-                    onPressed: () => showUnboundedWelcomeDialog(context, ref),
-                  ),
-                  const SizedBox(width: 12),
-                  Expanded(
-                    child: Text(
-                      'smc_intro'.i18n,
-                      style: textTheme.bodyMedium,
-                    ),
-                  ),
-                ],
+            // The whole note re-opens the welcome dialog — a strict superset
+            // of the old icon-only tap target — so it can reuse the app's
+            // shared note component instead of a one-off Container.
+            Tooltip(
+              message: 'about_unbounded'.i18n,
+              child: InfoRow(
+                text: 'smc_intro'.i18n,
+                textStyle: textTheme.labelMedium?.copyWith(
+                  color: context.textSecondary,
+                ),
+                onPressed: () => showUnboundedWelcomeDialog(context, ref),
               ),
             ),
             const SizedBox(height: 16),
@@ -924,181 +908,160 @@ class _StatusCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final textTheme = Theme.of(context).textTheme;
-    // Status text source-of-truth, in priority order:
-    //   1. Off and not probing → "Off"
-    //   2. Probing UPnP locally → "Probing your network…"
-    //   3. SmC mode → granular phase from radiance peer.Status. The
-    //      backend emits one phase per stage during Start so the user
-    //      sees real progress instead of "Active" for several seconds.
-    //   4. Unbounded mode → static "Active — Unbounded" (no equivalent
-    //      staged lifecycle on the broflake side yet).
-    final modeLabel = switch ((state.mode, state.phase)) {
-      // Off-with-error is a legitimate terminal state: the enable
-      // path failed (e.g. setUnboundedEnabled / setPeerProxyEnabled
-      // returned Left) and reverted mode to off. Render the error
-      // before the catch-all "Off" so the user sees an actionable
-      // message instead of a misleading off state.
-      (ShareMode.off, SharePhase.error) =>
-        state.errorMessage != null
-            ? 'smc_status_error_with_message'.i18n.fill([state.errorMessage!])
-            : 'smc_status_error_generic'.i18n,
-      (ShareMode.off, _) =>
-        state.probing ? 'smc_status_probing'.i18n : 'smc_status_off'.i18n,
-      (ShareMode.unbounded, _) => 'smc_status_active_unbounded'.i18n,
-      (ShareMode.smc, SharePhase.mappingPort) =>
-        'smc_status_mapping_port'.i18n,
-      (ShareMode.smc, SharePhase.detectingIp) =>
-        'smc_status_detecting_ip'.i18n,
-      (ShareMode.smc, SharePhase.registering) =>
-        'smc_status_registering'.i18n,
-      (ShareMode.smc, SharePhase.startingProxy) =>
-        'smc_status_starting_proxy'.i18n,
-      (ShareMode.smc, SharePhase.verifying) =>
-        'smc_status_verifying'.i18n,
-      (ShareMode.smc, SharePhase.serving) =>
-        'smc_status_serving'.i18n,
-      (ShareMode.smc, SharePhase.stopping) => 'smc_status_stopping'.i18n,
-      (ShareMode.smc, SharePhase.error) =>
-        state.errorMessage != null
-            ? 'smc_status_error_with_message'.i18n.fill([state.errorMessage!])
-            : 'smc_status_error_generic'.i18n,
-      // SmC active but no phase yet (e.g. very first frame after toggle
-      // before the backend's first event arrives) — fall back to the
-      // legacy active label so the UI isn't blank.
-      (ShareMode.smc, SharePhase.idle) => 'smc_status_active_smc'.i18n,
+    // Status text source-of-truth, collapsed to the three states the spec
+    // calls for — "Off", "Enabled", and (while a Start/probe is actually in
+    // flight) "Configuring network" — rather than the old multi-line
+    // per-phase prose. SmC's granular radiance phases still gate the same
+    // "Configuring network" text so the panel doesn't go blank mid-Start.
+    final modeLabel = switch (state.mode) {
+      ShareMode.off => switch (state.phase) {
+          // Off-with-error is a legitimate terminal state: the enable path
+          // failed (e.g. setUnboundedEnabled / setPeerProxyEnabled returned
+          // Left) and reverted mode to off. Render the error before the
+          // catch-all "Off" so the user sees an actionable message instead
+          // of a misleading off state.
+          SharePhase.error => state.errorMessage != null
+              ? 'smc_status_error_with_message'
+                  .i18n
+                  .fill([state.errorMessage!])
+              : 'smc_status_error_generic'.i18n,
+          _ => state.probing
+              ? 'smc_status_configuring'.i18n
+              : 'smc_status_off'.i18n,
+        },
+      ShareMode.unbounded => 'enabled'.i18n,
+      ShareMode.smc => switch (state.phase) {
+          SharePhase.serving => 'enabled'.i18n,
+          SharePhase.error => state.errorMessage != null
+              ? 'smc_status_error_with_message'
+                  .i18n
+                  .fill([state.errorMessage!])
+              : 'smc_status_error_generic'.i18n,
+          // mappingPort / detectingIp / registering / startingProxy /
+          // verifying / stopping / idle — all mid-flight SmC stages.
+          _ => 'smc_status_configuring'.i18n,
+        },
     };
 
     return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.black12),
+      decoration: const BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.shadowColor,
+            blurRadius: 32,
+            offset: Offset(0, 4),
+            spreadRadius: 0,
+          ),
+        ],
       ),
-      child: Column(
-        children: [
-          Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-            child: Row(
-              children: [
-                Icon(Icons.public,
-                    size: 20, color: Theme.of(context).hintColor),
-                const SizedBox(width: 12),
-                Expanded(
-                  child: Text.rich(
-                    TextSpan(
-                      style: textTheme.bodyMedium,
-                      children: [
-                        TextSpan(text: '${'smc_status_label'.i18n}: '),
-                        TextSpan(
-                          text: modeLabel,
-                          style: TextStyle(
-                            color: state.active
-                                ? AppColors.green6
-                                : Theme.of(context).hintColor,
-                            fontWeight: FontWeight.w600,
+      child: Card(
+        elevation: 0,
+        margin: EdgeInsets.zero,
+        child: Column(
+          children: [
+            Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+              child: Row(
+                children: [
+                  Icon(Icons.public_outlined,
+                      size: 20, color: Theme.of(context).hintColor),
+                  const SizedBox(width: 12),
+                  Expanded(
+                    child: Text.rich(
+                      TextSpan(
+                        style: textTheme.bodyMedium,
+                        children: [
+                          TextSpan(text: '${'smc_status_label'.i18n}: '),
+                          TextSpan(
+                            text: modeLabel,
+                            style: TextStyle(
+                              color: state.active
+                                  ? AppColors.green6
+                                  : Theme.of(context).hintColor,
+                              fontWeight: FontWeight.w600,
+                            ),
                           ),
-                        ),
-                      ],
+                        ],
+                      ),
                     ),
                   ),
-                ),
-                const SizedBox(width: 8),
-                // Match the rest of the app's toggles (vpn_setting.dart etc.).
-                // SwitchButton has no built-in disabled state, so during the
-                // probe we render the switch but absorb the tap so the user
-                // doesn't double-fire toggle().
-                SwitchButton(
-                  value: state.active || state.probing,
-                  onChanged: (value) {
-                    if (state.probing) return;
-                    onToggle();
-                  },
-                ),
-              ],
+                  const SizedBox(width: 8),
+                  // Match the rest of the app's toggles (vpn_setting.dart etc.).
+                  // SwitchButton has no built-in disabled state, so during the
+                  // probe we render the switch but absorb the tap so the user
+                  // doesn't double-fire toggle().
+                  SwitchButton(
+                    value: state.active || state.probing,
+                    onChanged: (value) {
+                      if (state.probing) return;
+                      onToggle();
+                    },
+                  ),
+                ],
+              ),
             ),
-          ),
-          if (state.active) ...[
-            const Divider(height: 1),
-            _StatRow(
+            // Always shown — including while Unbounded is off — so the
+            // panel doesn't collapse/expand as the toggle flips. activeCount
+            // reads 0 and totalCount keeps the persisted lifetime total.
+            const DividerSpace(),
+            AppTile(
               icon: Icons.person_outline,
               label: 'smc_stat_active_now'.i18n,
-              value: '${state.activeCount}',
-              tooltip: 'smc_connections_tooltip'.i18n,
+              trailing: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Tooltip(
+                    triggerMode: TooltipTriggerMode.tap,
+                    waitDuration: const Duration(milliseconds: 200),
+                    showDuration: const Duration(seconds: 8),
+                    preferBelow: false,
+                    margin: const EdgeInsets.symmetric(horizontal: 24),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 12, vertical: 10),
+                    textStyle:
+                        const TextStyle(color: Colors.white, fontSize: 12),
+                    decoration: BoxDecoration(
+                      color: Colors.black87,
+                      borderRadius: BorderRadius.circular(8),
+                    ),
+                    message: 'smc_connections_tooltip'.i18n,
+                    child: Icon(
+                      Icons.info_outline,
+                      size: 16,
+                      color: Theme.of(context).hintColor,
+                    ),
+                  ),
+                  const SizedBox(width: 8),
+                  Text(
+                    '${state.activeCount}',
+                    style: textTheme.titleMedium!
+                        .copyWith(color: context.textLink),
+                  ),
+                ],
+              ),
             ),
-            const Divider(height: 1),
-            _StatRow(
-              icon: Icons.people_outline,
+            const DividerSpace(),
+            AppTile(
+              icon: Icons.groups_2_outlined,
               label: 'smc_stat_total_helped'.i18n,
-              value: '${state.totalCount}',
-            ),
-          ],
-        ],
-      ),
-    );
-  }
-}
-
-class _StatRow extends StatelessWidget {
-  final IconData icon;
-  final String label;
-  final String value;
-  final String? tooltip;
-
-  const _StatRow({
-    required this.icon,
-    required this.label,
-    required this.value,
-    this.tooltip,
-  });
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return Padding(
-      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-      child: Row(
-        children: [
-          Icon(icon, size: 20, color: Theme.of(context).hintColor),
-          const SizedBox(width: 12),
-          Expanded(child: Text(label, style: textTheme.bodyMedium)),
-          if (tooltip != null) ...[
-            Tooltip(
-              triggerMode: TooltipTriggerMode.tap,
-              waitDuration: const Duration(milliseconds: 200),
-              showDuration: const Duration(seconds: 8),
-              preferBelow: false,
-              margin: const EdgeInsets.symmetric(horizontal: 24),
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-              textStyle: const TextStyle(color: Colors.white, fontSize: 12),
-              decoration: BoxDecoration(
-                color: Colors.black87,
-                borderRadius: BorderRadius.circular(8),
-              ),
-              message: tooltip!,
-              child: Icon(
-                Icons.info_outline,
-                size: 16,
-                color: Theme.of(context).hintColor,
+              trailing: Text(
+                '${state.totalCount}',
+                style:
+                    textTheme.titleMedium!.copyWith(color: context.textLink),
               ),
             ),
-            const SizedBox(width: 8),
           ],
-          Text(
-            value,
-            style: textTheme.bodyMedium?.copyWith(
-              color: AppColors.blue8, // text/link
-              fontWeight: FontWeight.w600,
-            ),
-          ),
-        ],
+        ),
       ),
     );
   }
 }
 
 /// Mirrors the Unbounded Settings toggle, surfaced on the tab itself because
-/// the spec puts the choice next to the thing it controls.
+/// the spec puts the choice next to the thing it controls. Uses a checkbox
+/// rather than the switch UnboundedSetting's identical row uses — per the
+/// Figma spec, this tab-embedded copy is the one exception.
 class _AutoEnableCard extends ConsumerWidget {
   const _AutoEnableCard();
 
@@ -1109,43 +1072,34 @@ class _AutoEnableCard extends ConsumerWidget {
         ref.watch(appSettingProvider.select((s) => s.unboundedAutoEnable));
     final notifier = ref.read(shareProvider.notifier);
     return Container(
-      decoration: BoxDecoration(
-        color: Theme.of(context).cardColor,
-        borderRadius: BorderRadius.circular(12),
-        border: Border.all(color: Colors.black12),
-      ),
-      child: InkWell(
-        borderRadius: BorderRadius.circular(12),
-        onTap: () => notifier.setAutoEnable(context, !autoEnable),
-        child: Padding(
-          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-          child: Row(
-            children: [
-              Icon(Icons.auto_mode,
-                  size: 20, color: Theme.of(context).hintColor),
-              const SizedBox(width: 12),
-              Expanded(
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text('auto_enable_unbounded'.i18n,
-                        style: textTheme.bodyMedium),
-                    Text('auto_enable_unbounded_subtitle'.i18n,
-                        style: textTheme.labelSmall),
-                  ],
-                ),
-              ),
-              const SizedBox(width: 8),
-              Checkbox(
-                value: autoEnable,
-                onChanged: (v) => notifier.setAutoEnable(context, v ?? false),
-                activeColor: AppColors.blue10,
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(4),
-                ),
-              ),
-            ],
+      decoration: const BoxDecoration(
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.shadowColor,
+            blurRadius: 32,
+            offset: Offset(0, 4),
+            spreadRadius: 0,
           ),
+        ],
+      ),
+      child: Card(
+        elevation: 0,
+        margin: EdgeInsets.zero,
+        child: AppTile(
+          label: 'auto_enable_unbounded'.i18n,
+          subtitle: Text(
+            'auto_enable_unbounded_subtitle'.i18n,
+            style: textTheme.labelMedium!.copyWith(
+              color: context.textTertiary,
+            ),
+          ),
+          icon: Icons.auto_mode,
+          trailing: Checkbox(
+            value: autoEnable,
+            onChanged: (v) => notifier.setAutoEnable(context, v ?? false),
+            activeColor: context.textLink,
+          ),
+          onPressed: () => notifier.setAutoEnable(context, !autoEnable),
         ),
       ),
     );
@@ -1518,11 +1472,15 @@ class _ArrivalToastState extends ConsumerState<_ArrivalToast> {
   @override
   Widget build(BuildContext context) {
     final event = _current;
+    final shareState = ref.watch(shareProvider);
     // _current only tracks arrivals from the last few seconds, so its absence
     // does not mean nobody is connected. The idle pill has to key off the live
     // peer count or it claims we are waiting for connections directly above a
-    // stat reporting several active ones.
-    final hasPeers = ref.watch(shareProvider).activeCount > 0;
+    // stat reporting several active ones. It also only makes sense while
+    // Unbounded is actually on — otherwise "waiting for connections" shows
+    // over an inert globe with the toggle off.
+    final hasPeers = shareState.activeCount > 0;
+    final showWaiting = shareState.active && !hasPeers;
     return AnimatedSwitcher(
       duration: const Duration(milliseconds: 280),
       transitionBuilder: (child, anim) => FadeTransition(
@@ -1535,9 +1493,9 @@ class _ArrivalToastState extends ConsumerState<_ArrivalToast> {
         ),
       ),
       child: event == null
-          ? (hasPeers
-              ? const SizedBox.shrink(key: ValueKey('arrival-idle'))
-              : const _WaitingCard(key: ValueKey('arrival-waiting')))
+          ? (showWaiting
+              ? const _WaitingCard(key: ValueKey('arrival-waiting'))
+              : const SizedBox.shrink(key: ValueKey('arrival-idle')))
           : _ArrivalCard(
               // ValueKey forces AnimatedSwitcher to swap children when a
               // new arrival lands while the previous toast is still up,


### PR DESCRIPTION
## Summary

Fixes every checklist item in getlantern/engineering#3844 — the Unbounded feature UI didn't match the Figma designs (https://www.figma.com/design/hNlyYToB5TnX9SDBFDYJTq/Lantern-VPN?node-id=2403-19287), mostly because it was built with one-off widgets/hardcoded colors instead of reusing existing components and semantic color tokens.

### Tab bar (macOS main screen) — `lib/features/home/home.dart`, `lib/core/widgets/vpn_status_indicator.dart`
- White `bg/elevated` background behind the whole app bar + tab strip (was inheriting the app-wide grey `bg/surface`).
- Indicator lights extracted into a shared `StatusDot` widget so both tabs reuse the exact same asset/behavior as the VPN status panel's indicator.
- VPN/Unbounded tab icons are now Material `vpn_key`/`handshake` — outline when unselected, filled when selected.
- Selected pill is 40px tall, hugs its content with 24px side padding (drawn by the tab itself rather than via `TabBar`'s indicator geometry, which can't hug content the way the spec wants).
- Hover/press overlay is pill-shaped (`splashBorderRadius`) instead of square.
- Tab label font is `subtitle/small` (`textTheme.titleSmall`).
- Selected/unselected colors now come from the existing `context.actionTabbar*` semantic tokens instead of hardcoded `AppColors` — this was the actual dark-mode bug.

### Unbounded tab — `lib/features/share_my_connection/share_my_connection.dart`
- "Help others bypass censorship" note now uses the shared `InfoRow` component (fixes icon alignment and font to match every other note in the app).
- Status panel and auto-enable card wrapped in `Card` + the same drop shadow as the VPN page's panel (`AppColors.shadowColor`, blur 32, offset (0,4)).
- Status icons are now Material icons matching Figma (`public_outlined`, `person_outline`, `groups_2_outlined`, `auto_mode`).
- "People you're helping" / "Total people helped" rows now use `AppTile` (the app's single-line list component) instead of a bespoke row.
- Status text collapsed from long per-phase prose to the spec's three states: `Enabled` / `Off` / `Configuring network` (replacing "Probing your network…" and all the granular SmC phase strings).
- Status panel no longer collapses when Unbounded is off — it's always shown, with `0`/lifetime-total counts.
- "Waiting for connections" pill now only shows when Unbounded is actually on and has no active connections (previously showed even when off).
- Auto-Enable Unbounded card converted to `AppTile` (double-line list, correct fonts) with a Material `Checkbox` colored `text/link` instead of hardcoded blue.

### Unbounded Settings + main Settings — `lib/features/setting/unbounded_setting.dart`, `lib/features/setting/setting.dart`, `assets/locales/en.po`
- Auto-Enable / Hide Unbounded rows now use the correct Material icons (`auto_mode`, `visibility_off_outlined`).
- `hide_unbounded_subtitle` shortened to match Figma exactly ("Removes Unbounded from the UI"), fixing the text wrap.
- Main Settings' "Unbounded Settings" row now uses the same `handshake` icon as the Unbounded tab.

## Test plan
- [x] `flutter analyze` — no new issues (33 pre-existing issues elsewhere, none touched by this diff)
- [x] `flutter test` — 159/159 passing
- [ ] Live visual check on macOS — blocked in my sandbox by a pre-existing, unrelated CocoaPods/SwiftPM conflict (`screen_retriever_macos` requires macOS 10.14, the `FlutterFramework` SwiftPM package requires 10.15); reviewer should do a visual pass against the Figma link above before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9QUxmHCBem9Awc7RSEx1L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added clearer VPN status indicators for connected, disconnected, and configuring states.
  - Updated the Home tab bar with refreshed icons, colors, hover effects, and status badges.
  - Improved Share My Connection status cards, network information, usage totals, and auto-enable controls.
  - Added clearer waiting feedback when sharing is active without connected peers.

- **Bug Fixes**
  - Prevented sharing controls from being tapped while connection status is being checked.

- **Style**
  - Refreshed Unbounded settings icons and updated related explanatory text.
  - Improved informational layouts and card presentation in Share My Connection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->