### PR TITLE
Fix Android Action Mode being disarmed by IPC fallback shutdown

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260910162321-50149728c3d0
+	github.com/getlantern/radiance v0.0.0-20260910183250-bc7dc6dd5faa
 	github.com/sagernet/sing-box v1.13.19
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260910183850-298c40468590
+	github.com/getlantern/radiance v0.0.0-20260910191700-b1be56e1f949
 	github.com/sagernet/sing-box v1.13.19
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.mod
+++ b/go.mod
@@ -31,7 +31,7 @@ require (
 	github.com/alecthomas/assert/v2 v2.3.0
 	github.com/getlantern/common v1.2.1-0.20260910154003-08e030318f24
 	github.com/getlantern/lantern-server-provisioner v0.0.0-20251031121934-8ea031fccfa9
-	github.com/getlantern/radiance v0.0.0-20260910183250-bc7dc6dd5faa
+	github.com/getlantern/radiance v0.0.0-20260910183850-298c40468590
 	github.com/sagernet/sing-box v1.13.19
 	golang.org/x/mobile v0.0.0-20250711185624-d5bb5ecc55c0
 	golang.org/x/sys v0.45.0

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260910183250-bc7dc6dd5faa h1:I13ME5IWFRF4ho05yGA4ROAISV866emEfFeOhG8zYyA=
-github.com/getlantern/radiance v0.0.0-20260910183250-bc7dc6dd5faa/go.mod h1:JhD5XCgy78CyrC9Yp/xWNuV2tOiO7JZvkEsCDojZxyc=
+github.com/getlantern/radiance v0.0.0-20260910183850-298c40468590 h1:qUKPjIxSc6jVsEJZJTsxmsfMm2/Rq2plo0JVS9bZht4=
+github.com/getlantern/radiance v0.0.0-20260910183850-298c40468590/go.mod h1:JhD5XCgy78CyrC9Yp/xWNuV2tOiO7JZvkEsCDojZxyc=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260910162321-50149728c3d0 h1:6ldqoLfz1IZVVlkg/lXW8+AlLO6YPvKu4nZDwV68l5k=
-github.com/getlantern/radiance v0.0.0-20260910162321-50149728c3d0/go.mod h1:JhD5XCgy78CyrC9Yp/xWNuV2tOiO7JZvkEsCDojZxyc=
+github.com/getlantern/radiance v0.0.0-20260910183250-bc7dc6dd5faa h1:I13ME5IWFRF4ho05yGA4ROAISV866emEfFeOhG8zYyA=
+github.com/getlantern/radiance v0.0.0-20260910183250-bc7dc6dd5faa/go.mod h1:JhD5XCgy78CyrC9Yp/xWNuV2tOiO7JZvkEsCDojZxyc=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/go.sum
+++ b/go.sum
@@ -271,8 +271,8 @@ github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535 h1:rtDmW8YL
 github.com/getlantern/pluriconfig v0.0.0-20251126214241-8cc8bc561535/go.mod h1:WKJEdjMOD4IuTRYwjQHjT4bmqDl5J82RShMLxPAvi0Q=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b h1:gMYJzEhLrmIqQ+JnjiYNm+UyUDalK3WUmVyecFwmV5g=
 github.com/getlantern/publicip v0.0.0-20260328175246-2c460fe80c6b/go.mod h1:NpfXdK4ldEKkjQ4P1R+DBF4ua5VFOlxmgHROTnYrApg=
-github.com/getlantern/radiance v0.0.0-20260910183850-298c40468590 h1:qUKPjIxSc6jVsEJZJTsxmsfMm2/Rq2plo0JVS9bZht4=
-github.com/getlantern/radiance v0.0.0-20260910183850-298c40468590/go.mod h1:JhD5XCgy78CyrC9Yp/xWNuV2tOiO7JZvkEsCDojZxyc=
+github.com/getlantern/radiance v0.0.0-20260910191700-b1be56e1f949 h1:ps3lT8JCmM6OO5nnRFnVdHb4bVgQlmj9CqffKIKZWss=
+github.com/getlantern/radiance v0.0.0-20260910191700-b1be56e1f949/go.mod h1:JhD5XCgy78CyrC9Yp/xWNuV2tOiO7JZvkEsCDojZxyc=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064 h1:NhCyQAWGEWjok/jg4gRD6fzCZvyOQy/4dVSFYhzU5xk=
 github.com/getlantern/samizdat v0.0.3-0.20260819153658-ebc74116a064/go.mod h1:uEeykQSW2/6rTjfPlj3MTTo59poSHXfAHTGgzYDkbr0=
 github.com/getlantern/semconv v0.0.0-20260327040646-21845dda05cb h1:c5YM7b3a4r2J8Eh89KkI6M/iTFe6Bi+b8AJlfkKdFq4=

--- a/lantern-core/init_mobile.go
+++ b/lantern-core/init_mobile.go
@@ -4,6 +4,7 @@ package lanterncore
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/getlantern/radiance/backend"
 	"github.com/getlantern/radiance/ipc"
@@ -12,6 +13,9 @@ import (
 )
 
 func createClient(ctx context.Context, opts *utils.Opts) (*ipc.Client, error) {
+	if runtime.GOOS == "android" {
+		return ipc.NewRemoteClient(), nil
+	}
 	backendOpts := backend.Options{
 		DataDir:                 opts.DataDir,
 		LogDir:                  opts.LogDir,


### PR DESCRIPTION
Android Action Mode persisted its enabled toggle but never ran the donor: setting up the UI created a second Radiance backend, and closing that fallback after IPC connected disarmed the service's process-wide Unbounded manager. Ticket 182752 records 97 consecutive enabled-but-not-running snapshots despite the current STUN configuration and binaries.

Use `ipc.NewRemoteClient` only on Android, where `LanternVpnService` starts the owning backend before UI setup. Socket failures remain explicit instead of starting another backend. Apple clients retain their fallback behavior. This changes neither the API nor STUN configuration.

Uses merged getlantern/radiance#635, pinned to merge commit `b1be56e1f949`. Ran `go mod tidy` and committed go.mod/go.sum together.

```mermaid
sequenceDiagram
    autonumber
    participant A as Android<br/>LanternVpnService.kt
    participant L as Core<br/>init_mobile.go
    participant I as IPC<br/>client_mobile.go
    participant B as Backend<br/>radiance.go
    participant U as Donor<br/>unbounded.go
    A->>B: LanternVpnService.kt:375<br/>Start service backend
    A->>L: LanternVpnService.kt:376<br/>Set up UI client
    L->>I: init_mobile.go:17<br/>NewRemoteClient with no fallback backend ⚠️
    I->>B: client_mobile.go:109<br/>Request through service socket
    rect rgba(255, 200, 200, 0.3)
        Note over B,U: radiance.go:468<br/>Old fallback Close called process-wide Unbounded Stop 🐛
    end
    Note over I: client_mobile.go:80<br/>No local backend to close after IPC success
```

Line references use this PR and Radiance merge commit `b1be56e1f949`.

Validation: complete Go suite with CI tags (`CGO_ENABLED=1 go test -tags with_gvisor,with_quic,with_wireguard,with_utls,with_grpc ./... -timeout=180s`). Radiance regression tests cover missing/refused sockets, successful request/SSE recovery, and repeated close with no fallback backend. On-device recovery is not yet verified.

Android ARM64 CGO compilation of `./lantern-core/mobile` with the CI build tags passed using NDK 28.2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Android client initialization for more reliable communication with the backend.
  - Preserved existing client initialization behavior on iOS and desktop platforms.

- **Stability**
  - Updated underlying communication components to support continued reliability improvements across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->