### PR TITLE
Fix Unbounded UI state drifting from active backend connections

### DIFF
--- a/assets/locales/en.po
+++ b/assets/locales/en.po
@@ -1979,3 +1979,6 @@ msgstr "Renew Now"
 
 msgid "dismiss"
 msgstr "Dismiss"
+
+msgid "unbounded_status_waiting"
+msgstr "Waiting to start — Unbounded"

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260908121906-3e3e2489526b
+	github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464
 	github.com/sagernet/sing-box v1.13.19
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260909182533-7c76ec7cb348
+	github.com/getlantern/radiance v0.0.0-20260909185234-6950dfbcd9be
 	github.com/sagernet/sing-box v1.13.19
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464
+	github.com/getlantern/radiance v0.0.0-20260909182533-7c76ec7cb348
 	github.com/sagernet/sing-box v1.13.19
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -275,6 +275,8 @@ github.com/getlantern/radiance v0.0.0-20260908121906-3e3e2489526b h1:NXEQDHkdwpM
 github.com/getlantern/radiance v0.0.0-20260908121906-3e3e2489526b/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
 github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464 h1:OR2g3iBu3XD9a/gbburSJ3X7tTYH1dTR1hXAhrzhcXg=
 github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
+github.com/getlantern/radiance v0.0.0-20260909182533-7c76ec7cb348 h1:RdSPo3YnMjcpAk/pgLNad5idE94T+0Uqn/Xylx9rOGM=
+github.com/getlantern/radiance v0.0.0-20260909182533-7c76ec7cb348/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -277,6 +277,8 @@ github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464 h1:OR2g3iBu3XD
 github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
 github.com/getlantern/radiance v0.0.0-20260909182533-7c76ec7cb348 h1:RdSPo3YnMjcpAk/pgLNad5idE94T+0Uqn/Xylx9rOGM=
 github.com/getlantern/radiance v0.0.0-20260909182533-7c76ec7cb348/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
+github.com/getlantern/radiance v0.0.0-20260909185234-6950dfbcd9be h1:zoSuwOcpm40x+Yi7cesqVGXMZnfQhllDv5qR4PvjC2Y=
+github.com/getlantern/radiance v0.0.0-20260909185234-6950dfbcd9be/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -273,6 +273,8 @@ github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmI
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
 github.com/getlantern/radiance v0.0.0-20260908121906-3e3e2489526b h1:NXEQDHkdwpMkMf91LcsgJGvc51d2jqL53gcvCbgtNQ4=
 github.com/getlantern/radiance v0.0.0-20260908121906-3e3e2489526b/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
