### PR TITLE
macos/ios: tear down a live tunnel before starting a new one

### DIFF
--- a/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/ios/Tunnel/SingBox/ExtensionPlatformInterface.swift
@@ -236,8 +236,12 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
       return
     }
 
+    // Scans the process for the lowest-numbered utun, so it is only correct while
+    // exactly one is open — see the teardown guard in ExtensionProvider.startTunnel
+    // (getlantern/engineering#3781). Logged so a recurrence is distinguishable.
     let tunFdFromLoop = LibboxGetTunnelFileDescriptor()
     if tunFdFromLoop != -1 {
+      appLogger.info("Returning tunnel file descriptor \(tunFdFromLoop) (from C loop)")
       ret0_.pointee = tunFdFromLoop
     } else {
       throw NSError(domain: "missing file descriptor", code: 0)
@@ -269,6 +273,11 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
     guard let listener else {
       return
     }
+    // libbox can start a monitor without closing the previous one — the reporter's
+    // logs in getlantern/engineering#3781 show 72 monitors started against 59
+    // closed. Replacing the reference without cancelling leaks the old
+    // NWPathMonitor, which keeps pushing path updates into a dead sing-box.
+    nwMonitor?.cancel()
     let monitor = NWPathMonitor()
     nwMonitor = monitor
     let semaphore = DispatchSemaphore(value: 0)

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -25,9 +25,49 @@ import NetworkExtension
 class ExtensionProvider: NEPacketTunnelProvider {
   private var platformInterface: ExtensionPlatformInterface!
 
+  /// Whether a tunnel bring-up has been attempted and not yet torn down.
+  ///
+  /// The extension process outlives the app, so this survives an app quit —
+  /// unlike any state the app holds. Guarded because `startTunnel` and
+  /// `stopTunnel` arrive on NetworkExtension's queue while `restartService`
+  /// arrives on a libbox thread.
+  private let tunnelStateQueue = DispatchQueue(
+    label: "org.getlantern.lantern.Tunnel.tunnelState")
+  private var _tunnelIsRunning = false
+
+  /// Marks a bring-up as starting and reports whether one was already live.
+  /// Test and set are atomic so two starts cannot both see "nothing running".
+  private func claimTunnel() -> Bool {
+    tunnelStateQueue.sync {
+      let wasRunning = _tunnelIsRunning
+      _tunnelIsRunning = true
+      return wasRunning
+    }
+  }
+
+  private func setTunnelRunning(_ running: Bool) {
+    tunnelStateQueue.sync { _tunnelIsRunning = running }
+  }
+
   override open func startTunnel(options: [String: NSObject]?) async throws {
     if platformInterface == nil {
       platformInterface = ExtensionPlatformInterface(self)
+    }
+
+    // A start can arrive while the previous tunnel is still up: the extension
+    // process outlives the app, so a force-quit without disconnecting — or an
+    // app-side stop that no-ops on a stale NEVPNStatus — leaves it running.
+    // Starting on top leaves the old utun open, and openTun's fallback then
+    // hands the new sing-box the lowest-numbered utun in the process (the dead
+    // one) while the system routes traffic to the new interface. Every packet
+    // is blackholed until the extension process is killed, which is why
+    // reporters find that only a reboot fixes it (getlantern/engineering#3781).
+    //
+    // Claimed before the bring-up rather than after: a start that fails partway
+    // can still have opened a utun.
+    if claimTunnel() {
+      appLogger.info("(lantern-tunnel) start arrived with a live tunnel; stopping it first")
+      stopService()
     }
 
     // Start the IPC server before any VPN operations
@@ -153,6 +193,7 @@ class ExtensionProvider: NEPacketTunnelProvider {
     if error != nil {
       appLogger.log("error while stopping tunnel \(error?.localizedDescription ?? "")")
     }
+    setTunnelRunning(false)
     postServiceClose()
   }
 
@@ -174,6 +215,7 @@ class ExtensionProvider: NEPacketTunnelProvider {
       cancelTunnelWithError(error)
       throw error
     }
+    setTunnelRunning(true)
     appLogger.log("(lantern-tunnel) tunnel restarted successfully")
   }
 

--- a/ios/Tunnel/SingBox/ExtensionProvider.swift
+++ b/ios/Tunnel/SingBox/ExtensionProvider.swift
@@ -164,6 +164,9 @@ class ExtensionProvider: NEPacketTunnelProvider {
   override open func stopTunnel(with reason: NEProviderStopReason) async {
     let startTime = Date()
     appLogger.log("(lantern-tunnel) stopping, reason: \(reason)")
+    // The tunnel is genuinely going away, so ownership is released here rather
+    // than inside stopService().
+    setTunnelRunning(false)
     stopService()
     var error: NSError?
     MobileCloseIPCServer(&error)
@@ -193,7 +196,12 @@ class ExtensionProvider: NEPacketTunnelProvider {
     if error != nil {
       appLogger.log("error while stopping tunnel \(error?.localizedDescription ?? "")")
     }
-    setTunnelRunning(false)
+    // Deliberately does not release the claim. This is a teardown primitive:
+    // startTunnel calls it to replace a tunnel it still owns, and restartService
+    // calls it mid-restart. Releasing here would let a second start observe
+    // "nothing running" and begin a bring-up overlapping the replacement.
+    // Ownership is released only where the tunnel is genuinely going away —
+    // stopTunnel(with:).
     postServiceClose()
   }
 

--- a/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
@@ -262,11 +262,17 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
       return
     }
 
+    // This fallback carries every tunnel on macOS 12, where the KVC path above
+    // never resolves. It scans the process for the lowest-numbered utun, so it is
+    // only correct while exactly one is open — which is what the teardown guard in
+    // ExtensionProvider.startTunnel exists to ensure. Logged so a recurrence can be
+    // told apart from a stale-fd selection in a user's logs.
     appLogger.info("Accessing tunnel file descriptor from C loop...")
     let tunFdFromLoop = LibboxGetTunnelFileDescriptor()
     guard tunFdFromLoop != -1 else {
       throw NSError(domain: "Missing TUN FD", code: 0)
     }
+    appLogger.info("Returning tunnel file descriptor \(tunFdFromLoop) (from C loop)")
     ret0_.pointee = tunFdFromLoop
   }
 
@@ -299,6 +305,11 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
       return
     }
     appLogger.info("startDefaultInterfaceMonitor: monitoring default interface")
+    // libbox can start a monitor without closing the previous one — the reporter's
+    // logs in getlantern/engineering#3781 show 72 monitors started against 59
+    // closed. Replacing the reference without cancelling leaks the old
+    // NWPathMonitor, which keeps pushing path updates into a dead sing-box.
+    nwMonitor?.cancel()
     let monitor = NWPathMonitor()
     nwMonitor = monitor
     let semaphore = DispatchSemaphore(value: 0)

--- a/macos/PacketTunnel/SingBox/ExtensionProvider.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionProvider.swift
@@ -172,7 +172,7 @@ public class ExtensionProvider: NEPacketTunnelProvider {
       appLogger.log("error closing IPC server \(error?.localizedDescription ?? "")")
     }
     appLogger.log("(lantern-tunnel) tunnel closed")
-    // macOS tears down inline rather than through stopService(), so release here too.
+    // The tunnel is genuinely going away — the one place ownership is released.
     setTunnelRunning(false)
     platformInterface.reset()
   }
