### PR TITLE
ci: emit real newlines in Slack release message

### DIFF
--- a/scripts/ci/format.sh
+++ b/scripts/ci/format.sh
@@ -152,7 +152,7 @@ slack)
     text="${text}\n• iOS: Build uploaded to TestFlight"
   fi
 
-  echo "$text"
+  printf '%b\n' "$text"
   ;;
 
 *)


### PR DESCRIPTION
## Summary

Nightly posts in #releases have shown a literal `\n` between every line since Aug 25 ([example](https://wdynhnkxvsdx.slack.com/archives/C06F5EKHN5S/p1788842906758989)), instead of one line per download as [before](https://wdynhnkxvsdx.slack.com/archives/C06F5EKHN5S/p1787633327416349).

**Cause.** `scripts/ci/format.sh slack` builds its text with `\n` inside double-quoted bash strings, which bash does not expand, so the script emits the two characters `\` `n`. Before #8955 the workflow interpolated that raw text into a hand-written JSON payload, so Slack's JSON parser decoded `\n` as a newline and the message rendered correctly by accident. #8955 switched to `jq --arg text "$text"`, which correctly escapes the backslash to `\\n`, and Slack now displays the escape literally.

**Fix.** Expand the escapes in the script: `echo "$text"` → `printf '%b\n' "$text"`. The message contains no other backslashes, so nothing else changes. The jq step in `release.yml` is correct and untouched. The `nightly-failure-notify` message was never affected because it composes its text with `printf` format strings.

## Test plan

- [x] Ran `format.sh slack` before/after with nightly env and piped through `jq -Rs '{text: .}'`: before produces `\\n` in the JSON string, after produces `\n`.
- [x] `format.sh job-summary` output unchanged (the change is scoped to the `slack)` case).
- [ ] Next scheduled nightly renders one line per download in #releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Slack CI message formatting so interpreted escape sequences display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->