+github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464 h1:OR2g3iBu3XD9a/gbburSJ3X7tTYH1dTR1hXAhrzhcXg=
+github.com/getlantern/radiance v0.0.0-20260909181327-22dad8652464/go.mod h1:yQYp6xgDGi+pk59seIuumS+v68Ziwt9dIVzDIfCR8uk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/lantern-core/core.go
+++ b/lantern-core/core.go
@@ -309,6 +309,7 @@ func (lc *LanternCore) initialize(opts *utils.Opts, eventEmitter utils.FlutterEv
 	go lc.listenConfigEvents()
 	go lc.listenDataCapEvents()
 	go lc.listenPeerConnectionEvents()
+	go lc.listenUnboundedSnapshots()
 	go lc.listenPeerStatusEvents()
 	go lc.listenUserMessageAvailability()
 	go lc.fetchUserDataIfNeeded()

--- a/lantern-core/unbounded_snapshot.go
+++ b/lantern-core/unbounded_snapshot.go
@@ -4,27 +4,36 @@ import (
 	"context"
 	"encoding/json"
 	"time"
+
+	"github.com/getlantern/radiance/unbounded"
 )
 
 func (lc *LanternCore) listenUnboundedSnapshots() {
 	ticker := time.NewTicker(time.Second)
 	defer ticker.Stop()
+	pollUnboundedSnapshots(lc.ctx, ticker.C, lc.client.UnboundedSnapshot, lc.notifyFlutter)
+}
+
+func pollUnboundedSnapshots(ctx context.Context, ticks <-chan time.Time, read func(context.Context) (unbounded.Snapshot, error), notify func(string, string)) {
+	unavailable := false
 	for {
-		ctx, cancel := context.WithTimeout(lc.ctx, 3*time.Second)
-		snapshot, err := lc.client.UnboundedSnapshot(ctx)
+		requestCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
+		snapshot, err := read(requestCtx)
 		cancel()
 		if err == nil {
+			unavailable = false
 			if data, err := json.Marshal(snapshot); err == nil {
-				lc.notifyFlutter("unbounded-snapshot", string(data))
+				notify("unbounded-snapshot", string(data))
 			}
 		}
-		if err != nil && lc.ctx.Err() == nil {
-			lc.notifyFlutter("unbounded-unavailable", "{}")
+		if err != nil && !unavailable && ctx.Err() == nil {
+			unavailable = true
+			notify("unbounded-unavailable", "{}")
 		}
 		select {
-		case <-lc.ctx.Done():
+		case <-ctx.Done():
 			return
-		case <-ticker.C:
+		case <-ticks:
 		}
 	}
 }

--- a/lantern-core/unbounded_snapshot.go
+++ b/lantern-core/unbounded_snapshot.go
@@ -1,0 +1,30 @@
+package lanterncore
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+)
+
+func (lc *LanternCore) listenUnboundedSnapshots() {
+	ticker := time.NewTicker(time.Second)
+	defer ticker.Stop()
+	for {
+		ctx, cancel := context.WithTimeout(lc.ctx, 3*time.Second)
+		snapshot, err := lc.client.UnboundedSnapshot(ctx)
+		cancel()
+		if err == nil {
+			if data, err := json.Marshal(snapshot); err == nil {
+				lc.notifyFlutter("unbounded-snapshot", string(data))
+			}
+		}
+		if err != nil && lc.ctx.Err() == nil {
+			lc.notifyFlutter("unbounded-unavailable", "{}")
+		}
+		select {
+		case <-lc.ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}

--- a/lantern-core/unbounded_snapshot_test.go
+++ b/lantern-core/unbounded_snapshot_test.go
@@ -1,0 +1,49 @@
+package lanterncore
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/getlantern/radiance/unbounded"
+)
+
+func TestUnboundedUnavailableIsEmittedOncePerOutage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	ticks := make(chan time.Time, 3)
+	for range 3 {
+		ticks <- time.Now()
+	}
+	calls := 0
+	var events []string
+	pollUnboundedSnapshots(ctx, ticks, func(context.Context) (unbounded.Snapshot, error) {
+		calls++
+		if calls == 3 {
+			return unbounded.Snapshot{Running: true}, nil
+		}
+		return unbounded.Snapshot{}, errors.New("offline")
+	}, func(name, _ string) {
+		events = append(events, name)
+		if len(events) == 3 {
+			cancel()
+		}
+	})
+	want := []string{"unbounded-unavailable", "unbounded-snapshot", "unbounded-unavailable"}
+	if !reflect.DeepEqual(events, want) {
+		t.Fatalf("events = %v, want %v", events, want)
+	}
+	if calls != 4 {
+		t.Fatalf("read calls = %d, want 4", calls)
+	}
+}
+
+func TestUnboundedCancellationDoesNotReportOutage(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	pollUnboundedSnapshots(ctx, nil, func(ctx context.Context) (unbounded.Snapshot, error) {
+		return unbounded.Snapshot{}, ctx.Err()
+	}, func(name, _ string) { t.Fatalf("unexpected event: %s", name) })
+}

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -84,18 +84,18 @@ enum SharePhase {
 class ShareState {
   final bool active;
   final bool probing;
+  final bool unboundedRunning;
   final ShareMode mode;
   final int activeCount;
   final int totalCount;
-  // SmC-only: granular Start/Stop phase from radiance peer.Status. For
-  // Unbounded mode this stays SharePhase.idle (no equivalent staged
-  // lifecycle on the broflake side yet).
+  // SmC uses peer.Status phases; Unbounded uses unboundedRunning from snapshots.
   final SharePhase phase;
   final String? errorMessage;
 
   const ShareState({
     this.active = false,
     this.probing = false,
+    this.unboundedRunning = false,
     this.mode = ShareMode.off,
     this.activeCount = 0,
     this.totalCount = 0,
@@ -106,6 +106,7 @@ class ShareState {
   ShareState copyWith({
     bool? active,
     bool? probing,
+    bool? unboundedRunning,
     ShareMode? mode,
     int? activeCount,
     int? totalCount,
@@ -121,6 +122,7 @@ class ShareState {
       ShareState(
         active: active ?? this.active,
         probing: probing ?? this.probing,
+        unboundedRunning: unboundedRunning ?? this.unboundedRunning,
         mode: mode ?? this.mode,
         activeCount: activeCount ?? this.activeCount,
         totalCount: totalCount ?? this.totalCount,
@@ -138,6 +140,7 @@ class ShareState {
 class _UnsetErrorMessage {
   const _UnsetErrorMessage();
 }
+
 const _unsetErrorMessage = _UnsetErrorMessage();
 
 // ─── Notifier (mock-backed) ──────────────────────────────────────────────────
@@ -239,6 +242,12 @@ class ShareNotifier extends Notifier<ShareState> {
   }
 
   StreamSubscription? _appEventSub;
+  StreamSubscription? _snapshotSub;
+  int _changes = 0;
+  bool get _changing => _changes > 0;
+  String? _snapshotEpoch;
+  int _lastArrivals = 0;
+  bool _hasUnboundedSnapshot = false;
   int _workerSeq = 0;
   // Per-peer arc + active-stream count. samizdat multiplexes many H2 streams
   // over one TCP conn, all sharing the same RemoteAddr — ref-count so the arc
@@ -265,7 +274,27 @@ class ShareNotifier extends Notifier<ShareState> {
     // subscription and stream controller still get cleaned up when
     // it does actually happen.
     ref.keepAlive();
+    _snapshotSub = ref.read(lanternServiceProvider).watchAppEvents().listen((
+      event,
+    ) {
+      if (event.eventType == 'unbounded-unavailable') {
+        if (!_changing && state.mode == ShareMode.unbounded) {
+          _clearPeers();
+          state = state.copyWith(unboundedRunning: false, activeCount: 0);
+        }
+        return;
+      }
+      if (event.eventType != 'unbounded-snapshot') return;
+      try {
+        _applyUnboundedSnapshot(
+          jsonDecode(event.message) as Map<String, dynamic>,
+        );
+      } catch (e) {
+        debugPrint('share-my-connection: bad snapshot: $e');
+      }
+    });
     ref.onDispose(() {
+      _snapshotSub?.cancel();
       _stopEventSubscription();
       _eventController.close();
     });
@@ -300,6 +329,16 @@ class ShareNotifier extends Notifier<ShareState> {
   ///      forwarded a port, so use it and skip the probe.
   ///   2. Otherwise probe UPnP: available → SmC, unavailable → Unbounded.
   Future<void> toggle(BuildContext context, WidgetRef widgetRef) async {
+    if (_changing) return;
+    _changes++;
+    try {
+      await _toggle(context, widgetRef);
+    } finally {
+      _changes--;
+    }
+  }
+
+  Future<void> _toggle(BuildContext context, WidgetRef widgetRef) async {
     if (state.active || state.probing) {
       await _stop(widgetRef);
       return;
@@ -341,8 +380,7 @@ class ShareNotifier extends Notifier<ShareState> {
     // status from copyWith(probing: true) above is visible to the
     // user. Any failure (no IGD, timeout, FFI / channel error) is
     // treated as "UPnP unavailable" → fall back to Unbounded.
-    final probeRes =
-        await widgetRef.read(lanternServiceProvider).probeUPnP();
+    final probeRes = await widgetRef.read(lanternServiceProvider).probeUPnP();
     final upnpAvailable = probeRes.fold((_) => false, (v) => v);
     if (!upnpAvailable) {
       await _start(widgetRef, ShareMode.unbounded);
@@ -366,10 +404,15 @@ class ShareNotifier extends Notifier<ShareState> {
   /// direction. Consent is collected by toggle() or by enabling auto-start in
   /// Unbounded Settings, both of which have a BuildContext.
   Future<void> autoStart(WidgetRef widgetRef) async {
-    if (state.active || state.probing) return;
+    if (_changing || state.active || state.probing) return;
     if (!_consentAcked) return;
-    state = state.copyWith(probing: true);
-    await _start(widgetRef, ShareMode.unbounded);
+    _changes++;
+    try {
+      state = state.copyWith(probing: true);
+      await _start(widgetRef, ShareMode.unbounded);
+    } finally {
+      _changes--;
+    }
   }
 
   /// Reconciles ShareState with what the peer client is actually doing.
@@ -502,41 +545,24 @@ class ShareNotifier extends Notifier<ShareState> {
         );
         break;
       case ShareMode.unbounded:
-        // Unbounded is the broflake / WebRTC widget-proxy mode. Local
-        // opt-in only — actual run state also depends on the server's
-        // Features[unbounded] flag and supplied UnboundedConfig. When
-        // running, broflake's OnConnectionChange callback emits
-        // unbounded.ConnectionEvent → forwarded by lantern-core as the
-        // same EventTypePeerConnection FlutterEvent the SmC path uses,
-        // so this Dart subscription consumes both protocols uniformly.
-        //
-        // Unbounded has no equivalent of the peer.Client phase=error
-        // StatusEvent that the SmC path leans on for failure recovery,
-        // so check the Either return here and revert to off if the
-        // setting flip failed (core not initialized, MethodChannel
-        // failure, etc.) — otherwise the UI sticks at "Active" while
-        // nothing actually started.
         final res = await widgetRef
             .read(lanternServiceProvider)
             .setUnboundedEnabled(true);
-        res.fold(
-          (err) {
-            appLogger.error('setUnboundedEnabled failed: ${err.error}');
-            _stopEventSubscription();
-            state = ShareState(
-              active: false,
-              probing: false,
-              mode: ShareMode.off,
-              activeCount: 0,
-              // Preserve lifetime totalCount across a failed Start (see
-              // matching comment in the SmC branch above).
-              totalCount: state.totalCount,
-              phase: SharePhase.error,
-              errorMessage: err.error,
-            );
-          },
-          (_) => null,
-        );
+        res.fold((err) {
+          appLogger.error('setUnboundedEnabled failed: ${err.error}');
+          _stopEventSubscription();
+          state = ShareState(
+            active: false,
+            probing: false,
+            mode: ShareMode.off,
+            activeCount: 0,
+            // Preserve lifetime totalCount across a failed Start (see
+            // matching comment in the SmC branch above).
+            totalCount: state.totalCount,
+            phase: SharePhase.error,
+            errorMessage: err.error,
+          );
+        }, (_) => null);
         break;
       case ShareMode.off:
         break;
@@ -556,9 +582,7 @@ class ShareNotifier extends Notifier<ShareState> {
             .setPeerProxy(false);
         break;
       case ShareMode.unbounded:
-        await widgetRef
-            .read(lanternServiceProvider)
-            .setUnboundedEnabled(false);
+        await widgetRef.read(lanternServiceProvider).setUnboundedEnabled(false);
         break;
       case ShareMode.off:
         break;
@@ -579,15 +603,15 @@ class ShareNotifier extends Notifier<ShareState> {
 
   void _startEventSubscription(WidgetRef widgetRef) {
     _peerArcs.clear();
-    _appEventSub = widgetRef
-        .read(lanternServiceProvider)
-        .watchAppEvents()
-        .listen((event) {
+    _appEventSub =
+        widgetRef.read(lanternServiceProvider).watchAppEvents().listen((event) {
       if (event.eventType == 'peer-status') {
         _handlePeerStatus(event.message, widgetRef);
         return;
       }
-      if (event.eventType != 'peer-connection') return;
+      if (event.eventType != 'peer-connection' || state.mode != ShareMode.smc) {
+        return;
+      }
       try {
         final payload = jsonDecode(event.message) as Map<String, dynamic>;
         final eventState = (payload['state'] as num?)?.toInt() ?? 0;
@@ -642,11 +666,13 @@ class ShareNotifier extends Notifier<ShareState> {
           // the geo lookup completed). Otherwise the globe never saw it
           // and a -1 with no preceding +1 would just be noise.
           if (entry.geo != null) {
-            _eventController.add(UnboundedConnectionEvent(
-              state: -1,
-              workerIdx: entry.workerIdx,
-              addr: '',
-            ));
+            _eventController.add(
+              UnboundedConnectionEvent(
+                state: -1,
+                workerIdx: entry.workerIdx,
+                addr: '',
+              ),
+            );
           }
           state = state.copyWith(
             activeCount: max(0, state.activeCount - 1),
@@ -664,7 +690,65 @@ class ShareNotifier extends Notifier<ShareState> {
     });
   }
 
-  Future<void> _resolveAndEmit(String ip, _PeerArc arc) async {
+  void _applyUnboundedSnapshot(Map<String, dynamic> snapshot) {
+    if (_changing || state.mode == ShareMode.smc) return;
+    final enabled = snapshot['enabled'] as bool;
+    final running = snapshot['running'] as bool;
+    final peers = (snapshot['peers'] as List).cast<String>();
+    final counts = <String, int>{};
+    if (enabled && running) {
+      for (final source in peers) {
+        final ip = _extractIP(source);
+        if (ip.isNotEmpty) counts.update(ip, (n) => n + 1, ifAbsent: () => 1);
+      }
+    }
+    final replay = !_hasUnboundedSnapshot;
+    _hasUnboundedSnapshot = true;
+    for (final ip in _peerArcs.keys.toList()) {
+      if (counts.containsKey(ip)) continue;
+      final arc = _peerArcs.remove(ip)!;
+      if (arc.geo != null) {
+        _eventController.add(
+          UnboundedConnectionEvent(
+            state: -1,
+            workerIdx: arc.workerIdx,
+            addr: '',
+          ),
+        );
+      }
+    }
+    final epoch = snapshot['epoch'] as String;
+    final arrivals = (snapshot['arrivals'] as num).toInt();
+    for (final entry in counts.entries) {
+      var arc = _peerArcs[entry.key];
+      if (arc == null) {
+        arc = _PeerArc(_workerSeq++);
+        _peerArcs[entry.key] = arc;
+        unawaited(_resolveAndEmit(entry.key, arc, isReplay: replay));
+      }
+      arc.streamCount = entry.value;
+    }
+    final total = state.totalCount +
+        (_snapshotEpoch == epoch ? max<int>(0, arrivals - _lastArrivals) : 0);
+    _snapshotEpoch = epoch;
+    _lastArrivals = arrivals;
+    state = state.copyWith(
+      active: enabled,
+      mode: enabled ? ShareMode.unbounded : ShareMode.off,
+      unboundedRunning: enabled && running,
+      activeCount: counts.length,
+      totalCount: total,
+    );
+    if (total != ref.read(appSettingProvider).unboundedTotalHelped) {
+      ref.read(appSettingProvider.notifier).setUnboundedTotalHelped(total);
+    }
+  }
+
+  Future<void> _resolveAndEmit(
+    String ip,
+    _PeerArc arc, {
+    bool isReplay = false,
+  }) async {
     PeerGeo geo;
     try {
       geo = await GeoLookupService.peerLookup(ip);
@@ -676,23 +760,25 @@ class ShareNotifier extends Notifier<ShareState> {
     // a late lookup completion doesn't throw "Bad state: Cannot add
     // event after closing" on the disposed sink.
     if (_eventController.isClosed) return;
-    // Peer may have disconnected before the lookup returned. The map
-    // entry's identity (workerIdx) is the cheapest check.
+    // A lookup from an earlier session must not add an arc to its replacement.
     final current = _peerArcs[ip];
-    if (current == null || current.workerIdx != arc.workerIdx) return;
+    if (!identical(current, arc)) return;
     // Skip arcs we couldn't geo-locate. The peer is still counted in
     // activeCount, but we don't draw a wrong-country arc.
     if (geo.countryCode.isEmpty) return;
     arc.geo = geo;
-    _eventController.add(UnboundedConnectionEvent(
-      state: 1,
-      workerIdx: arc.workerIdx,
-      addr: ip,
-      countryName: geo.countryName,
-      countryCode: geo.countryCode,
-      flagEmoji: geo.flagEmoji,
-      coordinates: geo.coordinates,
-    ));
+    _eventController.add(
+      UnboundedConnectionEvent(
+        state: 1,
+        workerIdx: arc.workerIdx,
+        addr: ip,
+        countryName: geo.countryName,
+        countryCode: geo.countryCode,
+        flagEmoji: geo.flagEmoji,
+        coordinates: geo.coordinates,
+        isReplay: isReplay,
+      ),
+    );
   }
 
   /// Replays a synthetic +1 for every currently-active peer that has a
@@ -706,37 +792,35 @@ class ShareNotifier extends Notifier<ShareState> {
       final arc = entry.value;
       final geo = arc.geo;
       if (geo == null) continue;
-      _eventController.add(UnboundedConnectionEvent(
-        state: 1,
-        workerIdx: arc.workerIdx,
-        addr: entry.key,
-        countryName: geo.countryName,
-        countryCode: geo.countryCode,
-        flagEmoji: geo.flagEmoji,
-        coordinates: geo.coordinates,
-        isReplay: true,
-      ));
+      _eventController.add(
+        UnboundedConnectionEvent(
+          state: 1,
+          workerIdx: arc.workerIdx,
+          addr: entry.key,
+          countryName: geo.countryName,
+          countryCode: geo.countryCode,
+          flagEmoji: geo.flagEmoji,
+          coordinates: geo.coordinates,
+          isReplay: true,
+        ),
+      );
     }
   }
 
   void _stopEventSubscription() {
-    // Synthesize -1 for every active peer BEFORE killing the source
-    // stream. peer.Client.Stop on the Go side suppresses the box.Close
-    // disconnect cascade (correct — avoids a flood of post-Stop noise),
-    // so without this loop the globe would never see -1's for peers
-    // that were live at toggle-time. Their arcs would orphan and rotate
-    // with the globe indefinitely. With this loop, the globe sees real
-    // -1's and runs them through the normal linger-then-remove path.
-    for (final arc in _peerArcs.values) {
-      if (arc.geo == null) continue;
-      _eventController.add(UnboundedConnectionEvent(
-        state: -1,
-        workerIdx: arc.workerIdx,
-        addr: '',
-      ));
-    }
     _appEventSub?.cancel();
     _appEventSub = null;
+    _clearPeers();
+  }
+
+  void _clearPeers() {
+    // Backend shutdown can suppress disconnect events, so remove globe arcs explicitly.
+    for (final arc in _peerArcs.values) {
+      if (arc.geo == null) continue;
+      _eventController.add(
+        UnboundedConnectionEvent(state: -1, workerIdx: arc.workerIdx, addr: ''),
+      );
+    }
     _peerArcs.clear();
     _workerSeq = 0;
   }
@@ -808,42 +892,23 @@ class ShareNotifier extends Notifier<ShareState> {
   // setting back to false, so all we owe is to flip our local state to
   // Unbounded and enable broflake.
   //
-  // Constructs ShareState directly (rather than copyWith) so errorMessage
-  // gets cleared — copyWith's `?? this.errorMessage` keeps the previous
-  // SmC failure string around otherwise.
-  //
-  // Event subscription: deliberately does NOT call _startEventSubscription.
-  // The error path arrives here via _handlePeerStatus which is already
-  // inside the subscription started by the prior _start; flipping the
-  // local state.mode keeps the same subscription forwarding events for
-  // the new (Unbounded) mode. _stop is the only teardown path for the
-  // subscription, and the error path doesn't go through _stop.
   Future<void> _fallbackToUnbounded(WidgetRef widgetRef) async {
-    // One failed Start arrives here twice: from the phase=error event and from
-    // setPeerProxy's returned error. Without this guard Unbounded is started
-    // twice and the second call races the first one's state. A plain field
-    // check suffices — both callers run on the main isolate and the mode flip
-    // below is synchronous, so whichever arrives second always observes it.
     if (state.mode == ShareMode.unbounded) return;
-    state = ShareState(
-      active: true,
-      probing: false,
-      mode: ShareMode.unbounded,
-      activeCount: 0,
-      totalCount: state.totalCount,
-      phase: SharePhase.idle,
-    );
-    final result = await widgetRef
-        .read(lanternServiceProvider)
-        .setUnboundedEnabled(true);
-    result.fold(
-      (err) {
-        // Both SmC and the fallback to Unbounded failed. Roll back the
-        // optimistic active=true state to off+error so the UI doesn't
-        // claim Unbounded is running when nothing actually started —
-        // same shape as the Unbounded branch in _start. Tear down the
-        // event subscription too, since it was kept alive across the
-        // SmC→Unbounded flip and there's nothing left to consume it.
+    _changes++;
+    try {
+      _stopEventSubscription();
+      state = ShareState(
+        active: true,
+        probing: false,
+        mode: ShareMode.unbounded,
+        activeCount: 0,
+        totalCount: state.totalCount,
+        phase: SharePhase.idle,
+      );
+      final result = await widgetRef
+          .read(lanternServiceProvider)
+          .setUnboundedEnabled(true);
+      result.fold((err) {
         appLogger.error(
           'SmC→Unbounded fallback: setUnboundedEnabled failed: ${err.error}',
         );
@@ -857,9 +922,10 @@ class ShareNotifier extends Notifier<ShareState> {
           phase: SharePhase.error,
           errorMessage: err.error,
         );
-      },
-      (_) => {},
-    );
+      }, (_) => {});
+    } finally {
+      _changes--;
+    }
   }
 }
 
@@ -1010,7 +1076,9 @@ class _StatusCard extends StatelessWidget {
               ? 'smc_status_configuring'.i18n
               : 'smc_status_off'.i18n,
         },
-      ShareMode.unbounded => 'enabled'.i18n,
+      ShareMode.unbounded => state.unboundedRunning
+          ? 'enabled'.i18n
+          : 'unbounded_status_waiting'.i18n,
       ShareMode.smc => switch (state.phase) {
           SharePhase.serving => 'enabled'.i18n,
           SharePhase.error => state.errorMessage != null

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -435,14 +435,7 @@ class ShareNotifier extends Notifier<ShareState> {
     if (state.active || state.probing) return;
     final res =
         await widgetRef.read(lanternServiceProvider).getPeerStatusJSON();
-    // Re-check: the read above is an IPC round-trip bounded by a 5s
-    // timeout, and this runs at first paint, so the user has a wide window
-    // to hit the toggle while it is in flight. Adopting the snapshot then
-    // would stamp mode=smc over a session that had just started as
-    // Unbounded — a later toggle-off would call setPeerProxy(false) and
-    // leave Unbounded running — and would install a second event
-    // subscription over the first, which _startEventSubscription
-    // overwrites rather than cancels.
+    // A toggle during the status read may have already started another mode.
     if (state.active || state.probing) return;
     final phase = adoptablePhase(res.fold((_) => '', (v) => v));
     if (phase == null) return;
@@ -602,7 +595,8 @@ class ShareNotifier extends Notifier<ShareState> {
   // already use.
 
   void _startEventSubscription(WidgetRef widgetRef) {
-    _peerArcs.clear();
+    _stopEventSubscription();
+    if (state.mode != ShareMode.smc) return;
     _appEventSub =
         widgetRef.read(lanternServiceProvider).watchAppEvents().listen((event) {
       if (event.eventType == 'peer-status') {

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -808,6 +808,7 @@ class ShareNotifier extends Notifier<ShareState> {
   }
 
   void _clearPeers() {
+    _hasUnboundedSnapshot = false;
     // Backend shutdown can suppress disconnect events, so remove globe arcs explicitly.
     for (final arc in _peerArcs.values) {
       if (arc.geo == null) continue;

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -238,6 +238,7 @@ class ShareNotifier extends Notifier<ShareState> {
       return;
     }
     if (!await ensureConsent(context)) return;
+    if (!ref.mounted) return;
     settings.setUnboundedAutoEnable(true);
   }
 
@@ -346,6 +347,7 @@ class ShareNotifier extends Notifier<ShareState> {
 
     // Consent gates every start path, before the mode is even known.
     if (!await ensureConsent(context)) return;
+    if (!ref.mounted) return;
     // Showing it is async, so re-check: another surface — or a second tap on
     // this one — can have started sharing while the dialog was up.
     if (state.active || state.probing) return;
@@ -367,6 +369,7 @@ class ShareNotifier extends Notifier<ShareState> {
     // an explicit request for the residential-IP path.
     final manualPortRes =
         await widgetRef.read(lanternServiceProvider).getPeerManualPort();
+    if (!ref.mounted) return;
     final manualPort = manualPortRes.fold((_) => 0, (p) => p);
     if (manualPort > 0) {
       await _start(widgetRef, ShareMode.smc);
@@ -381,6 +384,7 @@ class ShareNotifier extends Notifier<ShareState> {
     // user. Any failure (no IGD, timeout, FFI / channel error) is
     // treated as "UPnP unavailable" → fall back to Unbounded.
     final probeRes = await widgetRef.read(lanternServiceProvider).probeUPnP();
+    if (!ref.mounted) return;
     final upnpAvailable = probeRes.fold((_) => false, (v) => v);
     if (!upnpAvailable) {
       await _start(widgetRef, ShareMode.unbounded);
@@ -435,6 +439,7 @@ class ShareNotifier extends Notifier<ShareState> {
     if (state.active || state.probing) return;
     final res =
         await widgetRef.read(lanternServiceProvider).getPeerStatusJSON();
+    if (!ref.mounted) return;
     // A toggle during the status read may have already started another mode.
     if (state.active || state.probing) return;
     final phase = adoptablePhase(res.fold((_) => '', (v) => v));
@@ -513,6 +518,7 @@ class ShareNotifier extends Notifier<ShareState> {
         final smcRes = await widgetRef
             .read(radianceSettingsProvider.notifier)
             .setPeerProxy(true);
+        if (!ref.mounted) return;
         smcRes.fold(
           (err) {
             // Falls back rather than reporting. setPeerProxy returns
@@ -541,6 +547,7 @@ class ShareNotifier extends Notifier<ShareState> {
         final res = await widgetRef
             .read(lanternServiceProvider)
             .setUnboundedEnabled(true);
+        if (!ref.mounted) return;
         res.fold((err) {
           appLogger.error('setUnboundedEnabled failed: ${err.error}');
           _stopEventSubscription();
@@ -903,6 +910,7 @@ class ShareNotifier extends Notifier<ShareState> {
       final result = await widgetRef
           .read(lanternServiceProvider)
           .setUnboundedEnabled(true);
+      if (!ref.mounted) return;
       result.fold((err) {
         appLogger.error(
           'SmC→Unbounded fallback: setUnboundedEnabled failed: ${err.error}',

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -824,7 +824,6 @@ class ShareNotifier extends Notifier<ShareState> {
       );
     }
     _peerArcs.clear();
-    _workerSeq = 0;
   }
 
   // Parses a `peer-status` FlutterEvent and folds the new phase / error

--- a/test/features/share_my_connection/share_notifier_test.dart
+++ b/test/features/share_my_connection/share_notifier_test.dart
@@ -1,4 +1,7 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/models/app_event.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
 import 'package:hooks_riverpod/hooks_riverpod.dart';
 import 'package:lantern/core/models/app_setting.dart';
 import 'package:lantern/core/services/injection_container.dart';
@@ -25,9 +28,17 @@ class _FakeStorage implements LocalStorageService {
   dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
+class _FakeService implements LanternService {
+ @override
+ Stream<AppEvent> watchAppEvents() => const Stream.empty();
+ @override
+ dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
 ShareNotifier _notifier() {
   final container = ProviderContainer(
     overrides: [
+      lanternServiceProvider.overrideWithValue(_FakeService()),
       appSettingProvider.overrideWithValue(const AppSetting()),
     ],
   );

--- a/test/features/share_my_connection/snapshot_test.dart
+++ b/test/features/share_my_connection/snapshot_test.dart
@@ -199,6 +199,60 @@ void main() {
     expect(container.read(shareProvider).totalCount, 11);
   });
 
+  testWidgets('pending auto-start ignores failure after disposal',
+      (tester) async {
+    late WidgetRef widgetRef;
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: Consumer(builder: (ctx, ref, child) {
+        widgetRef = ref;
+        return const SizedBox();
+      }),
+    ));
+    final starting =
+        container.read(shareProvider.notifier).autoStart(widgetRef);
+    expect(service.enableCalls, 1);
+    container.invalidate(shareProvider);
+    await tester.runAsync(() async {
+      service.enableResult.complete(
+          left(Failure(error: 'offline', localizedErrorMessage: 'offline')));
+      await starting;
+    });
+  });
+
+  testWidgets('pending fallback ignores failures after disposal',
+      (tester) async {
+    late WidgetRef widgetRef;
+    late BuildContext context;
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: Consumer(builder: (ctx, ref, child) {
+        widgetRef = ref;
+        context = ctx;
+        return const SizedBox();
+      }),
+    ));
+    final radiance = container.read(radianceSettingsProvider.notifier)
+        as FakeRadianceSettings;
+    final starting =
+        container.read(shareProvider.notifier).toggle(context, widgetRef);
+    await tester.pump();
+    service.events.add(AppEvent(
+        eventType: 'peer-status',
+        message: jsonEncode({'phase': 'error', 'error': 'port unreachable'})));
+    await tester.pump();
+    expect(service.enableCalls, 1);
+    container.invalidate(shareProvider);
+    final failure = left<Failure, Unit>(
+        Failure(error: 'offline', localizedErrorMessage: 'offline'));
+    await tester.runAsync(() async {
+      service.enableResult.complete(failure);
+      radiance.startResult.complete(failure);
+      await starting;
+    });
+    await tester.pump();
+  });
+
   testWidgets('fallback clears peers and serializes snapshots and toggles',
       (tester) async {
     late WidgetRef widgetRef;
@@ -252,6 +306,7 @@ void main() {
           .complete(right(unit));
       await Future<void>.delayed(Duration.zero);
     });
+    await tester.pump();
     await tester.pump();
     await starting;
     service.events.add(AppEvent(

--- a/test/features/share_my_connection/snapshot_test.dart
+++ b/test/features/share_my_connection/snapshot_test.dart
@@ -1,0 +1,233 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:lantern/core/services/injection_container.dart';
+import 'package:lantern/core/services/local_storage_service.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/widgets.dart';
+import 'package:fpdart/fpdart.dart';
+import 'package:lantern/core/common/common.dart';
+import 'package:lantern/core/models/radiance_settings_state.dart';
+import 'package:lantern/features/home/provider/radiance_settings_providers.dart';
+import 'package:hooks_riverpod/hooks_riverpod.dart';
+import 'package:lantern/core/models/app_event.dart';
+import 'package:lantern/core/models/app_setting.dart';
+import 'package:lantern/features/home/provider/app_setting_notifier.dart';
+import 'package:lantern/features/share_my_connection/share_my_connection.dart';
+import 'package:lantern/lantern/lantern_service.dart';
+import 'package:lantern/lantern/lantern_service_notifier.dart';
+
+class FakeStorage implements LocalStorageService {
+ @override
+ bool containsKey(String key) => true;
+ @override
+ dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeService implements LanternService {
+  final enableResult = Completer<Either<Failure, Unit>>();
+  int enableCalls = 0;
+  @override
+  Future<Either<Failure, int>> getPeerManualPort() async => right(1);
+  @override
+  Future<Either<Failure, Unit>> setUnboundedEnabled(bool enabled) {
+    enableCalls++;
+    return enableResult.future;
+  }
+
+  final events = StreamController<AppEvent>.broadcast(sync: true);
+  @override
+  Stream<AppEvent> watchAppEvents() => events.stream;
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class FakeSettings extends AppSettingNotifier {
+  @override
+  AppSetting build() => const AppSetting(unboundedTotalHelped: 10);
+  @override
+  void setUnboundedTotalHelped(int value) {
+    state = state.copyWith(unboundedTotalHelped: value);
+  }
+}
+
+class FakeRadianceSettings extends RadianceSettings {
+  final startResult = Completer<Either<Failure, Unit>>();
+  @override
+  RadianceSettingsState build() => const RadianceSettingsState();
+  @override
+  Future<Either<Failure, Unit>> setPeerProxy(bool value) => startResult.future;
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late FakeService service;
+  late ProviderContainer container;
+  setUp(() {
+    sl.registerSingleton<LocalStorageService>(FakeStorage());
+    service = FakeService();
+    container = ProviderContainer(
+      overrides: [
+        lanternServiceProvider.overrideWithValue(service),
+        appSettingProvider.overrideWith(FakeSettings.new),
+        radianceSettingsProvider.overrideWith(FakeRadianceSettings.new),
+      ],
+    );
+    container.read(shareProvider);
+  });
+  tearDown(() async {
+    container.dispose();
+    await service.events.close();
+    await sl.reset();
+  });
+  Future<void> snapshot(
+    bool enabled,
+    bool running,
+    List<String> peers, {
+    int arrivals = 2,
+    String epoch = "run-1",
+  }) async {
+    service.events.add(
+      AppEvent(
+        eventType: 'unbounded-snapshot',
+        message: jsonEncode({
+          'epoch': epoch,
+          'arrivals': arrivals,
+          'enabled': enabled,
+          'running': running,
+          'peers': peers,
+        }),
+      ),
+    );
+    await Future<void>.delayed(Duration.zero);
+  }
+
+  test(
+    'restores a running backend without recounting lifetime arrivals',
+    () async {
+      await snapshot(true, true, ['192.0.2.1', '192.0.2.1', '192.0.2.2']);
+      final state = container.read(shareProvider);
+      expect(state.active, true);
+      expect(state.unboundedRunning, true);
+      expect(state.mode, ShareMode.unbounded);
+      expect(state.activeCount, 2);
+      expect(state.totalCount, 10);
+      await snapshot(true, true, ['192.0.2.1', '192.0.2.2']);
+      expect(container.read(shareProvider).activeCount, 2);
+      expect(container.read(shareProvider).totalCount, 10);
+    },
+  );
+  test('reconciles missed disconnects and new arrivals idempotently', () async {
+    await snapshot(true, true, ['192.0.2.1']);
+    await snapshot(true, true, ['192.0.2.2'], arrivals: 3);
+    expect(container.read(shareProvider).activeCount, 1);
+    expect(container.read(shareProvider).totalCount, 11);
+    await snapshot(true, true, ['192.0.2.2'], arrivals: 3);
+    expect(container.read(shareProvider).totalCount, 11);
+    await snapshot(true, true, [], arrivals: 3);
+    expect(container.read(shareProvider).activeCount, 0);
+  });
+  test(
+    'enabled is distinct from running and backend stop clears peers',
+    () async {
+      await snapshot(true, true, ['192.0.2.1']);
+      await snapshot(true, false, []);
+      expect(container.read(shareProvider).active, true);
+      expect(container.read(shareProvider).unboundedRunning, false);
+      expect(container.read(shareProvider).activeCount, 0);
+      await snapshot(false, false, []);
+      expect(container.read(shareProvider).active, false);
+      expect(container.read(shareProvider).mode, ShareMode.off);
+    },
+  );
+  test(
+    'counts connections completed between snapshots and rebases after restart',
+    () async {
+      await snapshot(true, true, [], arrivals: 4);
+      await snapshot(true, true, [], arrivals: 7);
+      expect(container.read(shareProvider).totalCount, 13);
+      await snapshot(true, true, [], arrivals: 1, epoch: 'run-2');
+      expect(container.read(shareProvider).totalCount, 13);
+    },
+  );
+  test('backend loss clears stale running status and peers', () async {
+    await snapshot(true, true, ['192.0.2.1']);
+    service.events.add(
+      AppEvent(eventType: 'unbounded-unavailable', message: '{}'),
+    );
+    await Future<void>.delayed(Duration.zero);
+    expect(container.read(shareProvider).unboundedRunning, false);
+    expect(container.read(shareProvider).activeCount, 0);
+    await snapshot(true, true, ['192.0.2.1']);
+    expect(container.read(shareProvider).activeCount, 1);
+    expect(container.read(shareProvider).totalCount, 10);
+  });
+  testWidgets('fallback clears peers and serializes snapshots and toggles',
+      (tester) async {
+    late WidgetRef widgetRef;
+    late BuildContext context;
+    await tester.pumpWidget(UncontrolledProviderScope(
+      container: container,
+      child: Consumer(builder: (ctx, ref, child) {
+        widgetRef = ref;
+        context = ctx;
+        return const SizedBox();
+      }),
+    ));
+    final notifier = container.read(shareProvider.notifier);
+    final starting = notifier.toggle(context, widgetRef);
+    await tester.pump();
+    service.events.add(AppEvent(
+        eventType: 'peer-connection',
+        message: jsonEncode({
+          'state': 1,
+          'source': '192.0.2.1:1234',
+        })));
+    await tester.pump();
+    expect(container.read(shareProvider).activeCount, 1);
+    service.events.add(AppEvent(
+        eventType: 'peer-status',
+        message: jsonEncode({
+          'phase': 'error',
+          'error': 'port unreachable',
+        })));
+    await tester.pump();
+    expect(container.read(shareProvider).mode, ShareMode.unbounded);
+    expect(container.read(shareProvider).activeCount, 0);
+    service.events.add(AppEvent(
+        eventType: 'unbounded-snapshot',
+        message: jsonEncode({
+          'enabled': false,
+          'running': false,
+          'peers': [],
+          'epoch': 'run-1',
+          'arrivals': 0,
+        })));
+    await tester.pump();
+    await notifier.toggle(context, widgetRef);
+    expect(service.enableCalls, 1);
+    expect(container.read(shareProvider).mode, ShareMode.unbounded);
+    await tester.runAsync(() async {
+      service.enableResult.complete(right(unit));
+      (container.read(radianceSettingsProvider.notifier)
+              as FakeRadianceSettings)
+          .startResult
+          .complete(right(unit));
+      await Future<void>.delayed(Duration.zero);
+    });
+    await tester.pump();
+    await starting;
+    service.events.add(AppEvent(
+        eventType: 'unbounded-snapshot',
+        message: jsonEncode({
+          'enabled': true,
+          'running': true,
+          'peers': ['192.0.2.1'],
+          'epoch': 'run-1',
+          'arrivals': 1,
+        })));
+    await tester.pump();
+    expect(container.read(shareProvider).activeCount, 1);
+    expect(container.read(shareProvider).unboundedRunning, true);
+  });
+}

--- a/test/features/share_my_connection/snapshot_test.dart
+++ b/test/features/share_my_connection/snapshot_test.dart
@@ -70,6 +70,18 @@ void main() {
   setUp(() async {
     await sl.reset();
     GeoLookupService.resetCacheForTest();
+    await http.runWithClient(
+      () => Future.wait(['192.0.2.1', '192.0.2.2', '192.0.2.251']
+          .map(GeoLookupService.peerLookup)),
+      () => MockClient((_) async => http.Response(
+          jsonEncode({
+            'Country': {
+              'IsoCode': 'US',
+              'Names': {'en': 'United States'}
+            }
+          }),
+          200)),
+    );
     sl.registerSingleton<LocalStorageService>(FakeStorage());
     service = FakeService();
     container = ProviderContainer(
@@ -170,17 +182,6 @@ void main() {
   });
   test('recovered peers replay without a new-arrival animation', () async {
     const ip = '192.0.2.251';
-    await http.runWithClient(
-      () => GeoLookupService.peerLookup(ip),
-      () => MockClient((_) async => http.Response(
-          jsonEncode({
-            'Country': {
-              'IsoCode': 'US',
-              'Names': {'en': 'United States'}
-            },
-          }),
-          200)),
-    );
     final events = <UnboundedConnectionEvent>[];
     final sub = container
         .read(shareProvider.notifier)
@@ -191,11 +192,13 @@ void main() {
     await snapshot(true, true, [ip], arrivals: 3);
     expect(events.last.state, 1);
     expect(events.last.isReplay, false);
+    final originalWorker = events.last.workerIdx;
     service.events
         .add(AppEvent(eventType: 'unbounded-unavailable', message: '{}'));
     await snapshot(true, true, [ip], arrivals: 3);
     expect(events.last.state, 1);
     expect(events.last.isReplay, true);
+    expect(events.last.workerIdx, greaterThan(originalWorker));
     expect(container.read(shareProvider).totalCount, 11);
   });
 

--- a/test/features/share_my_connection/snapshot_test.dart
+++ b/test/features/share_my_connection/snapshot_test.dart
@@ -1,5 +1,9 @@
 import 'dart:async';
 import 'dart:convert';
+import 'package:http/http.dart' as http;
+import 'package:http/testing.dart';
+import 'package:lantern/core/models/unbounded_connection_event.dart';
+import 'package:lantern/core/services/geo_lookup_service.dart';
 import 'package:lantern/core/services/injection_container.dart';
 import 'package:lantern/core/services/local_storage_service.dart';
 
@@ -18,10 +22,10 @@ import 'package:lantern/lantern/lantern_service.dart';
 import 'package:lantern/lantern/lantern_service_notifier.dart';
 
 class FakeStorage implements LocalStorageService {
- @override
- bool containsKey(String key) => true;
- @override
- dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+  @override
+  bool containsKey(String key) => true;
+  @override
+  dynamic noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
 }
 
 class FakeService implements LanternService {
@@ -63,7 +67,9 @@ void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   late FakeService service;
   late ProviderContainer container;
-  setUp(() {
+  setUp(() async {
+    await sl.reset();
+    GeoLookupService.resetCacheForTest();
     sl.registerSingleton<LocalStorageService>(FakeStorage());
     service = FakeService();
     container = ProviderContainer(
@@ -162,6 +168,37 @@ void main() {
     expect(container.read(shareProvider).activeCount, 1);
     expect(container.read(shareProvider).totalCount, 10);
   });
+  test('recovered peers replay without a new-arrival animation', () async {
+    const ip = '192.0.2.251';
+    await http.runWithClient(
+      () => GeoLookupService.peerLookup(ip),
+      () => MockClient((_) async => http.Response(
+          jsonEncode({
+            'Country': {
+              'IsoCode': 'US',
+              'Names': {'en': 'United States'}
+            },
+          }),
+          200)),
+    );
+    final events = <UnboundedConnectionEvent>[];
+    final sub = container
+        .read(shareProvider.notifier)
+        .connectionEvents
+        .listen(events.add);
+    addTearDown(sub.cancel);
+    await snapshot(true, true, []);
+    await snapshot(true, true, [ip], arrivals: 3);
+    expect(events.last.state, 1);
+    expect(events.last.isReplay, false);
+    service.events
+        .add(AppEvent(eventType: 'unbounded-unavailable', message: '{}'));
+    await snapshot(true, true, [ip], arrivals: 3);
+    expect(events.last.state, 1);
+    expect(events.last.isReplay, true);
+    expect(container.read(shareProvider).totalCount, 11);
+  });
+
   testWidgets('fallback clears peers and serializes snapshots and toggles',
       (tester) async {
     late WidgetRef widgetRef;


### PR DESCRIPTION
Unbounded can be running before the sharing UI subscribes, leaving the display at zero until another connection arrives. Reconcile the UI once per second from the backend’s current running state and peers, show waiting when enabled but not running, and clear stale peers when backend contact is lost. Report unavailability once per outage and restore peers after recovery without false new-arrival animations. A cumulative backend arrival counter preserves totals for connections that finish between snapshots without recounting restored peers.

Clear peer tracking when falling back from router sharing, serialize fallback/toggle transitions, and reject location lookups belonging to an earlier peer session. Guard asynchronous IPC continuations against provider disposal. Preserve the consent and fallback behavior on current main.

Uses the merged https://github.com/getlantern/radiance/pull/630, pinned at merge commit `6950dfbcd9be`. No local workspace overrides are required.

Validation:
- All 248 Flutter tests pass, including nine snapshot/fallback/lifecycle regressions.
- Dart analysis passes for the sharing UI and tests.
- `go test ./lantern-core` passes with the pinned Radiance module, including outage/recovery and cancellation regressions.
- Independent code/comment review completed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live status snapshots for Unbounded connections.
  * Added a localized “Waiting to start — Unbounded” status message.

* **Bug Fixes**
  * Improved recovery when Unbounded services become temporarily unavailable.
  * Prevented stale connection information after backend interruptions.
  * Improved reliability during asynchronous connection-sharing operations and provider disposal.
  * Ensured recovered connections do not trigger incorrect new-connection animations.
  * Improved connection counts and status restoration across service restarts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