@@ -184,7 +184,12 @@ public class ExtensionProvider: NEPacketTunnelProvider {
     if error != nil {
       appLogger.log("error while stopping tunnel \(error?.localizedDescription ?? "")")
     }
-    setTunnelRunning(false)
+    // Deliberately does not release the claim. This is a teardown primitive:
+    // startTunnel calls it to replace a tunnel it still owns, and restartService
+    // calls it mid-restart. Releasing here would let a second start observe
+    // "nothing running" and begin a bring-up overlapping the replacement.
+    // Ownership is released only where the tunnel is genuinely going away —
+    // stopTunnel(with:).
     postServiceClose()
   }
 

--- a/macos/PacketTunnel/SingBox/ExtensionProvider.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionProvider.swift
@@ -25,9 +25,50 @@ import OSLog
 
 public class ExtensionProvider: NEPacketTunnelProvider {
   private var platformInterface: ExtensionPlatformInterface!
+
+  /// Whether a tunnel bring-up has been attempted and not yet torn down.
+  ///
+  /// The extension process outlives the app, so this survives an app quit —
+  /// unlike any state the app holds. Guarded because `startTunnel` and
+  /// `stopTunnel` arrive on NetworkExtension's queue while `restartService`
+  /// arrives on a libbox thread.
+  private let tunnelStateQueue = DispatchQueue(
+    label: "org.getlantern.lantern.PacketTunnel.tunnelState")
+  private var _tunnelIsRunning = false
+
+  /// Marks a bring-up as starting and reports whether one was already live.
+  /// Test and set are atomic so two starts cannot both see "nothing running".
+  private func claimTunnel() -> Bool {
+    tunnelStateQueue.sync {
+      let wasRunning = _tunnelIsRunning
+      _tunnelIsRunning = true
+      return wasRunning
+    }
+  }
+
+  private func setTunnelRunning(_ running: Bool) {
+    tunnelStateQueue.sync { _tunnelIsRunning = running }
+  }
+
   override open func startTunnel(options: [String: NSObject]?) async throws {
     if platformInterface == nil {
       platformInterface = ExtensionPlatformInterface(self)
+    }
+
+    // A start can arrive while the previous tunnel is still up: the extension
+    // process outlives the app, so a force-quit without disconnecting — or an
+    // app-side stop that no-ops on a stale NEVPNStatus — leaves it running.
+    // Starting on top leaves the old utun open, and openTun's fallback then
+    // hands the new sing-box the lowest-numbered utun in the process (the dead
+    // one) while the system routes traffic to the new interface. Every packet
+    // is blackholed until the extension process is killed, which is why
+    // reporters find that only a reboot fixes it (getlantern/engineering#3781).
+    //
+    // Claimed before the bring-up rather than after: a start that fails partway
+    // can still have opened a utun.
+    if claimTunnel() {
+      appLogger.info("(lantern-tunnel) start arrived with a live tunnel; stopping it first")
+      stopService()
     }
 
     // Start the IPC server before any VPN operations
@@ -131,6 +172,8 @@ public class ExtensionProvider: NEPacketTunnelProvider {
       appLogger.log("error closing IPC server \(error?.localizedDescription ?? "")")
     }
     appLogger.log("(lantern-tunnel) tunnel closed")
+    // macOS tears down inline rather than through stopService(), so release here too.
+    setTunnelRunning(false)
     platformInterface.reset()
   }
 
@@ -141,6 +184,7 @@ public class ExtensionProvider: NEPacketTunnelProvider {
     if error != nil {
       appLogger.log("error while stopping tunnel \(error?.localizedDescription ?? "")")
     }
+    setTunnelRunning(false)
     postServiceClose()
   }
 
@@ -162,6 +206,7 @@ public class ExtensionProvider: NEPacketTunnelProvider {
       cancelTunnelWithError(error)
       throw error
     }
+    setTunnelRunning(true)
     appLogger.log("(lantern-tunnel) tunnel restarted successfully")
   }
 


