### PR TITLE
macos: bind the tunnel to the utun this start created

### DIFF
--- a/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
+++ b/macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift
@@ -262,18 +262,97 @@ public class ExtensionPlatformInterface: NSObject, UtilsPlatformInterfaceProtoco
       return
     }
 
-    // This fallback carries every tunnel on macOS 12, where the KVC path above
-    // never resolves. It scans the process for the lowest-numbered utun, so it is
-    // only correct while exactly one is open — which is what the teardown guard in
-    // ExtensionProvider.startTunnel exists to ensure. Logged so a recurrence can be
-    // told apart from a stale-fd selection in a user's logs.
+    // The KVC path above never resolves on macOS 12 or macOS 26, so this fallback
+    // carries every tunnel there. LibboxGetTunnelFileDescriptor scans the process for
+    // the lowest-numbered utun with no notion of which tunnel it belongs to, and a
+    // start that fails after applyNetworkSettings leaves an orphaned utun descriptor
+    // open for the life of the extension process. That orphan wins every later scan:
+    // sing-box reads a dead device while the system routes into the live one,
+    // blackholing every packet while the UI reads Connected. Pick the descriptor whose
+    // interface actually carries the address just installed instead.
     appLogger.info("Accessing tunnel file descriptor from C loop...")
-    let tunFdFromLoop = LibboxGetTunnelFileDescriptor()
-    guard tunFdFromLoop != -1 else {
+    ret0_.pointee = try tunnelFileDescriptor(
+      carrying: Set(settings.ipv4Settings?.addresses ?? []))
+  }
+
+  // SYSPROTO_CONTROL and UTUN_OPT_IFNAME, spelled out because <sys/sys_domain.h> and
+  // <net/if_utun.h> are not exposed to Swift.
+  private static let sysprotoControl: Int32 = 2
+  private static let utunOptIfname: Int32 = 2
+
+  /// Interface name of `fd` when it is a utun descriptor, otherwise nil.
+  ///
+  /// This is the same query sing-box makes of the descriptor it is handed
+  /// (`getTunnelName`), so a name returned here is the name sing-box will bind to.
+  private func utunInterfaceName(of fd: Int32) -> String? {
+    var name = [CChar](repeating: 0, count: 64)
+    var length = socklen_t(name.count)
+    guard getsockopt(fd, Self.sysprotoControl, Self.utunOptIfname, &name, &length) == 0 else {
+      return nil
+    }
+    let interfaceName = String(cString: name)
+    // Other kernel-control sockets answer option 2 with something of their own, so
+    // require the answer to actually name a utun.
+    return interfaceName.hasPrefix("utun") ? interfaceName : nil
+  }
+
+  /// Names of the interfaces currently carrying any of `addresses`.
+  private func interfaceNames(carrying addresses: Set<String>) -> Set<String> {
+    var names: Set<String> = []
+    var head: UnsafeMutablePointer<ifaddrs>?
+    guard getifaddrs(&head) == 0, let first = head else {
+      return names
+    }
+    defer { freeifaddrs(first) }
+    for ifa in sequence(first: first, next: { $0.pointee.ifa_next }) {
+      guard let address = ifa.pointee.ifa_addr, address.pointee.sa_family == UInt8(AF_INET)
+      else {
+        continue
+      }
+      var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+      guard
+        getnameinfo(
+          address, socklen_t(address.pointee.sa_len), &host, socklen_t(host.count), nil, 0,
+          NI_NUMERICHOST) == 0,
+        addresses.contains(String(cString: host))
+      else {
+        continue
+      }
+      names.insert(String(cString: ifa.pointee.ifa_name))
+    }
+    return names
+  }
+
+  /// The descriptor of the utun this tunnel just created.
+  ///
+  /// Scans the process the way LibboxGetTunnelFileDescriptor does, then keeps the
+  /// candidate whose interface holds one of the addresses just installed — the one
+  /// property that distinguishes this tunnel's device from an orphan left by an earlier
+  /// start. With no match (auto-route off, so no address was installed, or getifaddrs
+  /// racing the settings apply) it takes the highest-numbered utun rather than the
+  /// lowest: descriptors are handed out lowest-free-first, so while an orphan is still
+  /// open the newest utun sits above it.
+  private func tunnelFileDescriptor(carrying addresses: Set<String>) throws -> Int32 {
+    var candidates: [(fd: Int32, name: String)] = []
+    for fd in Int32(0)..<1024 {
+      if let name = utunInterfaceName(of: fd) {
+        candidates.append((fd, name))
+      }
+    }
+    guard let newest = candidates.last else {
       throw NSError(domain: "Missing TUN FD", code: 0)
     }
-    appLogger.info("Returning tunnel file descriptor \(tunFdFromLoop) (from C loop)")
-    ret0_.pointee = tunFdFromLoop
+    let found = candidates.map { "\($0.fd):\($0.name)" }.joined(separator: ", ")
+    let liveNames = interfaceNames(carrying: addresses)
+    if let live = candidates.last(where: { liveNames.contains($0.name) }) {
+      appLogger.info(
+        "Returning tunnel file descriptor \(live.fd) (\(live.name), from C loop; utuns: \(found))")
+      return live.fd
+    }
+    appLogger.error(
+      "No utun carries \(addresses.sorted()); returning newest tunnel file descriptor "
+        + "\(newest.fd) (\(newest.name), from C loop; utuns: \(found))")
+    return newest.fd
   }
 
   public func usePlatformAutoDetectControl() -> Bool {


### PR DESCRIPTION
## Summary

Auto-fix for Freshdesk ticket [#181905](https://lantern.freshdesk.com/a/tickets/181905) — Pro user on macOS 26.5.2 in China, app 9.1.23, UI showed **Connected** for 13 minutes with a total traffic blackhole (they reported it as "can't log in").

**Root cause.** `openTunSync`'s KVC fast path (`packetFlow.value(forKeyPath: "socket.fileDescriptor")`) returned nil on **all 10** tunnel opens ever recorded on that machine, so every open fell through to `LibboxGetTunnelFileDescriptor()` — a process-wide scan that returns the **lowest-numbered** utun descriptor with no notion of which tunnel owns it. Two earlier starts had aborted *after* `applyNetworkSettings` had already asked NetworkExtension for a utun (one `context deadline exceeded`, two `RunBlockingError error 0` — the `timedOut` case from `Extension+RunBlocking.swift:22`), leaving orphaned utun descriptors open for the life of the extension process. Being older, they sat below the live one and won every subsequent scan.

Log evidence: across four connects sing-box logged `started at utun10` while `updated available networks` reported `utun11` as the live device — 6/6 mismatch — and `tag=inbound/tun[tun-in]` never advanced past its 4 lifecycle lines. The same build carried 350–910 tun-in connections/minute the day before, when the names matched.

**Relation to #9008.** That PR removed one *source* of a second utun (a start arriving while a tunnel was still live) and deliberately left the selection lowest-wins, adding a log line "so a recurrence can be told apart from a stale-fd selection". This is that recurrence, from a different source: a start that fails partway still leaks a descriptor, which no teardown guard can catch.

## What changed

One file, `macos/PacketTunnel/SingBox/ExtensionPlatformInterface.swift`:

- The fallback now selects on a property of the *device* rather than descriptor order: scan the process for utun descriptors (`getsockopt(SYSPROTO_CONTROL, UTUN_OPT_IFNAME)`, the same query sing-box's `getTunnelName` makes of whatever it is handed), then keep the candidate whose interface carries an address from the `NEPacketTunnelNetworkSettings` just applied (via `getifaddrs`). An orphan cannot pass that test — it does not hold this tunnel's address.
- With no match (auto-route off, so no address was installed, or `getifaddrs` racing the settings apply) it takes the **highest**-numbered utun rather than the lowest. Descriptors are handed out lowest-free-first, so while an orphan is still open the newest utun sits above it — the opposite of today's tie-break, and correct in exactly the failure case.
- Both branches log the chosen descriptor, its interface name, and every candidate seen. Today the fallback logs nothing about *which* device it picked; the only visibility is sing-box's later `started at utunN`.
- No behaviour change when exactly one utun is open (the healthy case): a single candidate is returned either way. The KVC fast path is untouched, and `throw NSError(domain: "Missing TUN FD")` still covers "no utun at all", as before.

## What this deliberately does not do

- **Doesn't close the orphan in `reset()`.** The descriptor found by the scan belongs to NetworkExtension's `packetFlow`, not to us (sing-box `dup()`s it in `service.go`), so closing it would pull a live socket out from under NE. Making the selection orphan-proof is the safe half.
- **Doesn't repair the KVC fast path.** Why it returns nil on macOS 26 — a renamed/removed private ivar vs. a sysext sandbox denial — is still open; it has never once succeeded on this reporter's machine, so the fallback has to be correct regardless.
- **Doesn't touch the iOS twin** (`ios/Tunnel/SingBox/ExtensionPlatformInterface.swift:242`), which has the identical lowest-wins fallback. Same fix applies if we want it; kept out here to hold the change to the platform the evidence covers.

## Test plan

This cannot be verified in CI — reproducing needs macOS 26 hardware and a live tunnel. Reviewer verification:

- [ ] Builds (Xcode, PacketTunnel target). Helpers type-check standalone (`swiftc -typecheck`) and the `getifaddrs` address→interface mapping was smoke-tested on macOS 26.
- [ ] Normal connect on macOS 26: log line reads `Returning tunnel file descriptor N (utunM, ...)` and sing-box's `started at utunM` matches; `utunM` is absent from `updated available networks` (sing-box filters its own tun), and tun-in connections climb.
- [ ] Orphan repro: drop `runBlockingTimeout` in `Extension+RunBlocking.swift:17` to ~1 ms so one start throws `timedOut` after settings are applied, restore it, then reconnect. Expect ≥2 utun descriptors in `lsof -p $(pgrep -f org.getlantern.lantern.PacketTunnel) | grep utun`, the log listing both candidates, and the chosen one matching the live device — pre-fix this is the blackhole.
- [ ] macOS 12 (where the KVC path also never resolves) still connects — the single-utun path must be unchanged.

Refs getlantern/engineering#3781

---
*Auto-generated by `/issue-fix`.*