### PR TITLE
Fix macOS build: disable Swift Package Manager auto-migration

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -158,6 +158,22 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
+  # Opt this project out of Flutter's Swift Package Manager auto-migration
+  # for iOS/macOS. The project resolves all native darwin dependencies via
+  # CocoaPods (macos/Podfile, ios/Podfile) and has no checked-in
+  # Package.swift/Package.resolved. `flutter run`/`flutter build` silently
+  # add SwiftPM integration on top of that when the local `flutter config`
+  # has enable-swift-package-manager on (as it does on some dev machines),
+  # which breaks the macOS build: screen_retriever_macos's own Package.swift
+  # still declares a macOS 10.14 minimum, one below the 10.15 the new
+  # FlutterFramework SwiftPM product requires, so Xcode fails with "package
+  # product 'FlutterFramework' requires minimum platform version 10.15 ...
+  # but this target supports 10.14 (in target 'screen_retriever_macos')".
+  # Disabling SPM here keeps every machine on the CocoaPods path that
+  # already works, regardless of that machine's global flutter config.
+  config:
+    enable-swift-package-manager: false
+
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.


### PR DESCRIPTION
## Summary

`flutter run`/`flutter build macos` currently fails on any machine with `enable-swift-package-manager: true` in its local `flutter config` (a per-developer setting, on by default on newer Flutter installs):

```
error: The package product 'FlutterFramework' requires minimum platform version 10.15
for the macOS platform, but this target supports 10.14
(in target 'screen_retriever_macos' from project 'screen_retriever_macos')
** BUILD FAILED **
```

Root cause: Flutter's tooling auto-migrates the macOS project to also resolve plugins via Swift Package Manager on top of the existing CocoaPods setup, the first time it notices SPM is enabled locally. `screen_retriever_macos`'s own `Package.swift` still declares a macOS 10.14 minimum, one below the 10.15 the new `FlutterFramework` SwiftPM product requires, so Xcode's package graph resolution fails.

This project already resolves every native darwin dependency via CocoaPods (`macos/Podfile`, `ios/Podfile`) and has no `Package.swift`/`Package.resolved` of its own — there's nothing to gain from the migration, and it depends on a developer's local, machine-specific `flutter config` rather than anything checked into the repo, so the failure is inconsistent across machines.

## Fix

Added to `pubspec.yaml`:

```yaml
flutter:
  config:
    enable-swift-package-manager: false
```

This is the documented per-project opt-out (`flutter_manifest.dart`/`features.dart` in the Flutter SDK) and keeps every machine on the CocoaPods path that already works, regardless of that machine's global `flutter config`.

## Test plan
- [x] `flutter clean && flutter pub get && flutter build macos --debug` — succeeds (previously failed with the error above)
- [x] Built `Lantern.app` launches and runs correctly (verified interactively — navigated Home, Settings, Unbounded Settings, toggled dark mode)
- [x] `flutter analyze` / `flutter test` unaffected (this only touches `pubspec.yaml`, no Dart code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9QUxmHCBem9Awc7RSEx1L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration to keep iOS and macOS builds using CocoaPods for native dependencies.
  * Disabled automatic Swift Package Manager migration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->