### PR TITLE
Fix Action Mode and desktop navigation UI nits

### DIFF
--- a/lib/core/common/app_dialog.dart
+++ b/lib/core/common/app_dialog.dart
@@ -14,12 +14,15 @@ class AppDialog {
     required String primaryLabel,
     OnPressed? onPrimaryPressed,
     String? secondaryLabel,
+    String? secondaryIcon,
     OnPressed? onSecondaryPressed,
     bool centered = false,
     // Centers just the title while the body stays start-aligned (the
     // browser-warning layout: centered icon + title, left-aligned body).
     bool centeredTitle = false,
     bool barrierDismissible = false,
+    bool scrollable = false,
+    bool dismissOnSecondary = true,
     // When false the primary callback is responsible for dismissing the
     // dialog itself (e.g. vpnConflictDialog callers already pop).
     bool dismissOnPrimary = true,
@@ -30,6 +33,7 @@ class AppDialog {
       builder: (context) {
         final textTheme = Theme.of(context).textTheme;
         return AlertDialog(
+          scrollable: scrollable,
           // backgroundColor and shape come from dialogTheme in app_theme.dart
           contentPadding: EdgeInsets.all(24),
           // Buttons live inside content (not `actions`) so they can stretch
@@ -89,7 +93,13 @@ class AppDialog {
                   SizedBox(height: 12),
                   SecondaryButton(
                     label: secondaryLabel,
+                    icon: secondaryIcon,
+                    useThemeColor: true,
                     onPressed: () {
+                      if (!dismissOnSecondary) {
+                        onSecondaryPressed?.call();
+                        return;
+                      }
                       Navigator.of(context).pop();
                       if (onSecondaryPressed != null) {
                         Future.delayed(

--- a/lib/features/setting/setting.dart
+++ b/lib/features/setting/setting.dart
@@ -158,7 +158,7 @@ class _SettingState extends ConsumerState<Setting>
                   DividerSpace(),
                   AppTile(
                     label: 'unbounded_settings_title'.i18n,
-                    icon: AppImagePaths.actionMode,
+                    icon: AppImagePaths.handshake,
                     onPressed: () =>
                         settingMenuTap(_SettingType.unboundedSetting),
                   ),

--- a/lib/features/share_my_connection/action_mode_widgets.dart
+++ b/lib/features/share_my_connection/action_mode_widgets.dart
@@ -242,8 +242,8 @@ class ActionModeNavigation extends StatelessWidget {
       textScaler: MediaQuery.textScalerOf(context),
       maxLines: 1,
     )..layout();
-    // Eight pixels of padding plus the one-pixel border on each side.
-    final height = math.max(56.0, painter.height + 18);
+    // Eight pixels of vertical padding on each side of the pill.
+    final height = math.max(56.0, painter.height + 16);
     painter.dispose();
     return height;
   }
@@ -253,15 +253,32 @@ class ActionModeNavigation extends StatelessWidget {
     height: desktop
         ? desktopHeight(context)
         : 64 + math.max(0, MediaQuery.textScalerOf(context).scale(14) - 14) * 2,
-    padding: EdgeInsets.all(desktop ? 8 : 4),
+    padding: desktop
+        ? const EdgeInsets.symmetric(horizontal: 16, vertical: 8)
+        : const EdgeInsets.all(4),
     decoration: BoxDecoration(
       color: context.bgElevated,
       borderRadius: BorderRadius.circular(desktop ? 0 : 9999),
-      border: Border.all(color: context.borderDefault),
+      border: desktop ? null : Border.all(color: context.borderDefault),
     ),
     child: Row(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
-        for (var i = 0; i < 2; i++) Expanded(child: _item(context, i)),
+        for (var i = 0; i < 2; i++)
+          Expanded(
+            child: Padding(
+              padding: EdgeInsets.symmetric(
+                horizontal: desktop
+                    ? 20 /
+                          math.max(
+                            1,
+                            MediaQuery.textScalerOf(context).scale(14) / 14,
+                          )
+                    : 0,
+              ),
+              child: _item(context, i),
+            ),
+          ),
       ],
     ),
   );
@@ -269,12 +286,14 @@ class ActionModeNavigation extends StatelessWidget {
   Widget _item(BuildContext context, int index) {
     final selected = selectedIndex == index;
     final active = index == 0 ? vpnActive : actionActive;
-    final color = selected ? context.textLink : context.textDisabled;
+    final color = selected
+        ? context.actionTabbarSelectedText
+        : context.actionTabbarDisabledText;
     final label = (index == 0 ? 'vpn' : 'unbounded').i18n;
     final icon = AppImage(
       path: index == 0
           ? (selected ? AppImagePaths.vpnKeyFill : AppImagePaths.vpnKey)
-          : (selected ? AppImagePaths.handshakeFill : AppImagePaths.actionMode),
+          : (selected ? AppImagePaths.handshakeFill : AppImagePaths.handshake),
       width: 24,
       height: 24,
       color: color,
@@ -316,11 +335,11 @@ class ActionModeNavigation extends StatelessWidget {
       button: true,
       label: label,
       child: Material(
-        color: selected ? context.bgHover : Colors.transparent,
+        color: selected ? context.actionTabbarBg : Colors.transparent,
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(9999),
           side: BorderSide(
-            color: selected ? context.borderDefault : Colors.transparent,
+            color: selected ? context.actionTabbarBorder : Colors.transparent,
           ),
         ),
         child: InkWell(
@@ -328,7 +347,7 @@ class ActionModeNavigation extends StatelessWidget {
           borderRadius: BorderRadius.circular(9999),
           onTap: () => onSelected(index),
           child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 8),
+            padding: EdgeInsets.symmetric(horizontal: desktop ? 4 : 8),
             child: desktop
                 ? Row(
                     mainAxisAlignment: MainAxisAlignment.center,

--- a/lib/features/share_my_connection/share_my_connection.dart
+++ b/lib/features/share_my_connection/share_my_connection.dart
@@ -989,6 +989,7 @@ class ActionModeAutoEnable extends ConsumerWidget {
           key: const Key('action-mode.auto-enable'),
           value: enabled,
           activeColor: context.textLink,
+          checkColor: context.bgElevated,
           onChanged: change,
         ),
         onPressed: () => change(!enabled),
@@ -1943,8 +1944,8 @@ class ShareConsentDialog extends StatelessWidget {
 // ─── Welcome dialog ──────────────────────────────────────────────────────────
 
 /// Shows the first-visit Unbounded welcome popup per Figma
-/// (figma.com/design/hNlyYToB5TnX9SDBFDYJTq?node-id=2403-19287).
-/// Idempotent: dismissing the dialog (either button OR scrim tap)
+/// (figma.com/design/hNlyYToB5TnX9SDBFDYJTq?node-id=7377-28803).
+/// Idempotent: dismissing the dialog (Got It, back, or scrim tap)
 /// flips appSettingProvider.unboundedWelcomeSeen → true so the dialog
 /// only fires on the first visit. The info-bubble icon in the
 /// Unbounded tab header calls this same function to re-open it later.
@@ -1954,92 +1955,26 @@ void showUnboundedWelcomeDialog(BuildContext context, WidgetRef ref) {
   // disposed if navigation replaced Home — ref.read would then throw. The
   // notifier is owned by the root container and outlives the widget.
   final appSetting = ref.read(appSettingProvider.notifier);
-  showDialog<void>(
+  AppDialog.show(
     context: context,
-    builder: (_) => const _UnboundedWelcomeDialog(),
+    barrierDismissible: true,
+    scrollable: true,
+    header: const Center(
+      child: AppImage(path: AppImagePaths.actionMode, width: 48, height: 48),
+    ),
+    centeredTitle: true,
+    title: 'unbounded_welcome_title'.i18n,
+    body: [
+      'unbounded_welcome_body_1'.i18n,
+      'unbounded_welcome_body_2'.i18n,
+      'unbounded_welcome_body_3'.i18n,
+    ].join('\n\n'),
+    primaryLabel: 'got_it'.i18n,
+    secondaryLabel: 'learn_more'.i18n,
+    secondaryIcon: AppImagePaths.outsideBrowser,
+    dismissOnSecondary: false,
+    onSecondaryPressed: () => UrlUtils.openUrl(AppUrls.unbounded),
   ).whenComplete(() {
     appSetting.setUnboundedWelcomeSeen(true);
   });
-}
-
-class _UnboundedWelcomeDialog extends StatelessWidget {
-  const _UnboundedWelcomeDialog();
-
-  @override
-  Widget build(BuildContext context) {
-    final textTheme = Theme.of(context).textTheme;
-    return Dialog(
-      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
-      child: ConstrainedBox(
-        constraints: const BoxConstraints(maxWidth: 312),
-        child: SingleChildScrollView(
-          padding: const EdgeInsets.all(24),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              // Action Mode handshake icon from the Figma design.
-              const Center(
-                child: AppImage(
-                  path: AppImagePaths.actionMode,
-                  width: 48,
-                  height: 48,
-                ),
-              ),
-              const SizedBox(height: 16),
-              Center(
-                child: Text(
-                  'unbounded_welcome_title'.i18n,
-                  textAlign: TextAlign.center,
-                  style: textTheme.titleLarge?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              Text(
-                'unbounded_welcome_body_1'.i18n,
-                style: textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                'unbounded_welcome_body_2'.i18n,
-                style: textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 12),
-              Text(
-                'unbounded_welcome_body_3'.i18n,
-                style: textTheme.bodyMedium,
-              ),
-              const SizedBox(height: 16),
-              Wrap(
-                alignment: WrapAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: () => UrlUtils.openUrl(AppUrls.unbounded),
-                    child: Row(
-                      mainAxisSize: MainAxisSize.min,
-                      children: [
-                        Text('learn_more'.i18n),
-                        const SizedBox(width: 4),
-                        const AppImage(
-                          path: AppImagePaths.outsideBrowser,
-                          width: 16,
-                          height: 16,
-                        ),
-                      ],
-                    ),
-                  ),
-                  TextButton(
-                    onPressed: () => Navigator.of(context).pop(),
-                    child: Text('got_it'.i18n),
-                  ),
-                ],
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
 }

--- a/test/core/common/app_dialog_test.dart
+++ b/test/core/common/app_dialog_test.dart
@@ -33,6 +33,48 @@ void main() {
     expect(find.byKey(const Key('dialog_page')), findsOneWidget);
     expect(find.byKey(const Key('home')), findsNothing);
   });
+
+  testWidgets('secondary action can leave the dialog open until dismissed', (
+    tester,
+  ) async {
+    var secondaryCalls = 0;
+    var completed = false;
+    await tester.pumpWidget(
+      ScreenUtilInit(
+        designSize: const Size(390, 844),
+        child: MaterialApp(
+          theme: AppTheme.appTheme(),
+          home: Builder(
+            builder: (context) => Scaffold(
+              body: TextButton(
+                onPressed: () => AppDialog.show(
+                  context: context,
+                  title: 'Welcome',
+                  primaryLabel: 'Got it',
+                  secondaryLabel: 'Learn more',
+                  dismissOnSecondary: false,
+                  onSecondaryPressed: () => secondaryCalls++,
+                ).whenComplete(() => completed = true),
+                child: const Text('Open'),
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Open'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Learn more'));
+    await tester.pumpAndSettle();
+    expect(secondaryCalls, 1);
+    expect(completed, isFalse);
+    expect(find.text('Welcome'), findsOneWidget);
+    await tester.tap(find.text('Got it'));
+    await tester.pumpAndSettle();
+    expect(completed, isTrue);
+    expect(find.text('Welcome'), findsNothing);
+  });
 }
 
 class _HomePage extends StatelessWidget {

--- a/test/features/share_my_connection/action_mode_navigation_test.dart
+++ b/test/features/share_my_connection/action_mode_navigation_test.dart
@@ -1,0 +1,104 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:lantern/core/common/common.dart';
+import 'package:lantern/features/share_my_connection/action_mode_widgets.dart';
+
+void main() {
+  setUpAll(Localization.loadTranslations);
+
+  testWidgets('desktop pills fill the strip height with inset sides', (
+    tester,
+  ) async {
+    tester.view.physicalSize = const Size(393, 852);
+    tester.view.devicePixelRatio = 1;
+    addTearDown(tester.view.resetPhysicalSize);
+    addTearDown(tester.view.resetDevicePixelRatio);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: ActionModeNavigation(
+            selectedIndex: 0,
+            onSelected: (_) {},
+            vpnActive: false,
+            actionActive: false,
+            desktop: true,
+          ),
+        ),
+      ),
+    );
+    final nav = find.byType(ActionModeNavigation);
+    final pill = find.byKey(const Key('action-mode.nav.0'));
+    expect(tester.getSize(nav).height, 56);
+    expect(tester.getSize(pill).height, 40);
+    expect(tester.getSize(pill).width, 140.5);
+    final strip = tester.widget<Container>(
+      find.descendant(of: nav, matching: find.byType(Container)).first,
+    );
+    expect((strip.decoration! as BoxDecoration).border, isNull);
+    expect(tester.takeException(), isNull);
+  });
+
+  for (final desktop in [false, true]) {
+    for (final brightness in Brightness.values) {
+      testWidgets('navigation uses themed states: $desktop, $brightness', (
+        tester,
+      ) async {
+        var selected = 0;
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(brightness: brightness),
+            home: Scaffold(
+              body: StatefulBuilder(
+                builder: (context, setState) => ActionModeNavigation(
+                  selectedIndex: selected,
+                  onSelected: (index) => setState(() => selected = index),
+                  vpnActive: false,
+                  actionActive: true,
+                  desktop: desktop,
+                ),
+              ),
+            ),
+          ),
+        );
+        final navigation = find.byType(ActionModeNavigation);
+        final context = tester.element(navigation);
+        AppImage imageFor(String path) => tester.widget<AppImage>(
+          find.byWidgetPredicate((w) => w is AppImage && w.path == path),
+        );
+        expect(
+          imageFor(AppImagePaths.handshake).color,
+          context.actionTabbarDisabledText,
+        );
+        expect(
+          imageFor(AppImagePaths.vpnKeyFill).color,
+          context.actionTabbarSelectedText,
+        );
+        await tester.tap(find.byKey(const Key('action-mode.nav.1')));
+        await tester.pumpAndSettle();
+        expect(selected, 1);
+        expect(
+          imageFor(AppImagePaths.handshakeFill).color,
+          context.actionTabbarSelectedText,
+        );
+        expect(
+          imageFor(AppImagePaths.vpnKey).color,
+          context.actionTabbarDisabledText,
+        );
+        final pill = tester.widget<Material>(
+          find
+              .ancestor(
+                of: find.byKey(const Key('action-mode.nav.1')),
+                matching: find.byType(Material),
+              )
+              .first,
+        );
+        expect(pill.color, context.actionTabbarBg);
+        expect(
+          (pill.shape! as RoundedRectangleBorder).side.color,
+          context.actionTabbarBorder,
+        );
+        expect(tester.takeException(), isNull);
+      });
+    }
+  }
+}

--- a/test/features/share_my_connection/action_mode_widgets_test.dart
+++ b/test/features/share_my_connection/action_mode_widgets_test.dart
@@ -65,7 +65,9 @@ void main() {
         child: ScreenUtilInit(
           designSize: const Size(393, 852),
           child: MaterialApp(
-            theme: ThemeData(brightness: brightness),
+            theme: brightness == Brightness.dark
+                ? AppTheme.darkTheme()
+                : AppTheme.appTheme(),
             builder: (context, child) => MediaQuery(
               data: MediaQuery.of(
                 context,


### PR DESCRIPTION
Fixes getlantern/engineering#3894.

Align Action Mode controls with the app's shared components and theme tokens:

- Match the checked auto-start checkbox glyph to its card background in both Action Mode and Settings, preserving the existing fill color.
- Use the shared `AppDialog` with stacked primary/secondary buttons for the welcome popup. Preserve scrolling, Learn More opening the browser without dismissing, and seen-state updates on dismissal.
- Use the existing outlined Material handshake asset in Settings and unselected desktop/mobile tabs.
- Use dedicated Action Mode tab colors, stretch desktop pills to 40px at normal text size, inset their sides, and remove the desktop strip's outer divider. Retain large-text layout support.

The status globe color item was already fixed and remains unchanged.

Validation: the full 293-test Flutter suite passed; after the final dialog icon tint adjustment, all 21 focused dialog/Action Mode tests passed and focused Dart analysis is clean. Light/dark desktop and mobile widget renders were inspected. Tests cover navigation selection and light/dark tokens, desktop pill bounds, large text, consent controls, and dialog secondary-action dismissal behavior. Existing shared-dialog callers retain their defaults.

Design verification: Figma briefly exposed the desktop reference, then required sign-in because the session expired. Desktop horizontal spacing is based on that visible reference and existing theme tokens; exact Figma inspection remains outstanding.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Dialogs now support secondary-button icons, scrollable content, and configurable dismissal behavior.
  - The Unbounded welcome experience now offers centered branding, scrollable information, and “Got It” and “Learn More” actions.
- **UI Improvements**
  - Updated action-mode navigation with responsive desktop sizing, clearer selected-state colors, improved spacing, and handshake iconography.
  - Updated the Unbounded settings icon and checkbox styling for improved visual consistency.
- **Bug Fixes**
  - Secondary dialog actions can now complete their callback without dismissing the dialog when configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->