### PR TITLE
Fix empty-feeling Unbounded info tooltip

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -630,7 +630,7 @@ msgstr "Help others bypass censorship by securely sharing your connection."
 
 # Info-bubble tooltip on the Unbounded tab header
 msgid "about_unbounded"
-msgstr "About Unbounded"
+msgstr "Learn more about Unbounded"
 
 # Status card — phase labels
 msgid "smc_status_label"


### PR DESCRIPTION
## Summary

The hover tooltip on the Unbounded tab's info icon (top-left of the "Help others bypass censorship..." note) just repeated its own label, "About Unbounded" — no actual information, and redundant with the note text sitting right next to it in the same row.

Reported by Adam after live-testing #9002's build: "the 'about unbounded' info mouseover has no info."

## Fix

Reworded the tooltip (`about_unbounded` in `assets/locales/en.po`) from "About Unbounded" to "Learn more about Unbounded" — it now describes what clicking the icon actually does (opens the "Welcome to Unbounded" dialog with the full explanation), rather than just relabeling the icon.

## Test plan
- [x] Rebuilt and ran the macOS app, hovered the icon before/after — confirmed the tooltip mechanism itself works fine (this was a copy issue, not a rendering bug), and now reads "Learn more about Unbounded"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B9QUxmHCBem9Awc7RSEx1L

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the English translation to “Learn more about Unbounded” for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->