### PR TITLE
macos: validate the VPN profile before reusing it

### DIFF
--- a/macos/Runner/VPN/SystemExtensionManager.swift
+++ b/macos/Runner/VPN/SystemExtensionManager.swift
@@ -40,7 +40,7 @@ internal enum StaleRegistryRecovery {
 class SystemExtensionManager: NSObject, OSSystemExtensionRequestDelegate {
 
   static let shared = SystemExtensionManager()
-  private let tunnelBundleID = "org.getlantern.lantern.PacketTunnel"
+  private let tunnelBundleID = VPNProfileIdentity.providerBundleID
   /// All access to requestStates must go through contextQueue to avoid
   /// data races between init (possibly off main thread) and delegate
   /// callbacks (delivered on main queue).

--- a/macos/Runner/VPN/VPNBase.swift
+++ b/macos/Runner/VPN/VPNBase.swift
@@ -158,6 +158,74 @@ func shouldStopTunnel(for status: NEVPNStatus) throws -> Bool {
   }
 }
 
+/// Identity this build expects on a VPN profile it is willing to reuse.
+enum VPNProfileIdentity {
+  /// Bundle ID of the packet-tunnel provider shipped inside this build.
+  static let providerBundleID = "org.getlantern.lantern.PacketTunnel"
+  /// Name the profile carries in System Settings.
+  static let name = "Lantern"
+}
+
+/// Why a saved VPN profile cannot be launched by this build.
+enum VPNProfileDefect: Equatable, CustomStringConvertible {
+  /// The profile carries no `NETunnelProviderProtocol` configuration.
+  case notATunnelProfile
+  /// The profile names a provider this build does not contain.
+  case unknownProvider(found: String?)
+
+  var description: String {
+    switch self {
+    case .notATunnelProfile:
+      return "profile has no tunnel provider configuration"
+    case .unknownProvider(let found):
+      return
+        "profile names provider \(found ?? "none"), this build ships \(VPNProfileIdentity.providerBundleID)"
+    }
+  }
+}
+
+/// Returns why a saved profile is unlaunchable by this build, or nil when it can be reused.
+///
+/// Only the provider bundle ID disqualifies a profile. It has churned across
+/// releases (`.Tunnel` -> `.PacketTunnel` -> `.packet` -> `.PacketTunnel`), and
+/// macOS accepts `startVPNTunnel` against a profile naming a provider that is not
+/// installed: the session is torn down within tens of milliseconds and no error
+/// reaches the caller, so the app reports a successful connect that never happened.
+///
+/// A stale *name* is deliberately not a defect. Such a profile still launches, and
+/// rebuilding costs the user a system VPN-permission prompt, so the name is
+/// repaired in place instead. This is why iOS's `needsMigration()` cannot be reused
+/// verbatim here — it keys on the name, which differs per platform.
+func vpnProfileDefect(isTunnelProfile: Bool, providerBundleID: String?) -> VPNProfileDefect? {
+  guard isTunnelProfile else { return .notATunnelProfile }
+  guard providerBundleID == VPNProfileIdentity.providerBundleID else {
+    return .unknownProvider(found: providerBundleID)
+  }
+  return nil
+}
+
+/// Corrections a launchable profile needs before this build uses it.
+struct VPNProfileRepairs: Equatable {
+  /// Name to write, or nil when the profile is already named correctly.
+  var rename: String?
+  /// Whether the profile has to be re-enabled.
+  var enable: Bool
+
+  var isEmpty: Bool { rename == nil && !enable }
+}
+
+/// Returns what a launchable profile needs corrected.
+///
+/// These are drift, not defects: a profile with a foreign name or one the user
+/// disabled in System Settings still starts a tunnel once fixed up, so it is
+/// corrected in place. Rebuilding instead would cost a VPN-permission prompt.
+func vpnProfileRepairs(currentName: String?, isEnabled: Bool) -> VPNProfileRepairs {
+  VPNProfileRepairs(
+    rename: currentName == VPNProfileIdentity.name ? nil : VPNProfileIdentity.name,
+    enable: !isEnabled
+  )
+}
+
 protocol VPNBase: ObservableObject {
   var connectionStatus: NEVPNStatus { get }
   func startTunnel() async throws

--- a/macos/Runner/VPN/VPNManager.swift
+++ b/macos/Runner/VPN/VPNManager.swift
@@ -98,30 +98,91 @@ class VPNManager: VPNBase {
   private func setupVPN() async {
     do {
       let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-      if let existing = managers.first {
-        self.manager = existing
-        appLogger.log("Found existing VPN manager")
-      } else {
-        appLogger.log("No VPN profiles found, creating new profile")
-        createNewProfile()
-        try await self.manager.saveToPreferences()
-        try await self.manager.loadFromPreferences()
-        appLogger.log("Created and loaded new VPN profile")
+      if let reusable = await firstLaunchableProfile(among: managers) {
+        self.manager = reusable
+        try await repairProfile(reusable)
+        appLogger.log("Reusing existing VPN profile")
+        return
       }
+      if managers.isEmpty {
+        appLogger.log("No VPN profiles found, creating new profile")
+      } else {
+        appLogger.log("No saved VPN profile is launchable by this build, rebuilding")
+        await removeExistingVPNProfiles()
+      }
+      createNewProfile()
+      try await self.manager.saveToPreferences()
+      try await self.manager.loadFromPreferences()
+      appLogger.log("Created and loaded new VPN profile")
     } catch {
       appLogger.error("Failed to set up VPN: \(error.localizedDescription)")
     }
+  }
+
+  /// Returns the first saved profile this build can actually launch.
+  ///
+  /// Each candidate is refreshed from preferences before it is inspected:
+  /// `loadAllFromPreferences()` can hand back a manager whose configuration has
+  /// not been faulted in, and validating unpopulated fields would reject a
+  /// perfectly good profile.
+  private func firstLaunchableProfile(
+    among managers: [NETunnelProviderManager]
+  ) async -> NETunnelProviderManager? {
+    for candidate in managers {
+      do {
+        try await candidate.loadFromPreferences()
+      } catch {
+        // One unreadable profile must not hide a good one behind it, nor abort
+        // setup into the rebuild path when a usable profile may still follow.
+        appLogger.error(
+          "Skipping unreadable VPN profile \(candidate.localizedDescription ?? "Unnamed"): \(error.localizedDescription)"
+        )
+        continue
+      }
+      let tunnelProtocol = candidate.protocolConfiguration as? NETunnelProviderProtocol
+      guard
+        let defect = vpnProfileDefect(
+          isTunnelProfile: tunnelProtocol != nil,
+          providerBundleID: tunnelProtocol?.providerBundleIdentifier
+        )
+      else {
+        return candidate
+      }
+      appLogger.log(
+        "Discarding VPN profile \(candidate.localizedDescription ?? "Unnamed"): \(defect)")
+    }
+    return nil
+  }
+
+  /// Applies the corrections a launchable profile needs before use.
+  private func repairProfile(_ manager: NETunnelProviderManager) async throws {
+    let repairs = vpnProfileRepairs(
+      currentName: manager.localizedDescription,
+      isEnabled: manager.isEnabled
+    )
+    guard !repairs.isEmpty else { return }
+    if let rename = repairs.rename {
+      appLogger.log(
+        "Renaming VPN profile \(manager.localizedDescription ?? "Unnamed") to \(rename)")
+      manager.localizedDescription = rename
+    }
+    if repairs.enable {
+      appLogger.log("VPN profile is disabled, re-enabling")
+      manager.isEnabled = true
+    }
+    try await manager.saveToPreferences()
+    try await manager.loadFromPreferences()
   }
 
   // Sets up a new VPN configuration for Lantern.
   private func createNewProfile() {
     let manager = NETunnelProviderManager()
     let tunnelProtocol = NETunnelProviderProtocol()
-    tunnelProtocol.providerBundleIdentifier = "org.getlantern.lantern.PacketTunnel"
+    tunnelProtocol.providerBundleIdentifier = VPNProfileIdentity.providerBundleID
     tunnelProtocol.serverAddress = "0.0.0.0"
 
     manager.protocolConfiguration = tunnelProtocol
-    manager.localizedDescription = "Lantern"
+    manager.localizedDescription = VPNProfileIdentity.name
     manager.isEnabled = true
 
     let alwaysConnectRule = NEOnDemandRuleConnect()

--- a/macos/Runner/VPN/VPNManager.swift
+++ b/macos/Runner/VPN/VPNManager.swift
@@ -62,8 +62,11 @@ class VPNManager: VPNBase {
   func syncStatus() async {
     do {
       let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-      guard let existing = managers.first else {
-        // No VPN profile configured yet — nothing to sync.
+      guard let existing = await firstLaunchableProfile(among: managers) else {
+        // Nothing configured yet, or nothing this build can launch. Adopting an
+        // unlaunchable profile here would be worse than adopting none: the stop
+        // path reads this manager's status, and a stale profile reporting
+        // .disconnected makes it skip tearing down the tunnel that is running.
         return
       }
       self.manager = existing
@@ -83,40 +86,53 @@ class VPNManager: VPNBase {
     }
   }
 
-  private func removeExistingVPNProfiles() async {
-    do {
-      let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-      for manager in managers {
+  /// Removes every saved profile, attempting all of them even if one fails, and
+  /// rethrows the first failure.
+  ///
+  /// A profile left behind is found again by the next `loadAllFromPreferences()`,
+  /// so a partial clear is not a rebuild: the caller must not go on to create a
+  /// replacement and report success while the unlaunchable profile is still there.
+  private func removeExistingVPNProfiles() async throws {
+    let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+    var firstFailure: Error?
+    for manager in managers {
+      do {
         appLogger.log("Removing VPN configuration: \(manager.localizedDescription ?? "Unnamed")")
         try await manager.removeFromPreferences()
+      } catch {
+        appLogger.error("Unable to remove VPN profile: \(error.localizedDescription)")
+        firstFailure = firstFailure ?? error
       }
-    } catch {
-      appLogger.error("Unable to remove VPN profile: \(error.localizedDescription)")
+    }
+    if let firstFailure {
+      throw firstFailure
     }
   }
 
-  private func setupVPN() async {
-    do {
-      let managers = try await NETunnelProviderManager.loadAllFromPreferences()
-      if let reusable = await firstLaunchableProfile(among: managers) {
-        self.manager = reusable
-        try await repairProfile(reusable)
-        appLogger.log("Reusing existing VPN profile")
-        return
-      }
-      if managers.isEmpty {
-        appLogger.log("No VPN profiles found, creating new profile")
-      } else {
-        appLogger.log("No saved VPN profile is launchable by this build, rebuilding")
-        await removeExistingVPNProfiles()
-      }
-      createNewProfile()
-      try await self.manager.saveToPreferences()
-      try await self.manager.loadFromPreferences()
-      appLogger.log("Created and loaded new VPN profile")
-    } catch {
-      appLogger.error("Failed to set up VPN: \(error.localizedDescription)")
+  /// Ensures `manager` holds a profile this build can launch, rebuilding if none
+  /// of the saved ones qualify.
+  ///
+  /// Throws rather than logging: every caller starts a tunnel immediately
+  /// afterwards, and starting one against a profile we failed to repair or
+  /// rebuild is the silent failure this whole path exists to prevent.
+  private func setupVPN() async throws {
+    let managers = try await NETunnelProviderManager.loadAllFromPreferences()
+    if let reusable = await firstLaunchableProfile(among: managers) {
+      self.manager = reusable
+      try await repairProfile(reusable)
+      appLogger.log("Reusing existing VPN profile")
+      return
     }
+    if managers.isEmpty {
+      appLogger.log("No VPN profiles found, creating new profile")
+    } else {
+      appLogger.log("No saved VPN profile is launchable by this build, rebuilding")
+      try await removeExistingVPNProfiles()
+    }
+    createNewProfile()
+    try await self.manager.saveToPreferences()
+    try await self.manager.loadFromPreferences()
+    appLogger.log("Created and loaded new VPN profile")
   }
 
   /// Returns the first saved profile this build can actually launch.
@@ -204,7 +220,7 @@ class VPNManager: VPNBase {
 
   private func startTunnel(operationID: UInt) async throws {
     appLogger.log("Starting tunnel..")
-    await self.setupVPN()
+    try await self.setupVPN()
     guard await lifecycleCoordinator.canContinueConnectionOperation(operationID) else {
       throw VPNManagerError.operationInProgress
     }
@@ -231,7 +247,7 @@ class VPNManager: VPNBase {
   }
 
   private func connectToServer(serverName: String, operationID: UInt) async throws {
-    await self.setupVPN()
+    try await self.setupVPN()
     guard await lifecycleCoordinator.canContinueConnectionOperation(operationID) else {
       throw VPNManagerError.operationInProgress
     }

--- a/macos/Runner/VPN/VPNManager.swift
+++ b/macos/Runner/VPN/VPNManager.swift
@@ -92,10 +92,16 @@ class VPNManager: VPNBase {
   /// A profile left behind is found again by the next `loadAllFromPreferences()`,
   /// so a partial clear is not a rebuild: the caller must not go on to create a
   /// replacement and report success while the unlaunchable profile is still there.
-  private func removeExistingVPNProfiles() async throws {
+  private func removeExistingVPNProfiles(operationID: UInt) async throws {
     let managers = try await NETunnelProviderManager.loadAllFromPreferences()
     var firstFailure: Error?
     for manager in managers {
+      // Re-checked per profile rather than once for the loop: each removal is a
+      // separate await that can block, so a stop can land between two of them.
+      // Cancellation wins over `firstFailure` — the next setup attempt retries
+      // the removals, and continuing to delete profiles while teardown runs is
+      // the thing being prevented.
+      try await requireOperation(operationID)
       do {
         appLogger.log("Removing VPN configuration: \(manager.localizedDescription ?? "Unnamed")")
         try await manager.removeFromPreferences()
@@ -116,11 +122,13 @@ class VPNManager: VPNBase {
   /// afterwards, and starting one against a profile we failed to repair or
   /// rebuild is the silent failure this whole path exists to prevent.
   ///
-  /// `operationID` gates every write. The preference calls below can block on a
-  /// system permission prompt, and `beginStopOperation()` waits only 5s for this
-  /// operation to hand the manager back — past that a stop proceeds to teardown
-  /// while this call is still running, so a canceled start must not still be
-  /// removing profiles or saving new ones underneath it.
+  /// `operationID` is re-checked immediately before every preference write —
+  /// each `removeFromPreferences()` and the `saveToPreferences()` of a new
+  /// profile — not once up front. Each of those is a separate await that can
+  /// block on a system permission prompt, and `beginStopOperation()` waits only
+  /// 5s for this operation to hand the manager back; past that a stop proceeds
+  /// to teardown while this call is still running, so a canceled start must not
+  /// still be removing profiles or saving new ones underneath it.
   private func setupVPN(operationID: UInt) async throws {
     let managers = try await NETunnelProviderManager.loadAllFromPreferences()
     if let reusable = await firstLaunchableProfile(among: managers) {
@@ -131,21 +139,27 @@ class VPNManager: VPNBase {
       appLogger.log("Reusing existing VPN profile")
       return
     }
-    try await requireOperation(operationID)
     if managers.isEmpty {
       appLogger.log("No VPN profiles found, creating new profile")
     } else {
       appLogger.log("No saved VPN profile is launchable by this build, rebuilding")
-      try await removeExistingVPNProfiles()
+      try await removeExistingVPNProfiles(operationID: operationID)
     }
     let created = createNewProfile()
+    try await requireOperation(operationID)
     try await created.saveToPreferences()
     try await created.loadFromPreferences()
     self.manager = created
     appLogger.log("Created and loaded new VPN profile")
   }
 
-  /// Throws when a stop has canceled this connection operation.
+  /// Throws unless this operation still owns the VPN lifecycle.
+  ///
+  /// Ownership is lost when a stop is pending, and also when the stop handoff
+  /// already expired and released `activeConnectionID` (`VPNBase.swift`,
+  /// `expireStopHandoff`) — so this is broader than "a stop canceled us", and
+  /// `.operationInProgress` is the same error the coordinator raises for any
+  /// other lifecycle contention.
   private func requireOperation(_ operationID: UInt) async throws {
     guard await lifecycleCoordinator.canContinueConnectionOperation(operationID) else {
       throw VPNManagerError.operationInProgress

--- a/macos/Runner/VPN/VPNManager.swift
+++ b/macos/Runner/VPN/VPNManager.swift
@@ -115,24 +115,41 @@ class VPNManager: VPNBase {
   /// Throws rather than logging: every caller starts a tunnel immediately
   /// afterwards, and starting one against a profile we failed to repair or
   /// rebuild is the silent failure this whole path exists to prevent.
-  private func setupVPN() async throws {
+  ///
+  /// `operationID` gates every write. The preference calls below can block on a
+  /// system permission prompt, and `beginStopOperation()` waits only 5s for this
+  /// operation to hand the manager back — past that a stop proceeds to teardown
+  /// while this call is still running, so a canceled start must not still be
+  /// removing profiles or saving new ones underneath it.
+  private func setupVPN(operationID: UInt) async throws {
     let managers = try await NETunnelProviderManager.loadAllFromPreferences()
     if let reusable = await firstLaunchableProfile(among: managers) {
+      try await repairProfile(reusable, operationID: operationID)
+      // Adopted only once it is known good, so a concurrent stop never sees a
+      // half-repaired manager.
       self.manager = reusable
-      try await repairProfile(reusable)
       appLogger.log("Reusing existing VPN profile")
       return
     }
+    try await requireOperation(operationID)
     if managers.isEmpty {
       appLogger.log("No VPN profiles found, creating new profile")
     } else {
       appLogger.log("No saved VPN profile is launchable by this build, rebuilding")
       try await removeExistingVPNProfiles()
     }
-    createNewProfile()
-    try await self.manager.saveToPreferences()
-    try await self.manager.loadFromPreferences()
+    let created = createNewProfile()
+    try await created.saveToPreferences()
+    try await created.loadFromPreferences()
+    self.manager = created
     appLogger.log("Created and loaded new VPN profile")
+  }
+
+  /// Throws when a stop has canceled this connection operation.
+  private func requireOperation(_ operationID: UInt) async throws {
+    guard await lifecycleCoordinator.canContinueConnectionOperation(operationID) else {
+      throw VPNManagerError.operationInProgress
+    }
   }
 
   /// Returns the first saved profile this build can actually launch.
@@ -171,12 +188,16 @@ class VPNManager: VPNBase {
   }
 
   /// Applies the corrections a launchable profile needs before use.
-  private func repairProfile(_ manager: NETunnelProviderManager) async throws {
+  private func repairProfile(
+    _ manager: NETunnelProviderManager,
+    operationID: UInt
+  ) async throws {
     let repairs = vpnProfileRepairs(
       currentName: manager.localizedDescription,
       isEnabled: manager.isEnabled
     )
     guard !repairs.isEmpty else { return }
+    try await requireOperation(operationID)
     if let rename = repairs.rename {
       appLogger.log(
         "Renaming VPN profile \(manager.localizedDescription ?? "Unnamed") to \(rename)")
@@ -190,8 +211,9 @@ class VPNManager: VPNBase {
     try await manager.loadFromPreferences()
   }
 
-  // Sets up a new VPN configuration for Lantern.
-  private func createNewProfile() {
+  /// Builds a fresh VPN configuration for Lantern. The caller adopts it only
+  /// after it has been saved and reloaded.
+  private func createNewProfile() -> NETunnelProviderManager {
     let manager = NETunnelProviderManager()
     let tunnelProtocol = NETunnelProviderProtocol()
     tunnelProtocol.providerBundleIdentifier = VPNProfileIdentity.providerBundleID
@@ -205,7 +227,7 @@ class VPNManager: VPNBase {
     manager.onDemandRules = [alwaysConnectRule]
 
     manager.isOnDemandEnabled = false
-    self.manager = manager
+    return manager
   }
 
   // MARK: - VPN Control Methods
@@ -220,7 +242,7 @@ class VPNManager: VPNBase {
 
   private func startTunnel(operationID: UInt) async throws {
     appLogger.log("Starting tunnel..")
-    try await self.setupVPN()
+    try await self.setupVPN(operationID: operationID)
     guard await lifecycleCoordinator.canContinueConnectionOperation(operationID) else {
       throw VPNManagerError.operationInProgress
     }
@@ -247,7 +269,7 @@ class VPNManager: VPNBase {
   }
 
   private func connectToServer(serverName: String, operationID: UInt) async throws {
-    try await self.setupVPN()
+    try await self.setupVPN(operationID: operationID)
     guard await lifecycleCoordinator.canContinueConnectionOperation(operationID) else {
       throw VPNManagerError.operationInProgress
     }

--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -35,6 +35,106 @@ final class RunnerTests: XCTestCase {
     }
   }
 
+  // MARK: - VPN profile reuse (engineering#3827)
+
+  func testProfileWithCurrentProviderIsLaunchable() {
+    XCTAssertNil(
+      vpnProfileDefect(
+        isTunnelProfile: true,
+        providerBundleID: VPNProfileIdentity.providerBundleID
+      )
+    )
+  }
+
+  func testProfileWithHistoricalProviderIsRejected() {
+    // Every provider bundle ID this app has shipped under. A profile saved by an
+    // older build names one of these; macOS still starts a tunnel against it and
+    // kills the session in tens of milliseconds without raising an error.
+    let retired = [
+      "org.getlantern.lantern.Tunnel",
+      "org.getlantern.lantern.packet",
+      "org.getlantern.lantern.PacketTunnel.old",
+    ]
+    for providerBundleID in retired {
+      XCTAssertEqual(
+        vpnProfileDefect(isTunnelProfile: true, providerBundleID: providerBundleID),
+        .unknownProvider(found: providerBundleID),
+        "expected \(providerBundleID) to be rejected"
+      )
+    }
+    XCTAssertEqual(
+      vpnProfileDefect(isTunnelProfile: true, providerBundleID: nil),
+      .unknownProvider(found: nil)
+    )
+  }
+
+  func testProfileWithoutTunnelProtocolIsRejected() {
+    XCTAssertEqual(
+      vpnProfileDefect(isTunnelProfile: false, providerBundleID: nil),
+      .notATunnelProfile
+    )
+    // A non-tunnel profile is rejected on shape, whatever else it carries.
+    XCTAssertEqual(
+      vpnProfileDefect(
+        isTunnelProfile: false,
+        providerBundleID: VPNProfileIdentity.providerBundleID
+      ),
+      .notATunnelProfile
+    )
+  }
+
+  func testDefectDescriptionNamesFoundAndExpectedProvider() {
+    let description = VPNProfileDefect.unknownProvider(found: "org.getlantern.lantern.Tunnel")
+      .description
+    // This string is the only breadcrumb in the log when a profile is discarded.
+    XCTAssertTrue(description.contains("org.getlantern.lantern.Tunnel"))
+    XCTAssertTrue(description.contains(VPNProfileIdentity.providerBundleID))
+  }
+
+  /// A foreign profile name must be repaired, never treated as a defect.
+  ///
+  /// iOS keys its staleness check on the name (`Profile.swift`, `needsMigration()`
+  /// compares against "LanternVPN") while macOS names the profile "Lantern".
+  /// Porting that check here would make every macOS profile look stale and
+  /// rebuild it on every launch, prompting the user each time.
+  func testForeignProfileNameIsRepairedNotRejected() {
+    XCTAssertNotEqual(
+      VPNProfileIdentity.name, "LanternVPN",
+      "macOS and iOS name their profiles differently — the name cannot gate reuse")
+
+    // Launchability does not consider the name at all.
+    XCTAssertNil(
+      vpnProfileDefect(
+        isTunnelProfile: true,
+        providerBundleID: VPNProfileIdentity.providerBundleID
+      )
+    )
+
+    let repairs = vpnProfileRepairs(currentName: "LanternVPN", isEnabled: true)
+    XCTAssertEqual(repairs.rename, VPNProfileIdentity.name)
+    XCTAssertFalse(repairs.enable)
+  }
+
+  func testCorrectlyNamedEnabledProfileNeedsNoRepair() {
+    let repairs = vpnProfileRepairs(currentName: VPNProfileIdentity.name, isEnabled: true)
+    XCTAssertTrue(repairs.isEmpty)
+    XCTAssertNil(repairs.rename)
+    XCTAssertFalse(repairs.enable)
+  }
+
+  func testDisabledProfileIsReEnabled() {
+    let repairs = vpnProfileRepairs(currentName: VPNProfileIdentity.name, isEnabled: false)
+    XCTAssertFalse(repairs.isEmpty)
+    XCTAssertNil(repairs.rename)
+    XCTAssertTrue(repairs.enable)
+  }
+
+  func testUnnamedProfileIsRenamed() {
+    let repairs = vpnProfileRepairs(currentName: nil, isEnabled: false)
+    XCTAssertEqual(repairs.rename, VPNProfileIdentity.name)
+    XCTAssertTrue(repairs.enable)
+  }
+
   func testVPNStopStates() throws {
     for status in [NEVPNStatus.connected, .connecting, .reasserting] {
       XCTAssertTrue(try shouldStopTunnel(for: status))


### PR DESCRIPTION
## What

macOS `setupVPN()` reused whatever VPN profile it found first, without checking the current build could launch it. It now validates the provider bundle ID before reuse, rebuilds when no saved profile is launchable, and repairs name/enabled drift in place.

Fixes [engineering#3827](https://github.com/getlantern/engineering/issues/3827) (FD [#181603](https://lantern.freshdesk.com/a/tickets/181603) — Pro user in China, Connect toggle springs back in 20-70ms, VPN never worked on that machine across six versions since April).

## The bug

`providerBundleIdentifier` has churned four times (`.Tunnel` → `.PacketTunnel` → `.packet` → `.PacketTunnel`). A profile saved by an older build can name a provider this build does not contain. macOS **accepts** `startVPNTunnel` against such a profile and tears the session down within tens of milliseconds — without throwing. So the failure is invisible *and* unrecoverable: nothing surfaces an error, and nothing ever rebuilds the profile.

```mermaid
sequenceDiagram
    autonumber
    participant UI as Flutter UI<br/>vpn_notifier.dart
    participant MH as MethodHandler<br/>MethodHandler.swift
    participant VM as VPNManager<br/>VPNManager.swift
    participant NE as macOS<br/>NetworkExtension
    participant PT as PacketTunnel<br/>provider

    UI->>MH: vpn_notifier.dart:169<br/>lantern.startVPN()
    MH->>VM: MethodHandler.swift:501<br/>try await vpnManager.startTunnel()
    VM->>VM: VPNManager.swift:146<br/>await setupVPN()
    rect rgba(255, 200, 200, 0.3)
        Note over VM: VPNManager.swift:101<br/>managers.first taken as-is —<br/>no reload, no provider check ⚠️
    end
    VM->>NE: VPNManager.swift:203<br/>startVPNTunnel(options:)
    rect rgba(255, 200, 200, 0.3)
        NE-xPT: provider bundle ID not in this build —<br/>process never launches 🐛
    end
    NE-->>VM: returns without throwing —<br/>session dies in 20-70ms
    VM-->>MH: no error
    MH-->>UI: MethodHandler.swift:503<br/>result("VPN started successfully.")
```

Line numbers are pre-fix, against `main` at `3bd2cef26`.

Evidence from the reporter's logs: `Found existing VPN manager` 124x vs `No VPN profiles found, creating new profile` 0x over four months, and zero `PacketTunnelProvider starting tunnel` lines across four attached logs — the provider process never ran user code.

## The fix

`VPNBase.swift` gains the expected identity and two pure decision functions, matching the existing `shouldStartNewTunnel` / `shouldStopTunnel` pattern so both are unit-testable:

- `VPNProfileIdentity` — the provider bundle ID and profile name this build expects. `SystemExtensionManager` and `createNewProfile()` now both read from it instead of repeating the literal.
- `vpnProfileDefect(isTunnelProfile:providerBundleID:)` — why a saved profile is unlaunchable, or `nil`.
- `vpnProfileRepairs(currentName:isEnabled:)` — what a launchable profile needs corrected.

`setupVPN()` then reloads each candidate from preferences, reuses the first launchable one, and otherwise removes the saved profiles and rebuilds — wiring up `removeExistingVPNProfiles()`, which until now was declared and never called.

Setup failures propagate rather than being logged. `setupVPN()` and `removeExistingVPNProfiles()` both `throw`; every caller was already `async throws`, so a profile we could not repair or rebuild now surfaces an error instead of starting a tunnel anyway — the same silent failure this PR is about, one layer up. `removeExistingVPNProfiles()` attempts every profile before rethrowing the first error, because a profile left behind is returned by the next `loadAllFromPreferences()` and a partial clear is not a rebuild.

Profile writes are gated on the connection operation still being live. `setupVPN()` runs before `startTunnel()`'s first validity check, and this PR widened what it writes there — the reuse path previously wrote nothing and now saves repairs; the rebuild path removes every saved profile. Those preference calls can block on the system permission prompt, and `beginStopOperation()` waits only 5s for the handoff, so past that a canceled start could mutate profiles while teardown runs. `operationID` is now threaded through and checked before each write, and managers are adopted only once known good (`self.manager` is assigned after repair succeeds; `createNewProfile()` returns rather than assigns, so it is adopted only after save and reload).

`syncStatus()` uses the same launchable-profile selection. It assigns `self.manager`, and `stopTunnelAfterHandoff()` calls it and then reads that manager's status — so a stale profile reporting `.disconnected` made stop skip tearing down the tunnel that was actually running. It now adopts nothing when no saved profile qualifies, and still never creates one, so first launch does not trigger the permission prompt.

### Only the bundle ID is disqualifying

The issue suggested treating a name mismatch as staleness too, following iOS. **Deliberately not doing that.** iOS's `needsMigration()` compares against `"LanternVPN"` (`ios/Runner/VPN/Profile.swift:102`) while macOS names its profile `"Lantern"` (`VPNManager.swift:124`) — ported literally, every macOS profile looks stale and gets rebuilt on every launch, prompting the user for VPN permission each time.

A wrong name doesn't stop a tunnel from starting; a wrong provider does. So the name is **repaired in place**, and only the provider gates reuse. `testForeignProfileNameIsRepairedNotRejected` pins this, including an assertion that the two platform names differ.

## Tests

Eight cases in `macos/RunnerTests/RunnerTests.swift`: reuse on a matching provider; rejection of each retired provider ID and of `nil`; rejection of a non-tunnel profile; the discard log line naming both providers; foreign name repaired not rejected; no-op when already correct; re-enable when disabled; rename when unnamed.

## Not in this PR

Two items from the issue's Suggested Fix, both deliberately deferred:

**Masked success on `startVPNTunnel`.** Making the no-throw path distinguishable from a real connection means gating connect on an observed status transition with a timeout. That is a behavior change in the connect path for every user and every platform path through `startOrNotifyExistingTunnel`; a too-tight window turns slow connects into failures. It deserves its own PR validated on the `lantern-macos-smoke` runner, not a rider on a root-cause fix.

**The CI gap — the issue's framing is wrong.** It proposes adding a tunnel-start check to `SystemExtensionSmokeCommand.swift`. A tunnel-start check already exists (`run_connect_smoke` in `build-macos.yml`, which `release.yml:401` enables on tag pushes and the nightly schedule). It cannot catch this class of bug for a different reason: **the fault requires a profile saved by an older build, and a clean CI machine has none** — it always takes the create-new-profile path. Catching it in CI would require the smoke to first plant a stale profile, then connect. Worth doing, but it needs the self-hosted runner and is not a code change to the smoke command. Separately, no workflow that runs the connect smoke triggers on `pull_request` at all.

## Verification

`make macos-unit-tests` locally (gomobile bind + `xcodebuild test -only-testing:RunnerTests`): **45 passed, 0 failed**.

That local run is the only verification this PR gets. **No workflow compiles macOS Swift on a pull request** — only `android-compile-check`, `flutter-test`, `go`, and `update-issue-status` trigger on `pull_request`. `make macos-unit-tests` runs from `build-macos.yml:229`, which is reached only via `release.yml` (tag push, nightly schedule) and manual dispatch. So the green checks here say nothing about this change, and a regression in it would first surface at the nightly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VPN profile validation for incompatible, outdated, or non-tunnel profiles.
  * Automatically repairs eligible profiles by correcting their name and re-enabling them.
  * Reuses valid saved VPN profiles and removes unusable profiles before creating replacements.
  * Ensures newly created profiles use the current provider configuration.
  * Improves VPN setup and synchronization error handling so failures are reported reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


