### PR TITLE
Update Radiance to remove donor STUN download dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,9 +29,9 @@ replace github.com/refraction-networking/water => github.com/getlantern/water v0
 
 require (
 	github.com/alecthomas/assert/v2 v2.3.0
-	github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d
+	github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260909202009-bfa747746b95
+	github.com/getlantern/radiance v0.0.0-20260910162321-50149728c3d0
 	github.com/sagernet/sing-box v1.13.19
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -237,8 +237,8 @@ github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c h1:ZzxuhIWO295y4eE6
 github.com/getlantern/amp v0.0.0-20260606002220-a8629924577c/go.mod h1:b5teAOFT+vpBqc2CHoz74QTEM15iOv1PLdQogwXcfrM=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952 h1:nD8iJ4IpaTq/09PhoOzmaGTwatOxsR41neSmbCY6RS8=
 github.com/getlantern/broflake v0.0.0-20260810172605-bef5e5234952/go.mod h1:1+1kCIg9Zj+2CgN+vl868AlAZVUItuN4wLhFur5QakA=
-github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d h1:ere/uJH2664qGRepjvircloQN7WWCY4eQ+oiw2C4Hno=
-github.com/getlantern/common v1.2.1-0.20260828200436-eb05c571820d/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
+github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24 h1:RrJsgaBsK+IspwFX7JwjFRItCWKZoKVY7UcsugheQvg=
+github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24/go.mod h1:9iL78jR5kZqr0E7oPxi38o6gPMhVa5dJBC5ngUgHzdg=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201 h1:oEZYEpZo28Wdx+5FZo4aU7JFXu0WG/4wJWese5reQSA=
 github.com/getlantern/context v0.0.0-20220418194847-3d5e7a086201/go.mod h1:Y9WZUHEb+mpra02CbQ/QczLUe6f0Dezxaw5DCJlJQGo=
 github.com/getlantern/dnstt v0.0.0-20260603191204-3b860502c0ac h1:TMvkNgLVyIYAfu1dYrOuRPYMVY+cHEo1C0CYWhtSw2A=
@@ -271,8 +271,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260909202009-bfa747746b95 h1:hnpSNPqD27IqhUPgtYEk31peJq54w/ksv2bbJXW7pAQ=
-github.com/getlantern/radiance v0.0.0-20260909202009-bfa747746b95/go.mod h1:KTIYK6eoTJxZhRnBt2f4odfOD59VTBFz/FFDVsJkBOg=
+github.com/getlantern/radiance v0.0.0-20260910162321-50149728c3d0 h1:6ldqoLfz1IZVVlkg/lXW8+AlLO6YPvKu4nZDwV68l5k=
+github.com/getlantern/radiance v0.0.0-20260910162321-50149728c3d0/go.mod h1:JhD5XCgy78CyrC9Yp/xWNuV2tOiO7JZvkEsCDojZxyc=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=


### PR DESCRIPTION
Action Mode donors could report running while repeatedly failing to download the public STUN list through tunnel DNS. Pin merged getlantern/radiance#634 (`50149728c3d0`) so Lantern uses configured STUN servers with an eight-server IP fallback, removing that download from donor startup. Common advances to merged getlantern/common#34 (`08e030318f24`) for the shared configuration, normalization, and equality methods.

Updated clients work with older API responses through the compiled fallback. Companion getlantern/lantern-cloud#3324 supplies `unbounded.stun_servers` from API settings. The broader tunnel DNS/discovery transport issue remains separate; on-device recovery has not yet been verified.

```mermaid
sequenceDiagram
    autonumber
    participant A as API<br/>config.go
    participant R as Donor<br/>unbounded.go
    participant P as WebRTC<br/>producer.go
    participant S as STUN list<br/>settings.go
    A->>R: config.go:913<br/>Send configured STUN pool
    Note over R: unbounded.go:556<br/>Install local sampler before worker creation ⚠️
    P->>R: producer.go:38<br/>Request STUN batch
    R-->>P: unbounded.go:216<br/>Normalize configured pool or compiled fallback
    rect rgba(255, 200, 200, 0.3)
        Note over S: settings.go:115<br/>Old default fetched GitHub through system DNS 🐛
        Note over P: producer.go:41<br/>A fetch failure returned to initialization
    end
```

Line references use the companion API branch, pinned Radiance `50149728c3d0`, and broflake `bef5e5234952`.

Validation: `go mod tidy`; `CGO_ENABLED=1 go test -tags with_gvisor,with_quic,with_wireguard,with_utls,with_grpc ./... -timeout=180s` (same build tags as Go CI). Only Radiance and Common versions/checksums change. The Radiance range also includes the radiance-tester build/CI fix from getlantern/radiance#633.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies to newer versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->