### PR TITLE
preserve cached iOS frameworks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1134,7 +1134,8 @@ build-ios: $(MAYBE_STEALTH_PROFILE)
 	@echo "Built iOS Framework: $(IOS_FRAMEWORK_BUILD)"
 	mv $(IOS_FRAMEWORK_BUILD) $(IOS_FRAMEWORK_DIR)
 
-$(IOS_FRAMEWORK_OUTPUT): check-gomobile $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
+$(IOS_FRAMEWORK_OUTPUT): $(GO_SOURCES) $(MAYBE_STEALTH_PROFILE)
+	$(MAKE) check-gomobile
 	$(MAKE) build-ios
 
 # Unsigned simulator build; PR gate for Swift compile errors.


### PR DESCRIPTION
Run the gomobile check only when the iOS framework needs rebuilding. This prevents cache-hit failures while keeping the prerequisite check for fresh builds.