### PR DESCRIPTION
## What

The PacketTunnel extension now tears down a live tunnel before starting a new one, cancels the previous `NWPathMonitor` instead of leaking it, and logs the fallback TUN descriptor. macOS and iOS both.

Addresses [engineering#3781](https://github.com/getlantern/engineering/issues/3781). Tickets: [#181146](https://lantern.freshdesk.com/a/tickets/181146), [#181457](https://lantern.freshdesk.com/a/tickets/181457), and [#181315](https://lantern.freshdesk.com/a/tickets/181315) — *"if I disconnect and then reconnect, it connects but the network doesn't work; I have to restart the computer"* (China, Pro, macOS 12.3 Monterey).

## The bug

`providerBundleIdentifier` aside, the extension process outlives the app. A start can therefore arrive while the previous tunnel is still up — the app force-quits without disconnecting, or its stop no-ops on a stale `NEVPNStatus`. `startTunnel` had no already-running guard and no teardown, so it opened a second utun on top of the first.

`openTun` then resolves the descriptor via KVC on `packetFlow`, which **never resolves on macOS 12**, falling back to `LibboxGetTunnelFileDescriptor()` — a scan that returns the *lowest-numbered* utun in the process. That is the dead one. The system routes traffic to the new interface while sing-box reads the old, and every packet is blackholed until the extension process dies. Which is why reporters find that only a reboot fixes it.

```mermaid
sequenceDiagram
    autonumber
    participant App as Lantern app<br/>VPNManager.swift
    participant NE as macOS<br/>NetworkExtension
    participant P as ExtensionProvider<br/>ExtensionProvider.swift
    participant LB as libbox openTun<br/>ExtensionPlatformInterface.swift
    participant K as kernel<br/>utun devices

    App->>NE: connect
    NE->>P: ExtensionProvider.swift:28<br/>startTunnel(options:)
    P->>LB: openTun
    LB->>K: opens utun0
    Note over K: traffic flows normally ✅

    App-->>NE: user disconnects, or app quits<br/>without a clean stop
    Note over P: ExtensionProvider.swift:122<br/>stopTunnel never runs —<br/>the extension outlives the app,<br/>so utun0 stays open ⚠️

    App->>NE: reconnect
    NE->>P: ExtensionProvider.swift:28<br/>startTunnel — no already-running<br/>guard, no teardown ⚠️
    P->>LB: openTun
    LB->>LB: ExtensionPlatformInterface.swift:259<br/>KVC socket.fileDescriptor<br/>never resolves on macOS 12
    rect rgba(255, 200, 200, 0.3)
        LB->>K: ExtensionPlatformInterface.swift:266<br/>LibboxGetTunnelFileDescriptor()<br/>returns lowest utun = utun0 (dead) 🐛
    end
    K->>K: system routes traffic to utun1
    rect rgba(255, 200, 200, 0.3)
        Note over K: sing-box reads utun0, kernel writes utun1 —<br/>every packet blackholed until the<br/>extension process dies (reboot) 🐛
    end
```

Line numbers are pre-fix, against `main` at `5464a6d6`.

## The fix

- **Teardown guard.** `startTunnel` claims the tunnel and, if one was already live, calls `stopService()` first — the same teardown `restartService()` already performs. Deliberately *not* also closing the IPC server: `restartService()` is the proven precedent for stopping and restarting a session, and it leaves the IPC server alone.
- **Claimed before the bring-up, not after**, so a start that fails partway is still known to have possibly opened a utun.
- **`nwMonitor` is cancelled before being replaced.** The reporter's logs show 72 monitors started against 59 closed; each leaked one keeps pushing path updates into a dead sing-box instance.
- **The fallback descriptor is logged**, so a recurrence can be told apart from a stale-fd selection in a user's logs. This path carries *every* tunnel on macOS 12, so it is worth seeing.

## Evaluating the existing draft

There was a draft on `auto-fix/ticket-181146` (`f8f9dec`, never opened as a PR). It cherry-picks cleanly onto `main`, and its diagnosis and shape are right — the teardown-before-start approach, claiming before bring-up, and the fallback log line are all taken from it. Four things needed changing:

1. **The flag was racy.** A plain `Bool` read from NetworkExtension's queue (`startTunnel`/`stopTunnel`) and written from a libbox thread (`restartService`). It is now guarded by a serial queue, with an atomic test-and-set (`claimTunnel()`) so two starts cannot both observe "nothing running" — following the `contextQueue` pattern already used in `SystemExtensionManager`.
2. **It predates two rewrites of the functions it patches.** engineering#3822 added the `reasserting` + `Task.detached` block to `startTunnel`, and #8965 rewrote `openTun` wholesale. Rebased onto both.
3. **It was macOS-only.** iOS has all three defects, and #3781 notes the extension outliving the app matters *more* there, since it survives tunnel stop/start.
4. **It did not fix the `nwMonitor` leak**, which #3781 lists as a follow-up.

## Not in this PR

`VPNManager.stopTunnel`'s guard, #3781's remaining follow-up. It no longer looks the way the issue describes — it now routes through `VPNLifecycleCoordinator`, and `shouldStopTunnel(for:)` still returns false for a non-connected status, which is *correct* except in the exact wedged case. Changing it means changing when the app is willing to tear down a tunnel it believes is already stopped, which deserves its own change and its own reasoning.

## Verification

- **macOS: `make macos-unit-tests` — 45 passed, 0 failed.** The `PacketTunnel` target is compiled by this build (confirmed in the build log), so the macOS changes are compile-verified, not just parsed.
- **iOS: full `xcodebuild` of the `Runner` scheme against the simulator SDK**, after `make build-ios` + `flutter build ios --config-only`, so the `Tunnel` target's Swift is compiled too.
- `swift-format` clean on all four files. Note the repo has pre-existing drift against current swift-format — running the `swift-format` Make target rewrites six unrelated files, which are deliberately not included here.

**Not runtime-verified.** The failure needs a macOS 12 machine and a reconnect that lands while the previous tunnel is still live; I can reason about the ordering but cannot reproduce it here. The new fallback-descriptor log line is what would confirm or refute a recurrence in a user's logs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel startup reliability by preventing overlapping tunnel sessions.
  * Automatically stops an existing tunnel before starting a replacement.
  * Improved tunnel restart and shutdown state handling.
  * Prevented duplicate network path monitors from running simultaneously.

* **Diagnostics**
  * Added logging for tunnel file-descriptor selection and retrieval to improve troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->