### PR TITLE
ci: skip unchanged native checks and preserve framework artifacts

### DIFF
--- a/.github/scripts/swift_ci.py
+++ b/.github/scripts/swift_ci.py
@@ -42,7 +42,7 @@ def fingerprint(ref, platform, framework=False):
 
 
 def api(path):
-    return json.loads(subprocess.check_output(['gh', 'api', path], stderr=subprocess.PIPE))
+    return json.loads(subprocess.check_output(['gh', 'api', path], stderr=subprocess.PIPE, timeout=30))
 
 
 def trusted_run(run, event, repository):
@@ -73,7 +73,7 @@ def find_artifact(name, platform, event):
             jobs = api(f'repos/{repository}/actions/runs/{run_id}/jobs?per_page=100')['jobs']
             if any(j['name'] == JOB_NAMES[platform] and j['conclusion'] == 'success' for j in jobs):
                 return artifact
-    except (subprocess.CalledProcessError, KeyError, ValueError) as error:
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, KeyError, ValueError) as error:
         print(f'Artifact lookup unavailable ({type(error).__name__}); building instead.')
     return None
 

--- a/.github/scripts/swift_ci.py
+++ b/.github/scripts/swift_ci.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Plan native checks and find reusable artifacts from successful native jobs."""
+import argparse
+import hashlib
+import json
+import os
+from pathlib import Path
+import subprocess
+from urllib.parse import urlencode
+
+WORKFLOW = '.github/workflows/swift-compile-check.yml'
+SCRIPT = '.github/scripts/swift_ci.py'
+JOB_NAMES = {
+    'ios': 'iOS (Runner + Tunnel, simulator)',
+    'macos': 'macOS (Runner + PacketTunnel + RunnerTests)',
+}
+SHARED_FILES = {'go.mod', 'go.sum', 'Makefile', 'pubspec.yaml', 'pubspec.lock',
+                '.metadata', '.github/flutter-version.yaml', WORKFLOW, SCRIPT}
+SHARED_DIRS = ('lib/', 'assets/', 'lantern-core/', 'scripts/', 'profile/',
+               'protos/', 'resources/')
+
+
+def relevant(path, platform, framework=False):
+    if framework:
+        return (path in {'go.mod', 'go.sum', 'Makefile', WORKFLOW, SCRIPT}
+                or path.startswith(('lantern-core/', 'scripts/', 'profile/', 'resources/'))
+                or path.endswith(('.go', '.c', '.h', '.m', '.s')) and not path.startswith(('ios/', 'macos/', 'android/', 'windows/', 'linux/')))
+    return (path in SHARED_FILES or path.startswith(SHARED_DIRS)
+            or path.startswith(platform + '/') or path.endswith('.go'))
+
+
+def fingerprint(ref, platform, framework=False):
+    tree = subprocess.check_output(['git', 'ls-tree', '-rz', '--full-tree', ref])
+    entries = []
+    for entry in tree.split(b'\0'):
+        if not entry:
+            continue
+        metadata, path = entry.split(b'\t', 1)
+        if relevant(path.decode(), platform, framework):
+            entries.append(metadata + b'\t' + path)
+    return hashlib.sha256(b'\0'.join(sorted(entries))).hexdigest()
+
+
+def api(path):
+    return json.loads(subprocess.check_output(['gh', 'api', path], stderr=subprocess.PIPE))
+
+
+def trusted_run(run, event, repository):
+    if run.get('path', '').split('@')[0] != WORKFLOW:
+        return False
+    if run.get('head_repository', {}).get('full_name') != repository:
+        return False
+    if run.get('event') == 'push' and run.get('head_branch') == event['repository']['default_branch']:
+        return True
+    pr = event.get('pull_request')
+    return bool(pr and run.get('event') == 'pull_request'
+                and any(p['number'] == pr['number'] for p in run.get('pull_requests', [])))
+
+
+def find_artifact(name, platform, event):
+    repository = os.environ['GITHUB_REPOSITORY']
+    try:
+        result = api(f'repos/{repository}/actions/artifacts?' + urlencode({'name': name, 'per_page': 100}))
+        for artifact in result['artifacts']:
+            if artifact['expired'] or artifact['name'] != name:
+                continue
+            run_id = artifact['workflow_run']['id']
+            if str(run_id) == os.environ.get('GITHUB_RUN_ID'):
+                continue
+            run = api(f'repos/{repository}/actions/runs/{run_id}')
+            if not trusted_run(run, event, repository):
+                continue
+            jobs = api(f'repos/{repository}/actions/runs/{run_id}/jobs?per_page=100')['jobs']
+            if any(j['name'] == JOB_NAMES[platform] and j['conclusion'] == 'success' for j in jobs):
+                return artifact
+    except (subprocess.CalledProcessError, KeyError, ValueError) as error:
+        print(f'Artifact lookup unavailable ({type(error).__name__}); building instead.')
+    return None
+
+
+def emit(name, value):
+    with open(os.environ['GITHUB_OUTPUT'], 'a') as output:
+        output.write(f'{name}={value}\n')
+
+
+def plan(event):
+    summary = ['## Swift compile plan', '', '| Platform | Decision |', '|---|---|']
+    for platform in JOB_NAMES:
+        digest = fingerprint('HEAD', platform)
+        name = f'swift-success-v1-{platform}-{digest}'
+        emit(platform + '_digest', digest)
+        emit(platform + '_marker', name)
+        needed, reason = True, 'Native inputs need validation'
+        if os.environ['GITHUB_EVENT_NAME'] != 'workflow_dispatch':
+            pr = event.get('pull_request')
+            if pr and fingerprint(pr['base']['sha'], platform) == digest:
+                needed, reason = False, 'No platform inputs changed relative to base'
+            else:
+                artifact = find_artifact(name, platform, event)
+                if artifact:
+                    needed = False
+                    run_id = artifact['workflow_run']['id']
+                    reason = f'Reusing successful [run {run_id}](https://github.com/{os.environ["GITHUB_REPOSITORY"]}/actions/runs/{run_id})'
+        emit(platform + '_needed', str(needed).lower())
+        summary.append(f'| {platform} | {reason} |')
+    with open(os.environ['GITHUB_STEP_SUMMARY'], 'a') as output:
+        output.write('\n'.join(summary) + '\n')
+
+
+def framework(platform, event):
+    toolchain = b'\0'.join(subprocess.check_output(command) for command in (
+        ['go', 'version'], ['xcodebuild', '-version'], ['xcrun', '--sdk', 'iphonesimulator' if platform == 'ios' else 'macosx', '--show-sdk-version'], ['uname', '-m']))
+    digest = hashlib.sha256(fingerprint('HEAD', platform, framework=True).encode() + toolchain).hexdigest()
+    name = f'swift-framework-v1-{platform}-{digest}'
+    emit('name', name)
+    artifact = find_artifact(name, platform, event)
+    emit('artifact_id', artifact['id'] if artifact else '')
+    emit('run_id', artifact['workflow_run']['id'] if artifact else '')
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('command', choices=['plan', 'framework'])
+    parser.add_argument('--platform', choices=JOB_NAMES)
+    args = parser.parse_args()
+    event = json.loads(Path(os.environ['GITHUB_EVENT_PATH']).read_text())
+    if args.command == 'plan':
+        plan(event)
+    else:
+        framework(args.platform, event)

--- a/.github/scripts/test_swift_ci.py
+++ b/.github/scripts/test_swift_ci.py
@@ -1,4 +1,3 @@
-import json
 import os
 from pathlib import Path
 import subprocess

--- a/.github/scripts/test_swift_ci.py
+++ b/.github/scripts/test_swift_ci.py
@@ -1,0 +1,134 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+from unittest.mock import patch
+
+import swift_ci
+
+
+class InputTests(unittest.TestCase):
+    def test_platform_isolation(self):
+        self.assertTrue(swift_ci.relevant('ios/Shared/Logger.swift', 'ios'))
+        self.assertFalse(swift_ci.relevant('ios/Shared/Logger.swift', 'macos'))
+        self.assertTrue(swift_ci.relevant('macos/RunnerTests/RunnerTests.swift', 'macos'))
+        self.assertFalse(swift_ci.relevant('macos/RunnerTests/RunnerTests.swift', 'ios'))
+
+    def test_shared_inputs_invalidate_both(self):
+        for path in ['lib/main.dart', 'assets/locales/en.po', 'go.mod', 'go.sum',
+                     'lantern-core/mobile/mobile.go', 'scripts/ci/version.sh',
+                     'Makefile', 'pubspec.lock', swift_ci.WORKFLOW, swift_ci.SCRIPT]:
+            for platform in swift_ci.JOB_NAMES:
+                with self.subTest(path=path, platform=platform):
+                    self.assertTrue(swift_ci.relevant(path, platform))
+
+    def test_unrelated_edits_do_not_invalidate_native_builds(self):
+        for path in ['test/core/services/logger_service_test.dart', 'README.md',
+                     'android/app/build.gradle', 'windows/runner/main.cpp']:
+            for platform in swift_ci.JOB_NAMES:
+                self.assertFalse(swift_ci.relevant(path, platform))
+
+    def test_swift_edits_reuse_go_framework_but_go_edits_do_not(self):
+        self.assertFalse(swift_ci.relevant('ios/Shared/Logger.swift', 'ios', True))
+        self.assertTrue(swift_ci.relevant('lantern-core/mobile/mobile.go', 'ios', True))
+
+    def test_hash_detects_content_deletions_and_file_mode(self):
+        with tempfile.TemporaryDirectory() as directory:
+            old = os.getcwd()
+            os.chdir(directory)
+            try:
+                subprocess.run(['git', 'init', '-q'], check=True)
+                subprocess.run(['git', 'config', 'user.email', 'ci@example.test'], check=True)
+                subprocess.run(['git', 'config', 'user.name', 'CI Test'], check=True)
+                Path('ios').mkdir()
+                Path('test').mkdir()
+                source = Path('ios/source.swift')
+                source.write_text('first')
+                def commit():
+                    subprocess.run(['git', 'add', '-A'], check=True)
+                    subprocess.run(['git', 'commit', '-qm', 'fixture'], check=True)
+                commit()
+                original = swift_ci.fingerprint('HEAD', 'ios')
+                Path('test/unit.dart').write_text('test-only')
+                commit()
+                self.assertEqual(original, swift_ci.fingerprint('HEAD', 'ios'))
+                source.write_text('changed')
+                commit()
+                changed = swift_ci.fingerprint('HEAD', 'ios')
+                self.assertNotEqual(original, changed)
+                source.chmod(0o755)
+                commit()
+                self.assertNotEqual(changed, swift_ci.fingerprint('HEAD', 'ios'))
+                source.unlink()
+                commit()
+                self.assertNotEqual(original, swift_ci.fingerprint('HEAD', 'ios'))
+            finally:
+                os.chdir(old)
+
+
+class ArtifactTests(unittest.TestCase):
+    event = {'repository': {'default_branch': 'main'}, 'pull_request': {'number': 9014}}
+
+    def run_data(self, event='pull_request', number=9014):
+        return {'path': swift_ci.WORKFLOW, 'head_repository': {'full_name': 'getlantern/lantern'},
+                'event': event, 'head_branch': 'main' if event == 'push' else 'feature',
+                'pull_requests': [{'number': number}]}
+
+    def test_only_same_pr_or_main_can_supply_evidence(self):
+        self.assertTrue(swift_ci.trusted_run(self.run_data(), self.event, 'getlantern/lantern'))
+        self.assertTrue(swift_ci.trusted_run(self.run_data('push'), self.event, 'getlantern/lantern'))
+        self.assertFalse(swift_ci.trusted_run(self.run_data(number=9999), self.event, 'getlantern/lantern'))
+        run = self.run_data()
+        run['path'] = '.github/workflows/other.yml'
+        self.assertFalse(swift_ci.trusted_run(run, self.event, 'getlantern/lantern'))
+        run = self.run_data()
+        run['head_repository']['full_name'] = 'fork/lantern'
+        self.assertFalse(swift_ci.trusted_run(run, self.event, 'getlantern/lantern'))
+
+    @patch.dict(os.environ, {'GITHUB_REPOSITORY': 'getlantern/lantern', 'GITHUB_RUN_ID': '100'})
+    def test_only_successful_platform_jobs_are_reused(self):
+        artifact = {'id': 9, 'name': 'match', 'expired': False, 'workflow_run': {'id': 99}}
+        for conclusion in ['failure', 'cancelled', None, 'success']:
+            with patch.object(swift_ci, 'api', side_effect=[{'artifacts': [artifact]}, self.run_data(),
+                    {'jobs': [{'name': swift_ci.JOB_NAMES['ios'], 'conclusion': conclusion}]}]):
+                found = swift_ci.find_artifact('match', 'ios', self.event)
+                self.assertEqual(found is not None, conclusion == 'success')
+
+    @patch.dict(os.environ, {'GITHUB_REPOSITORY': 'getlantern/lantern', 'GITHUB_RUN_ID': '100'})
+    def test_expired_wrong_name_and_current_run_are_ignored(self):
+        for name, expired, run in [('match', True, 99), ('different', False, 99), ('match', False, 100)]:
+            with patch.object(swift_ci, 'api', return_value={'artifacts': [
+                    {'id': 9, 'name': name, 'expired': expired, 'workflow_run': {'id': run}}]}):
+                self.assertIsNone(swift_ci.find_artifact('match', 'ios', self.event))
+
+    @patch.dict(os.environ, {'GITHUB_REPOSITORY': 'getlantern/lantern'})
+    def test_api_failure_builds_instead(self):
+        with patch.object(swift_ci, 'api', side_effect=subprocess.CalledProcessError(1, 'gh')):
+            self.assertIsNone(swift_ci.find_artifact('match', 'ios', self.event))
+
+    def test_plan_reuses_success_and_manual_dispatch_forces_build(self):
+        for event_name, expected in [('pull_request', 'false'), ('workflow_dispatch', 'true')]:
+            with tempfile.TemporaryDirectory() as directory:
+                output = Path(directory) / 'output'
+                with patch.dict(os.environ, {'GITHUB_EVENT_NAME': event_name, 'GITHUB_OUTPUT': str(output),
+                        'GITHUB_STEP_SUMMARY': str(Path(directory) / 'summary'),
+                        'GITHUB_REPOSITORY': 'getlantern/lantern'}), \
+                        patch.object(swift_ci, 'fingerprint', return_value='digest'), \
+                        patch.object(swift_ci, 'find_artifact', return_value={'workflow_run': {'id': 99}}):
+                    swift_ci.plan({'repository': {'default_branch': 'main'}})
+                self.assertIn('ios_needed=' + expected, output.read_text())
+                self.assertIn('macos_needed=' + expected, output.read_text())
+
+    def test_platform_with_no_changes_skips_without_history(self):
+        event = {**self.event, 'pull_request': {'number': 9014, 'base': {'sha': 'base'}}}
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / 'output'
+            with patch.dict(os.environ, {'GITHUB_EVENT_NAME': 'pull_request', 'GITHUB_OUTPUT': str(output),
+                    'GITHUB_STEP_SUMMARY': str(Path(directory) / 'summary')}), \
+                    patch.object(swift_ci, 'fingerprint', return_value='same'), \
+                    patch.object(swift_ci, 'find_artifact') as find:
+                swift_ci.plan(event)
+                find.assert_not_called()
+            self.assertIn('ios_needed=false', output.read_text())

--- a/.github/workflows/swift-compile-check.yml
+++ b/.github/workflows/swift-compile-check.yml
@@ -49,8 +49,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 0
           persist-credentials: false
+      - name: Fetch PR base tree
+        if: github.event_name == 'pull_request'
+        run: git fetch --no-tags --depth=1 origin "$BASE_SHA"
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
       - name: Test native input selection
         run: python3 -m unittest discover -s .github/scripts -p 'test_swift_ci.py'
       - name: Compare native inputs and prior successes
@@ -161,6 +165,7 @@ jobs:
 
       - name: Save framework outside the dependency cache
         if: steps.framework-restore.outcome != 'success'
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.framework.outputs.name }}
@@ -173,6 +178,7 @@ jobs:
         run: echo "${{ needs.plan.outputs.macos_marker }}" > "$RUNNER_TEMP/native-success.txt"
 
       - name: Save successful-check marker
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.plan.outputs.macos_marker }}
@@ -274,6 +280,7 @@ jobs:
 
       - name: Save framework outside the dependency cache
         if: steps.framework-restore.outcome != 'success'
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.framework.outputs.name }}
@@ -286,6 +293,7 @@ jobs:
         run: echo "${{ needs.plan.outputs.ios_marker }}" > "$RUNNER_TEMP/native-success.txt"
 
       - name: Save successful-check marker
+        continue-on-error: true
         uses: actions/upload-artifact@v4
         with:
           name: ${{ needs.plan.outputs.ios_marker }}

--- a/.github/workflows/swift-compile-check.yml
+++ b/.github/workflows/swift-compile-check.yml
@@ -6,25 +6,63 @@ name: Swift Compile Check
 on:
   workflow_dispatch:
   pull_request:
+  push:
+    branches: [main]
     paths:
-      - "**/*.swift"
-      - "macos/**"
       - "ios/**"
+      - "macos/**"
+      - "lib/**"
+      - "assets/**"
+      - "lantern-core/**"
+      - "scripts/**"
+      - "profile/**"
+      - "protos/**"
+      - "resources/**"
+      - "**/*.go"
+      - "go.mod"
+      - "go.sum"
       - "pubspec.yaml"
       - "pubspec.lock"
       - "Makefile"
+      - ".metadata"
       - ".github/flutter-version.yaml"
       - ".github/workflows/swift-compile-check.yml"
+      - ".github/scripts/swift_ci.py"
+
+permissions:
+  contents: read
+  actions: read
 
 concurrency:
   group: swift-compile-check-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  plan:
+    name: Plan Swift checks
+    runs-on: ubuntu-latest
+    outputs:
+      ios_needed: ${{ steps.plan.outputs.ios_needed }}
+      macos_needed: ${{ steps.plan.outputs.macos_needed }}
+      ios_marker: ${{ steps.plan.outputs.ios_marker }}
+      macos_marker: ${{ steps.plan.outputs.macos_marker }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Test native input selection
+        run: python3 -m unittest discover -s .github/scripts -p 'test_swift_ci.py'
+      - name: Compare native inputs and prior successes
+        id: plan
+        run: python3 .github/scripts/swift_ci.py plan
+        env:
+          GH_TOKEN: ${{ github.token }}
+
   macos-compile-check:
+    needs: plan
+    if: needs.plan.outputs.macos_needed == 'true'
     name: macOS (Runner + PacketTunnel + RunnerTests)
-    permissions:
-      contents: "read"
     runs-on: macos-15
     timeout-minutes: 60
     steps:
@@ -45,17 +83,6 @@ jobs:
           channel: stable
           flutter-version-file: .github/flutter-version.yaml
           cache: true
-
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
 
       - name: Cache macOS CocoaPods
         uses: actions/cache@v4
@@ -81,35 +108,35 @@ jobs:
           echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
           mkdir -p "$HOME/.cache/gomobile"
 
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
+      - name: Find matching macOS framework artifact
+        id: framework
+        run: python3 .github/scripts/swift_ci.py framework --platform macos
+        env:
+          GH_TOKEN: ${{ github.token }}
 
-      - name: Cache macOS Liblantern.xcframework
-        id: macos-framework-cache
-        uses: actions/cache@v4
-        timeout-minutes: 5
+      - name: Download validated framework
+        id: framework-download
+        if: steps.framework.outputs.artifact_id != ''
         continue-on-error: true
+        uses: actions/download-artifact@v4
         with:
-          path: macos/Frameworks/Liblantern.xcframework
-          key: ${{ runner.os }}-macos-xcframework-${{ hashFiles('go.mod', 'go.sum', 'Makefile', '**/*.go') }}
+          artifact-ids: ${{ steps.framework.outputs.artifact_id }}
+          run-id: ${{ steps.framework.outputs.run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/native-framework
+          merge-multiple: true
 
-      # Restored files must look newer than the Go sources or make rebinds.
-      - name: Mark restored macOS xcframework fresh
-        if: steps.macos-framework-cache.outputs.cache-hit == 'true'
-        shell: bash
+      - name: Restore framework and refresh timestamps
+        id: framework-restore
+        if: steps.framework-download.outcome == 'success'
+        continue-on-error: true
         run: |
-          test -d macos/Frameworks/Liblantern.xcframework
+          tar -xzf "$RUNNER_TEMP/native-framework/framework.tar.gz"
+          test -f macos/Frameworks/Liblantern.xcframework/Info.plist
           find macos/Frameworks/Liblantern.xcframework -exec touch {} +
 
       - name: Install gomobile
-        if: steps.macos-framework-cache.outputs.cache-hit != 'true'
+        if: steps.framework-restore.outcome != 'success'
         run: make install-gomobile
         env:
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
@@ -128,10 +155,35 @@ jobs:
         env:
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
 
+      - name: Package validated framework
+        if: steps.framework-restore.outcome != 'success'
+        run: tar -czf "$RUNNER_TEMP/framework.tar.gz" macos/Frameworks/Liblantern.xcframework
+
+      - name: Save framework outside the dependency cache
+        if: steps.framework-restore.outcome != 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.framework.outputs.name }}
+          path: ${{ runner.temp }}/framework.tar.gz
+          retention-days: 7
+          compression-level: 0
+          overwrite: true
+
+      - name: Record successful native inputs
+        run: echo "${{ needs.plan.outputs.macos_marker }}" > "$RUNNER_TEMP/native-success.txt"
+
+      - name: Save successful-check marker
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.macos_marker }}
+          path: ${{ runner.temp }}/native-success.txt
+          retention-days: 7
+          overwrite: true
+
   ios-compile-check:
+    needs: plan
+    if: needs.plan.outputs.ios_needed == 'true'
     name: iOS (Runner + Tunnel, simulator)
-    permissions:
-      contents: "read"
     runs-on: macos-26
     timeout-minutes: 60
     steps:
@@ -153,17 +205,6 @@ jobs:
           flutter-version-file: .github/flutter-version.yaml
           cache: true
 
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
-
       - name: Cache iOS CocoaPods
         uses: actions/cache@v4
         timeout-minutes: 10
@@ -181,34 +222,35 @@ jobs:
           echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
           mkdir -p "$HOME/.cache/gomobile"
 
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
+      - name: Find matching iOS framework artifact
+        id: framework
+        run: python3 .github/scripts/swift_ci.py framework --platform ios
+        env:
+          GH_TOKEN: ${{ github.token }}
 
-      - name: Cache iOS Liblantern.xcframework
-        id: ios-framework-cache
-        uses: actions/cache@v4
-        timeout-minutes: 5
+      - name: Download validated framework
+        id: framework-download
+        if: steps.framework.outputs.artifact_id != ''
         continue-on-error: true
+        uses: actions/download-artifact@v4
         with:
-          path: ios/Frameworks/Liblantern.xcframework
-          key: ${{ runner.os }}-ios-xcframework-${{ hashFiles('go.mod', 'go.sum', 'Makefile', '**/*.go') }}
+          artifact-ids: ${{ steps.framework.outputs.artifact_id }}
+          run-id: ${{ steps.framework.outputs.run_id }}
+          github-token: ${{ github.token }}
+          path: ${{ runner.temp }}/native-framework
+          merge-multiple: true
 
-      - name: Mark restored iOS xcframework fresh
-        if: steps.ios-framework-cache.outputs.cache-hit == 'true'
-        shell: bash
+      - name: Restore framework and refresh timestamps
+        id: framework-restore
+        if: steps.framework-download.outcome == 'success'
+        continue-on-error: true
         run: |
-          test -d ios/Frameworks/Liblantern.xcframework
+          tar -xzf "$RUNNER_TEMP/native-framework/framework.tar.gz"
+          test -f ios/Frameworks/Liblantern.xcframework/Info.plist
           find ios/Frameworks/Liblantern.xcframework -exec touch {} +
 
       - name: Install gomobile
-        if: steps.ios-framework-cache.outputs.cache-hit != 'true'
+        if: steps.framework-restore.outcome != 'success'
         run: make install-gomobile
         env:
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
@@ -225,3 +267,28 @@ jobs:
         run: make ios-compile-check
         env:
           GOMOBILECACHE: ${{ env.GOMOBILECACHE }}
+
+      - name: Package validated framework
+        if: steps.framework-restore.outcome != 'success'
+        run: tar -czf "$RUNNER_TEMP/framework.tar.gz" ios/Frameworks/Liblantern.xcframework
+
+      - name: Save framework outside the dependency cache
+        if: steps.framework-restore.outcome != 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.framework.outputs.name }}
+          path: ${{ runner.temp }}/framework.tar.gz
+          retention-days: 7
+          compression-level: 0
+          overwrite: true
+
+      - name: Record successful native inputs
+        run: echo "${{ needs.plan.outputs.ios_marker }}" > "$RUNNER_TEMP/native-success.txt"
+
+      - name: Save successful-check marker
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ needs.plan.outputs.ios_marker }}
+          path: ${{ runner.temp }}/native-success.txt
+          retention-days: 7
+          overwrite: true

--- a/.github/workflows/swift-compile-check.yml
+++ b/.github/workflows/swift-compile-check.yml
@@ -29,6 +29,11 @@ on:
       - ".github/workflows/swift-compile-check.yml"
       - ".github/scripts/swift_ci.py"
 
+# Both gomobile and gobind use this exact module version via the Makefile.
+# The workflow is included in both fingerprints, so changing it invalidates reuse.
+env:
+  GOMOBILE_VERSION: v0.0.0-20260908204917-8b95e45f8d3e
+
 permissions:
   contents: read
   actions: read


### PR DESCRIPTION
A test-only follow-up to a PR that previously changed Swift reruns both native builds. On #9014, iOS took 20 minutes on one run and more than 24 minutes on the next, while a cached macOS build/test step took about 2 minutes. The previous run saved its iOS framework successfully, but that artifact disappeared from the dependency-cache inventory while repository cache usage was around 10 GB.

This change:

- Adds a Linux planner that hashes tracked build inputs (including file modes, additions and deletions) separately for iOS and macOS. A platform with no changes relative to the PR base is skipped. Shared Dart, Go, assets and build configuration invalidate both platforms; unrelated tests/docs do not.
- Reuses a successful platform check with identical inputs from this PR or a push to main, identified by a seven-day success artifact and a verified successful platform job. Missing/expired artifacts and API failures fall back to building. Manual dispatch forces native checks.
- Stores compressed xcframeworks as seven-day workflow artifacts, outside the dependency-cache eviction pool. Restoration requires matching framework inputs, Go version, Xcode version, SDK and architecture, plus a successful platform job from this PR or main. Tar preserves framework symlinks and modes; restored timestamps prevent Make from rebinding unchanged Go code.
- Pins gomobile/gobind to `v0.0.0-20260908204917-8b95e45f8d3e` in the workflow. Both fingerprints include the workflow, so tool-version changes invalidate framework and full-check reuse.
- Warms artifacts on relevant main pushes. Removes duplicate Flutter package caching and the ineffective gomobile cache (the observed archives were only ~260 bytes).

The lightweight planner intentionally runs on every PR: unrelated changes get explicit skipped native checks, and changes to the planner tests are validated. It completed in seven seconds in live CI. The existing native check names remain. The planner summary links to any prior successful run being reused. A cold build still takes time; this avoids repeating it unnecessarily. Artifacts have separate storage retention/costs, capped here at seven days. Full-check reuse is bounded by that retention, rather than detecting hosted runner image changes on Linux; manual dispatch provides a fresh check when needed.

```mermaid
sequenceDiagram
    autonumber
    participant P as Planner<br/>swift_ci.py
    participant A as Artifacts<br/>GitHub API
    participant M as Mac runner<br/>swift-compile-check.yml
    P->>P: swift_ci.py:89<br/>Hash tracked platform inputs
    P->>A: swift_ci.py:99<br/>Look up matching success marker
    A-->>P: swift_ci.py:74<br/>Require successful platform job
    Note over P: swift_ci.py:101<br/>Matching success disables redundant build ⚠️
    rect rgba(255, 200, 200, 0.3)
        Note over M: swift-compile-check.yml:73<br/>Previously allocated again for test-only follow-up 🐛
    end
    P->>M: swift-compile-check.yml:73<br/>Allocate only if inputs need validation
    M->>A: swift-compile-check.yml:289<br/>Save validated framework outside dependency cache
    M->>A: swift-compile-check.yml:302<br/>Save success marker for future checks
```

Validation:
- 11 planner/artifact tests pass: platform isolation, shared inputs, unrelated changes, content/deletion/mode hashing, trust boundaries, failed/cancelled jobs, expired artifacts, API failure, manual override and no-change skipping.
- `actionlint .github/workflows/swift-compile-check.yml` passes.
- Confirmed #9014 commits `81afdebfe` and `228d11c71` have identical native input fingerprints for both platforms.
- The Linux planner passed in live CI and selected both platform builds for this workflow change. Native builds/artifact round-trip validation are still running.
- Planner checkout fetches only the current and PR-base trees; artifact lookup has a 30-second request timeout. Artifact upload failures do not turn a passing native build into a failure.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated iOS and macOS compile checks for relevant native and build changes pushed to the main branch.
  * Reuses validated framework and build artifacts when available, reducing unnecessary rebuilds.
  * Publishes successful check markers to skip unchanged platform checks in future runs.
  * Pins the gomobile/gobind tool version for consistent builds.

* **Bug Fixes**
  * Added safeguards to prevent reuse of untrusted or unsuccessful artifacts.
  * Ensures platform checks run when planning fails.

* **Tests**
  * Added coverage for change detection, artifact validation, build planning, and platform-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
