### PR TITLE
fix(vpn): stop fastest-probe push overwriting Smart Location

### DIFF
--- a/lib/features/vpn/provider/available_servers_notifier.dart
+++ b/lib/features/vpn/provider/available_servers_notifier.dart
@@ -3,6 +3,7 @@ import 'package:lantern/core/common/common.dart';
 import 'package:lantern/core/models/available_servers.dart';
 import 'package:lantern/core/models/server_location.dart';
 import 'package:lantern/features/vpn/provider/server_location_notifier.dart';
+import 'package:lantern/features/vpn/provider/vpn_notifier.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 
@@ -97,7 +98,9 @@ class AvailableServersNotifier extends _$AvailableServersNotifier {
     }
   }
 
-  /// Pushes the fastest Lantern server to the Smart Location if the current selection is auto
+  /// Seeds Smart Location with the fastest-probed server while disconnected.
+  /// Smart Location will be updated using radiance's auto select events while
+  /// connected.
   void _pushFastestToSmartLocation(AvailableServers servers) {
     final fastest = servers.fastestLanternServer;
     if (fastest == null) return;
@@ -107,6 +110,7 @@ class AvailableServersNotifier extends _$AvailableServersNotifier {
       return;
     }
     if (current.autoLocation?.tag == fastest.tag) return;
+    if (ref.read(vpnProvider) != VPNStatus.disconnected) return;
 
     final country = fastest.location.country;
     final city = fastest.location.city;

--- a/test/features/vpn/provider/available_servers_smart_location_test.dart
+++ b/test/features/vpn/provider/available_servers_smart_location_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/models/available_servers.dart';
+import 'package:lantern/core/models/server_location.dart';
+import 'package:lantern/core/services/injection_container.dart';
+import 'package:lantern/core/services/local_storage_service.dart';
+import 'package:lantern/features/vpn/provider/available_servers_notifier.dart';
+import 'package:lantern/features/vpn/provider/server_location_notifier.dart';
+import 'package:lantern/features/vpn/provider/vpn_notifier.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
+
+const _activeTag = 'shadowsocks-out-active';
+const _fastestTag = 'hysteria2-out-fastest';
+
+Server _server(String tag, String city, int delayMs) => Server(
+  tag: tag,
+  type: tag.split('-').first,
+  isLantern: true,
+  location: GeoLocation(
+    country: 'United States',
+    countryCode: 'US',
+    city: city,
+    latitude: 0,
+    longitude: 0,
+  ),
+  selectionHistory: SelectionHistory(lastSuccessDelayMs: delayMs),
+);
+
+/// Fastest-by-probe is [_fastestTag]; [_activeTag] is slower, standing in for
+/// the server auto-select actually routes through.
+final _servers = AvailableServers([
+  _server(_activeTag, 'Ashburn', 400),
+  _server(_fastestTag, 'Los Angeles', 100),
+]);
+
+ServerLocation _autoLocation(String tag, String city) => ServerLocation(
+  serverType: ServerLocationType.auto.name,
+  serverName: '',
+  displayName: '',
+  protocol: '',
+  city: city,
+  autoLocation: AutoLocation(
+    country: 'United States',
+    countryCode: 'US',
+    displayName: 'United States - $city',
+    tag: tag,
+  ),
+);
+
+class _FakeStorage implements LocalStorageService {
+  _FakeStorage(this.location);
+
+  ServerLocation? location;
+
+  @override
+  ServerLocation? getServerLocation() => location;
+
+  @override
+  Future<void> saveServerLocation(ServerLocation value) async {
+    location = value;
+  }
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class _FakeLanternService implements LanternService {
+  @override
+  Future<Either<Failure, AvailableServers>>
+  getLanternAvailableServers() async => right(_servers);
+
+  /// The notifier under test must not depend on this; returning a failure keeps
+  /// [ServerLocationNotifier]'s own refresh from touching the location.
+  @override
+  Future<Either<Failure, Server>> getAutoServerLocation() async =>
+      left(Failure(error: 'unavailable', localizedErrorMessage: 'unavailable'));
+
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+ProviderContainer _container(VPNStatus status) => ProviderContainer(
+  overrides: [
+    lanternServiceProvider.overrideWithValue(_FakeLanternService()),
+    vpnProvider.overrideWithValue(status),
+  ],
+);
+
+void main() {
+  setUp(() async {
+    await sl.reset();
+    sl.registerSingleton<LocalStorageService>(
+      _FakeStorage(_autoLocation(_activeTag, 'Ashburn')),
+    );
+  });
+
+  tearDown(() async {
+    await sl.reset();
+  });
+
+  test(
+    'connected: a server-list refresh leaves the active location alone',
+    () async {
+      final container = _container(VPNStatus.connected);
+      addTearDown(container.dispose);
+
+      await container.read(availableServersProvider.future);
+      await container
+          .read(availableServersProvider.notifier)
+          .forceFetchAvailableServers();
+
+      expect(
+        container.read(serverLocationProvider).autoLocation?.tag,
+        _activeTag,
+        reason:
+            'while connected radiance owns the Smart Location; the fastest-probed '
+            'server must not overwrite the server traffic actually exits from',
+      );
+    },
+  );
+
+  test(
+    'connecting: a server-list refresh leaves the active location alone',
+    () async {
+      final container = _container(VPNStatus.connecting);
+      addTearDown(container.dispose);
+
+      await container.read(availableServersProvider.future);
+
+      expect(
+        container.read(serverLocationProvider).autoLocation?.tag,
+        _activeTag,
+      );
+    },
+  );
+
+  test(
+    'disconnected: the fastest-probed server seeds the Smart Location',
+    () async {
+      final container = _container(VPNStatus.disconnected);
+      addTearDown(container.dispose);
+
+      await container.read(availableServersProvider.future);
+
+      expect(
+        container.read(serverLocationProvider).autoLocation?.tag,
+        _fastestTag,
+      );
+    },
+  );
+}


### PR DESCRIPTION
Issue: the exit location changes constantly but the UI always shows the same city, so the Smart Location row names a server the traffic never exits from.

## Cause

Two independent writers to `serverLocationProvider` while in auto mode:

- **The truth** — `app_event_notifier.dart` handles the `server-location` app event, which radiance emits from `vpn.AutoSelectedEvent` (`lantern-core/core.go:348-366`). This is the server auto-select actually routes through.
- **A prediction** — `AvailableServersNotifier._pushFastestToSmartLocation` writes whichever server has the lowest `selectionHistory.lastSuccessDelayMs` (`lib/core/models/available_servers.dart:39-50`). That is probe latency, not the active outbound.

The `server-location` handler kicks off `forceFetchAvailableServers()` *before* applying the event, and that fetch calls `_pushFastestToSmartLocation` — so the prediction lands on top of the truth 20-40 ms later.

From the reporter's `flutter.log`:

```
19:09:56.423  Received app event of type: server-location
19:09:56.423  updateServerLocation: type=auto city=Ashburn      ← real exit
19:09:56.444  Pushing fastest server to Smart Location: tag=…phx… delay=109ms
19:09:56.444  updateServerLocation: type=auto city=Phoenix      ← clobbered
```

Over that session: **747 real `server-location` updates, 462 of them (62%) overwritten within ~30 ms by a differing fastest-probe push.** The winner was almost always an LA or Phoenix tag — hence "the UI always shows LA".

The existing `current.autoLocation?.tag == fastest.tag` guard doesn't help: the real event has just set the tag to the actual exit, so the tags differ and the push always proceeds.

## Fix

Restrict the seed to `VPNStatus.disconnected`. The fastest-probed server stays a useful preview of where auto mode would land while the tunnel is down; once it is anything but fully down, radiance's auto-select events own the value.

Covering `connecting`/`disconnecting` as well as `connected` matters for tunnel rebuilds, which go `connected → connecting → connected` without passing through `disconnected` — 7 such transitions in the reporter's log, against 14 cold connects. `config` events drive `forceFetchAvailableServers` too (4006 of them in that session), so a rebuild window was a live clobber path.

The status read sits after the existing cheap guards deliberately: reading `vpnProvider` instantiates `VpnNotifier`, which needs platform channels, so an eager read breaks tests that never exercise the write path.

## Tests

`test/features/vpn/provider/available_servers_smart_location_test.dart` — connected and connecting leave the active location alone; disconnected still seeds. Verified non-vacuous by reverting the guard, which fails with `Expected: shadowsocks-out-active / Actual: hysteria2-out-fastest` — the same substitution seen in the logs.

## Scope

UI truth only. The underlying churn — 42 exit changes in 92 minutes, median dwell 104 s, driven by false-positive data-plane stall detection in lantern-box's `MutableAutoSelect` — is a separate fix. **Expect the location to look noisier after this lands**: the UI will now faithfully report churn it was previously hiding.

Follow-up tracked separately: `ServerLocationNotifier.refreshAutoLocationIfNeeded()` has no callers, so after connecting the UI shows the disconnected-state prediction until radiance's next push.
