### PR TITLE
Speed up CI builds and consolidate shared setup

### DIFF
--- a/.github/actions/setup-android/action.yml
+++ b/.github/actions/setup-android/action.yml
@@ -1,0 +1,45 @@
+name: Set up Lantern Android toolchain
+description: Install Java, configure Gradle caching, and provision SDK versions from the Makefile.
+inputs:
+  gradle-version:
+    description: Optional standalone Gradle for jobs that invoke Gradle directly rather than through Flutter.
+    default: ""
+runs:
+  using: composite
+  steps:
+    - name: Free space on hosted Linux runners
+      if: runner.os == 'Linux' && runner.environment == 'github-hosted'
+      shell: bash
+      # These images are disposable. Keep the Android SDK/NDK and all tools used
+      # by this build; do not run cleanup on a developer or self-hosted machine.
+      run: |
+        sudo rm -rf /usr/share/dotnet /usr/share/swift /opt/hostedtoolcache/CodeQL
+        df -h .
+
+    - name: Install Java 17
+      uses: actions/setup-java@v4
+      with:
+        distribution: temurin
+        java-version: 17
+        # setup-gradle owns this cache; never also enable setup-java caching.
+
+    - name: Set up Gradle cache
+      uses: gradle/actions/setup-gradle@v4
+      with:
+        gradle-version: ${{ inputs.gradle-version }}
+        # Manual branch benchmarks must be able to warm their own caches.
+        # PRs only read caches; configuration caches/secrets are not persisted.
+        cache-read-only: ${{ github.event_name == 'pull_request' }}
+        cache-cleanup: on-success
+        dependency-graph: disabled
+        build-scan-publish: false
+
+    - name: Set up Android SDK
+      uses: android-actions/setup-android@v3
+
+    - name: Install Android SDK components
+      shell: bash
+      run: |
+        set -euo pipefail
+        make install-android-sdk
+        make android-env >> "$GITHUB_ENV"

--- a/.github/actions/setup-flutter/action.yml
+++ b/.github/actions/setup-flutter/action.yml
@@ -1,0 +1,68 @@
+name: Set up Lantern Flutter toolchain
+description: Install the pinned SDK and maintain one pub cache per host architecture.
+runs:
+  using: composite
+  steps:
+    - name: Read pinned Flutter version
+      id: version
+      shell: bash
+      env:
+        ACTION_PATH: ${{ github.action_path }}
+      # Passing flutter-version avoids flutter-action's Chocolatey/yq install
+      # on Windows, which has failed release builds during feed outages.
+      run: |
+        version=$(bash "$ACTION_PATH/read-version.sh" .github/flutter-version.yaml)
+        echo "version=$version" >> "$GITHUB_OUTPUT"
+
+    - name: Install Flutter SDK
+      id: flutter
+      if: runner.os != 'Linux' || runner.arch != 'ARM64'
+      uses: subosito/flutter-action@v2.23.0
+      with:
+        channel: stable
+        flutter-version: ${{ steps.version.outputs.version }}
+        cache: true
+        # One owner for pub caching, with fallback across lockfile updates.
+        pub-cache: false
+
+    # The pinned Flutter release has no Linux ARM64 SDK archive. Preserve the
+    # source-install path, but cache it instead of bootstrapping on every run.
+    - name: Cache Linux ARM64 Flutter SDK
+      if: runner.os == 'Linux' && runner.arch == 'ARM64'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}/lantern-flutter-sdk
+        key: flutter-source-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}
+
+    - name: Install Linux ARM64 Flutter SDK
+      if: runner.os == 'Linux' && runner.arch == 'ARM64'
+      shell: bash
+      env:
+        FLUTTER_VERSION: ${{ steps.version.outputs.version }}
+        SDK_PATH: ${{ runner.temp }}/lantern-flutter-sdk
+      run: |
+        set -euo pipefail
+        if [[ ! -d "$SDK_PATH/.git" ]]; then
+          git clone --depth 1 --branch "$FLUTTER_VERSION" https://github.com/flutter/flutter.git "$SDK_PATH"
+        fi
+        echo "$SDK_PATH/bin" >> "$GITHUB_PATH"
+        echo "FLUTTER_ROOT=$SDK_PATH" >> "$GITHUB_ENV"
+        "$SDK_PATH/bin/flutter" --version
+
+    - name: Locate pub cache
+      id: pub
+      shell: bash
+      run: |
+        set -euo pipefail
+        pub_cache="${PUB_CACHE:-$HOME/.pub-cache}"
+        mkdir -p "$pub_cache"
+        printf 'path=%s\n' "$pub_cache" >> "$GITHUB_OUTPUT"
+        printf 'PUB_CACHE=%s\n' "$pub_cache" >> "$GITHUB_ENV"
+
+    - name: Cache pub dependencies
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.pub.outputs.path }}
+        key: pub-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}-${{ hashFiles('pubspec.lock') }}
+        restore-keys: |
+          pub-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.version.outputs.version }}-

--- a/.github/actions/setup-flutter/read-version.sh
+++ b/.github/actions/setup-flutter/read-version.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Deliberately accept only the repository's single pinned-version format.
+set -euo pipefail
+
+if [[ $(grep -c '^[[:space:]]*flutter:' "$1") -ne 1 ]]; then
+  echo "Expected exactly one pinned Flutter version in $1" >&2
+  exit 1
+fi
+version=$(sed -n 's/^[[:space:]]*flutter:[[:space:]]*//p' "$1" | sed -E 's/[[:space:]]+$//; s/^"([^"]*)"$/\1/')
+if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$'; then
+  echo "Invalid pinned Flutter version: $version" >&2
+  exit 1
+fi
+printf '%s\n' "$version"

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -1,0 +1,64 @@
+name: Set up Lantern Go toolchain
+description: Install the pinned Go version and cache modules separately from target-specific compilation.
+inputs:
+  cache-scope:
+    description: Build target or test suite; prevents unrelated jobs from racing to save one compiled cache.
+    required: true
+  gomobile-cache:
+    description: Prepare the gomobile cache used by the Makefile (does not install gomobile).
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - name: Install Go
+      id: go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+        cache: false
+
+    - name: Locate caches
+      id: paths
+      shell: bash
+      run: |
+        set -euo pipefail
+        build_cache=$(go env GOCACHE)
+        module_cache=$(go env GOMODCACHE)
+        printf 'build=%s\nmodules=%s\n' "$build_cache" "$module_cache" >> "$GITHUB_OUTPUT"
+
+    # Modules can be shared across targets. Compiled objects cannot use one
+    # immutable key: the first macOS/iOS/Android job would win every cache save.
+    - name: Cache Go modules
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.paths.outputs.modules }}
+        key: go-mod-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}
+        restore-keys: |
+          go-mod-v1-${{ runner.os }}-${{ runner.arch }}-${{ steps.go.outputs.go-version }}-
+
+    - name: Cache Go compilation
+      uses: actions/cache@v4
+      with:
+        path: ${{ steps.paths.outputs.build }}
+        # Go validates objects against source/compiler/flags. Never cache final
+        # release binaries, which embed version, environment and identity data.
+        key: go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-scope }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}-${{ hashFiles('lantern-core/**', 'dart_api_dl/**', 'Makefile') }}
+        restore-keys: |
+          go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-scope }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum') }}-
+          go-build-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-scope }}-${{ steps.go.outputs.go-version }}-
+
+    - name: Configure gomobile cache
+      if: inputs.gomobile-cache == 'true'
+      shell: bash
+      run: |
+        mkdir -p "$HOME/.cache/gomobile"
+        echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
+
+    - name: Cache gomobile initialization
+      if: inputs.gomobile-cache == 'true'
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/gomobile
+        key: gomobile-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-scope }}-${{ steps.go.outputs.go-version }}-${{ hashFiles('go.mod', 'go.sum', 'Makefile') }}
+        restore-keys: |
+          gomobile-v1-${{ runner.os }}-${{ runner.arch }}-${{ inputs.cache-scope }}-${{ steps.go.outputs.go-version }}-

--- a/.github/workflows/android-compile-check.yml
+++ b/.github/workflows/android-compile-check.yml
@@ -6,7 +6,7 @@ name: Android Compile Check
 # so without this gate a Kotlin break (e.g. the bare success() call in #8754)
 # could merge undetected.
 #
-# Scope: the PR trigger runs only on Kotlin (*.kt) changes. It intentionally
+# Scope: the PR trigger covers Kotlin (*.kt) and shared CI setup changes. It
 # does NOT run on Go/gomobile-AAR or Flutter/dep changes — a Go change that
 # breaks the AAR<->Kotlin interface would surface in build-android.yml /
 # release, not here. workflow_dispatch exists only for benchmarking/debugging.
@@ -20,6 +20,9 @@ on:
       - "**/*.kt"
       # keep the self-trigger so edits to this workflow re-run it
       - ".github/workflows/android-compile-check.yml"
+      - ".github/actions/setup-android/**"
+      - ".github/actions/setup-flutter/**"
+      - ".github/actions/setup-go/**"
 
 concurrency:
   group: android-compile-check-${{ github.ref }}
@@ -35,90 +38,16 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
+          cache-scope: android-check
+          gomobile-cache: "true"
 
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
-
-      - name: Set up Java 17 (Gradle cache)
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: "gradle"
-          cache-dependency-path: |
-            **/*.gradle*
-            **/gradle-wrapper.properties
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Free Linux runner disk
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          set -euxo pipefail
-          df -h
-          sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
-          sdk_root="${sdk_root%/}"
-          if [[ -z "$sdk_root" || "$sdk_root" == "/" || "$sdk_root" != /* ]]; then
-            echo "Android SDK root is not set to a safe absolute path: '${sdk_root}'" >&2
-            exit 1
-          fi
-          # Keep the preinstalled Android platforms/build-tools/CMake/NDK; the
-          # shared Makefile defaults match the versions this job needs.
-          sudo rm -rf \
-            "$sdk_root/emulator" \
-            "$sdk_root/system-images" \
-            /opt/ghc \
-            /opt/hostedtoolcache/CodeQL \
-            /usr/local/.ghcup \
-            /usr/local/julia* \
-            /usr/local/share/boost \
-            /usr/share/dotnet \
-            /usr/share/swift
-          df -h
-
-      - name: Install Android SDK components
-        shell: bash
-        run: |
-          set -euxo pipefail
-          make install-android-sdk
-          make android-env >> "$GITHUB_ENV"
+      - name: Set up Android
+        uses: ./.github/actions/setup-android
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
-
-      - name: Set gomobile cache dir
-        shell: bash
-        run: |
-          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.cache/gomobile"
-
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
+        uses: ./.github/actions/setup-flutter
 
       - name: Cache Android AAR
         id: android-aar-cache

--- a/.github/workflows/android-compile-check.yml
+++ b/.github/workflows/android-compile-check.yml
@@ -58,7 +58,7 @@ jobs:
           path: |
             bin/android/liblantern.aar
             android/app/libs/liblantern.aar
-          key: ${{ runner.os }}-android-aar-${{ hashFiles('go.mod', 'go.sum', 'Makefile', '**/*.go') }}
+          key: ${{ runner.os }}-android-aar-${{ hashFiles('go.mod', 'go.sum', 'Makefile', '**/*.go', '.github/actions/setup-android/**', '.github/actions/setup-flutter/**', '.github/actions/setup-go/**') }}
 
       - name: Mark restored Android AAR fresh
         if: steps.android-aar-cache.outputs.cache-hit == 'true'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -43,7 +43,9 @@ jobs:
     env:
       BUILD_TYPE: ${{ inputs.build_type }}
       VERSION: ${{ inputs.version }}
-    runs-on: macos-26
+    # Android needs no Apple tooling. Public Linux runners have 4 CPUs/16 GB,
+    # versus 3 CPUs/7 GB on macOS ARM64, leaving more headroom for Gradle/R8.
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -54,57 +56,16 @@ jobs:
           name: pubspec
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
+          cache-scope: android
+          gomobile-cache: "true"
 
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
-
-      - name: Set up Java 17 (Gradle cache)
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: "gradle"
-          cache-dependency-path: |
-            **/*.gradle*
-            **/gradle-wrapper.properties
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
-      - name: Install Android SDK components
-        shell: bash
-        run: |
-          set -euxo pipefail
-          make install-android-sdk
-          make android-env >> "$GITHUB_ENV"
+      - name: Set up Android
+        uses: ./.github/actions/setup-android
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
-
-      - name: Cache Dart pub cache
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-dart-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-dart-
+        uses: ./.github/actions/setup-flutter
 
       - name: Set gradle properties
         env:
@@ -127,22 +88,6 @@ jobs:
           fileName: "keystore.release.jks"
           fileDir: "./android/app"
           encodedString: ${{ secrets.KEYSTORE }}
-
-      - name: Set gomobile cache dir
-        shell: bash
-        run: |
-          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.cache/gomobile"
-
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
 
       - name: Install dependencies (gomobile)
         run: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -34,28 +34,13 @@ jobs:
           name: pubspec
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
+          cache-scope: ios
+          gomobile-cache: "true"
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
-
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-    
+        uses: ./.github/actions/setup-flutter
 
       - name: Cache iOS CocoaPods
         uses: actions/cache@v4
@@ -115,22 +100,6 @@ jobs:
 
           # Create ExportOptions.plist
           echo "$EXPORT_OPTIONS" | base64 --decode > "$EXPORT_OPTIONS_PATH"
-
-      - name: Set gomobile cache dir
-        shell: bash
-        run: |
-          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.cache/gomobile"
-
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
 
       - name: Install dependencies
         run: make install-gomobile

--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -71,21 +71,9 @@ jobs:
           name: pubspec
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
-
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
+          cache-scope: linux
 
       - name: Cache APT archives
         uses: actions/cache@v4
@@ -136,35 +124,8 @@ jobs:
       - name: Install the ninja build tool
         uses: seanmiddleditch/gha-setup-ninja@master
 
-      - name: Load Flutter version
-        shell: bash
-        run: |
-          set -euo pipefail
-          FLUTTER_VERSION=$(grep -E '^[[:space:]]*flutter:' .github/flutter-version.yaml | sed -E 's/.*"([^"]+)".*/\1/')
-          if [[ -z "$FLUTTER_VERSION" ]]; then
-            echo "Failed to parse Flutter version from .github/flutter-version.yaml" >&2
-            exit 1
-          fi
-          echo "FLUTTER_VERSION=$FLUTTER_VERSION" >> "$GITHUB_ENV"
-
-      - name: Install Flutter (amd64)
-        uses: subosito/flutter-action@v2.23.0
-        if: ${{ matrix.arch == 'amd64' }}
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
-
-      - name: Install Flutter (arm64 fallback)
-        if: ${{ matrix.arch == 'arm64' }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          FLUTTER_HOME="$HOME/flutter"
-          git clone --depth 1 --branch "$FLUTTER_VERSION" https://github.com/flutter/flutter.git "$FLUTTER_HOME"
-          echo "$FLUTTER_HOME/bin" >> "$GITHUB_PATH"
-          export PATH="$FLUTTER_HOME/bin:$PATH"
-          flutter --version
+      - name: Install Flutter
+        uses: ./.github/actions/setup-flutter
 
       - name: Install dependencies
         run: make install-linux-deps

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -174,21 +174,10 @@ jobs:
           name: ${{ inputs.pubspec_artifact }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
-
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
+          cache-scope: macos
+          gomobile-cache: "true"
 
       - name: Cache macOS CocoaPods
         uses: actions/cache@v4
@@ -202,10 +191,7 @@ jobs:
             ${{ runner.os }}-macos-pods-          
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
+        uses: ./.github/actions/setup-flutter
 
       - name: Decode APP_ENV
         if: ${{ !inputs.secretless_test_build }}
@@ -282,22 +268,6 @@ jobs:
 
       - name: Enable Flutter Desktop Support
         run: flutter config --enable-macos-desktop
-
-      - name: Set gomobile cache dir
-        shell: bash
-        run: |
-          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.cache/gomobile"
-
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
 
       - name: Install dependencies
         run: make install-macos-deps

--- a/.github/workflows/build-windows-dll.yml
+++ b/.github/workflows/build-windows-dll.yml
@@ -19,13 +19,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
+          cache-scope: windows-dll
 
       - name: Set up MinGW
         shell: bash
-        run: ./scripts/ci/choco-retry.sh mingw -y
+        run: bash ./scripts/ci/setup-windows-toolchain.sh
       - name: Decode APP_ENV
         uses: timheuer/base64-to-file@v1.2
         with:

--- a/.github/workflows/build-windows-service.yml
+++ b/.github/workflows/build-windows-service.yml
@@ -19,12 +19,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
+          cache-scope: windows-service
+
       - name: Set up MinGW
         shell: bash
-        run: ./scripts/ci/choco-retry.sh mingw -y
+        run: bash ./scripts/ci/setup-windows-toolchain.sh
 
       - name: Build Windows service
         shell: pwsh

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -122,23 +122,14 @@ jobs:
           name: ${{ inputs.pubspec_artifact }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
-
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
+          cache-scope: windows
 
       - name: Install WebView2 Runtime
+        # Compilation downloads the WebView2 SDK separately. The runtime is
+        # needed only when this job actually launches the app.
+        if: ${{ (inputs.package_installer && inputs.run_installer_smoke) || inputs.run_auth_smoke || inputs.run_payment_smoke }}
         shell: pwsh
         run: |
           Invoke-WebRequest -Uri "https://go.microsoft.com/fwlink/p/?LinkId=2124703" -OutFile "MicrosoftEdgeWebView2Setup.exe"
@@ -146,34 +137,10 @@ jobs:
 
       - name: Set up MinGW
         shell: bash
-        run: ./scripts/ci/choco-retry.sh mingw -y
-
-      - name: Read pinned Flutter version
-        id: flutter-version
-        shell: bash
-        # Parsed here and passed as flutter-version rather than flutter-version-file:
-        # given the file input, flutter-action unconditionally runs `choco install yq`
-        # on Windows to parse it, and chocolatey.org 504s on that step failed the
-        # v9.1.18 and v9.1.19 release builds. The direct version input skips it.
-        run: |
-          matches=$(sed -n 's/^[[:space:]]*flutter:[[:space:]]*"\{0,1\}\([0-9][^"]*\)"\{0,1\}[[:space:]]*$/\1/p' .github/flutter-version.yaml)
-          if [ "$(printf '%s\n' "$matches" | grep -c .)" -ne 1 ]; then
-            echo "expected exactly one flutter version in .github/flutter-version.yaml, got:" >&2
-            printf '%s\n' "$matches" >&2
-            exit 1
-          fi
-          version=$(printf '%s' "$matches" | tr -d '[:space:]')
-          if ! printf '%s' "$version" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.]+)?$'; then
-            echo "parsed flutter version does not look like a version: '$version'" >&2
-            exit 1
-          fi
-          echo "version=$version" >> "$GITHUB_OUTPUT"
+        run: bash ./scripts/ci/setup-windows-toolchain.sh
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version: ${{ steps.flutter-version.outputs.version }}
+        uses: ./.github/actions/setup-flutter
 
       - name: Enable Flutter Desktop Support
         run: |
@@ -231,6 +198,9 @@ jobs:
           AUTO_UPDATE_E2E: ${{ inputs.auto_update_e2e }}
           FLUTTER_BUILD_MODE: ${{ inputs.flutter_build_mode }}
           FLUTTER_TARGET: ${{ inputs.flutter_target }}
+          # Parallelize translation units, not MSBuild projects: plugins install
+          # NuGet dependencies into a shared directory. Bound memory use on CI.
+          CL: /MP4
         run: |
           switch ($env:FLUTTER_BUILD_MODE) {
             'release' { make windows-release }

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -1,0 +1,27 @@
+name: CI configuration checks
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - ".github/actions/**"
+      - ".github/workflows/**"
+      - "scripts/ci/setup*.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate workflows
+        uses: docker://rhysd/actionlint:1.7.12
+        with:
+          args: -color -shellcheck=
+      - name: Check setup script syntax
+        run: |
+          bash -n .github/actions/setup-flutter/read-version.sh
+          bash -n scripts/ci/setup-windows-toolchain.sh

--- a/.github/workflows/ci-config.yml
+++ b/.github/workflows/ci-config.yml
@@ -7,6 +7,8 @@ on:
       - ".github/actions/**"
       - ".github/workflows/**"
       - "scripts/ci/setup*.sh"
+      - "scripts/ci/choco-retry.sh"
+      - "scripts/ci/validate_composite_actions.rb"
 
 permissions:
   contents: read
@@ -17,11 +19,16 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Validate workflows
         uses: docker://rhysd/actionlint:1.7.12
         with:
           args: -color -shellcheck=
+      - name: Validate composite actions
+        run: ruby scripts/ci/validate_composite_actions.rb
       - name: Check setup script syntax
         run: |
           bash -n .github/actions/setup-flutter/read-version.sh
+          bash -n scripts/ci/choco-retry.sh
           bash -n scripts/ci/setup-windows-toolchain.sh

--- a/.github/workflows/firebase-test-lab.yml
+++ b/.github/workflows/firebase-test-lab.yml
@@ -81,45 +81,19 @@ jobs:
             --project "$GCP_PROJECT_ID" >/dev/null
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
+          cache-scope: android-ftl
+          gomobile-cache: "true"
 
-      - name: Set up Java 17
-        uses: actions/setup-java@v4
+      - name: Set up Android
+        uses: ./.github/actions/setup-android
         with:
-          distribution: temurin
-          java-version: 17
-          cache: "gradle"
-          cache-dependency-path: |
-            **/*.gradle*
-            **/gradle-wrapper.properties
-
-      - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
-
-      # android/gradlew is gitignored, so install a matching Gradle on the
-      # runner instead (keep the version in sync with
-      # android/gradle/wrapper/gradle-wrapper.properties).
-      - name: Set up Gradle
-        uses: gradle/actions/setup-gradle@v4
-        with:
+          # This job invokes Gradle directly; keep in sync with the wrapper.
           gradle-version: "8.13"
 
-      - name: Install Android SDK components
-        shell: bash
-        run: |
-          set -euxo pipefail
-          make install-android-sdk
-          make android-env >> "$GITHUB_ENV"
-
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
+        uses: ./.github/actions/setup-flutter
 
       - name: Decode APP_ENV
         uses: timheuer/base64-to-file@v1.2
@@ -138,22 +112,6 @@ jobs:
           fileName: "auth_smoke_credentials.dart"
           fileDir: ${{ github.workspace }}/integration_test/auth
           encodedString: ${{ secrets.AUTH_SMOKE_CREDENTIALS }}
-
-      - name: Set gomobile cache dir
-        shell: bash
-        run: |
-          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.cache/gomobile"
-
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
 
       - name: Install dependencies (gomobile)
         run: make install-android-deps

--- a/.github/workflows/flutter-test.yml
+++ b/.github/workflows/flutter-test.yml
@@ -25,6 +25,7 @@ on:
       - ".github/flutter-version.yaml"
       # keep the self-trigger so edits to this workflow re-run it
       - ".github/workflows/flutter-test.yml"
+      - ".github/actions/setup-flutter/**"
 
 concurrency:
   group: flutter-test-${{ github.ref }}
@@ -39,23 +40,8 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
-
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
+        uses: ./.github/actions/setup-flutter
 
       # Generated sources are committed, but regenerating means the suite tests
       # the PR's own source rather than whatever .g.dart happened to be checked

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/go.yml'
+      - '.github/actions/setup-go/**'
       # lantern-core tests assert the report-issue app→core contract
       # against these files (see lantern-core/core_test.go).
       - 'lib/features/report_issue/report_issue.dart'
@@ -18,6 +19,7 @@ on:
       - 'go.mod'
       - 'go.sum'
       - '.github/workflows/go.yml'
+      - '.github/actions/setup-go/**'
       - 'lib/features/report_issue/report_issue.dart'
       - 'assets/locales/en.po'
 
@@ -30,20 +32,12 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
+          cache-scope: go-tests
 
       - name: Verify Go version
         run: go version
-
-      - name: Cache Go modules
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/Library/Caches/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
 
       - name: Install dependencies
         run: go mod download

--- a/.github/workflows/macos-auto-update-smoke.yml
+++ b/.github/workflows/macos-auto-update-smoke.yml
@@ -137,10 +137,7 @@ jobs:
           name: macos-auto-update-pubspec
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
+        uses: ./.github/actions/setup-flutter
 
       - name: Resolve Flutter dependencies
         run: flutter pub get

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -427,11 +427,7 @@ jobs:
           go mod verify
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.22.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
+        uses: ./.github/actions/setup-flutter
 
       - name: Resolve Flutter dependencies and generated sources
         run: |

--- a/.github/workflows/swift-compile-check.yml
+++ b/.github/workflows/swift-compile-check.yml
@@ -15,6 +15,8 @@ on:
       - "Makefile"
       - ".github/flutter-version.yaml"
       - ".github/workflows/swift-compile-check.yml"
+      - ".github/actions/setup-flutter/**"
+      - ".github/actions/setup-go/**"
 
 concurrency:
   group: swift-compile-check-${{ github.ref }}
@@ -34,28 +36,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
+          cache-scope: macos-check
+          gomobile-cache: "true"
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
-
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
+        uses: ./.github/actions/setup-flutter
 
       - name: Cache macOS CocoaPods
         uses: actions/cache@v4
@@ -74,22 +61,6 @@ jobs:
 
       - name: Enable Flutter Desktop Support
         run: flutter config --enable-macos-desktop
-
-      - name: Set gomobile cache dir
-        shell: bash
-        run: |
-          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.cache/gomobile"
-
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
 
       - name: Cache macOS Liblantern.xcframework
         id: macos-framework-cache
@@ -141,28 +112,13 @@ jobs:
           persist-credentials: false
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: ./.github/actions/setup-go
         with:
-          go-version-file: "go.mod"
-          cache: true
+          cache-scope: ios-check
+          gomobile-cache: "true"
 
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version-file: .github/flutter-version.yaml
-          cache: true
-
-      - name: Cache Flutter dependencies
-        uses: actions/cache@v4
-        timeout-minutes: 5
-        continue-on-error: true
-        with:
-          path: |
-            ~/.pub-cache
-          key: ${{ runner.os }}-flutter-${{ hashFiles('**/pubspec.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-flutter-
+        uses: ./.github/actions/setup-flutter
 
       - name: Cache iOS CocoaPods
         uses: actions/cache@v4
@@ -174,22 +130,6 @@ jobs:
           key: ${{ runner.os }}-ios-pods-${{ hashFiles('ios/Podfile.lock') }}
           restore-keys: |
             ${{ runner.os }}-ios-pods-
-
-      - name: Set gomobile cache dir
-        shell: bash
-        run: |
-          echo "GOMOBILECACHE=$HOME/.cache/gomobile" >> "$GITHUB_ENV"
-          mkdir -p "$HOME/.cache/gomobile"
-
-      - name: Cache gomobile
-        uses: actions/cache@v4
-        timeout-minutes: 10
-        continue-on-error: true
-        with:
-          path: ~/.cache/gomobile
-          key: ${{ runner.os }}-gomobile-${{ hashFiles('**/go.mod', '**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-gomobile-
 
       - name: Cache iOS Liblantern.xcframework
         id: ios-framework-cache

--- a/.github/workflows/windows-auto-update-smoke.yml
+++ b/.github/workflows/windows-auto-update-smoke.yml
@@ -140,21 +140,8 @@ jobs:
         with:
           name: windows-auto-update-pubspec
 
-      - name: Read pinned Flutter version
-        id: flutter-version
-        shell: pwsh
-        run: |
-          $match = Select-String -Path '.github/flutter-version.yaml' -Pattern '^\s*flutter:\s*["'']?([^"'']+)["'']?\s*$'
-          if (-not $match) {
-            throw 'Unable to read the pinned Flutter version'
-          }
-          "version=$($match.Matches[0].Groups[1].Value.Trim())" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
-
       - name: Install Flutter
-        uses: subosito/flutter-action@v2.23.0
-        with:
-          channel: stable
-          flutter-version: ${{ steps.flutter-version.outputs.version }}
+        uses: ./.github/actions/setup-flutter
 
       - name: Resolve Flutter dependencies
         run: flutter pub get

--- a/lib/features/share_my_connection/action_mode_widgets.dart
+++ b/lib/features/share_my_connection/action_mode_widgets.dart
@@ -266,18 +266,42 @@ class ActionModeNavigation extends StatelessWidget {
       children: [
         for (var i = 0; i < 2; i++)
           Expanded(
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: desktop
-                    ? 20 /
+            child: desktop
+                ? LayoutBuilder(
+                    builder: (context, constraints) {
+                      final painter = TextPainter(
+                        text: TextSpan(
+                          text: (i == 0 ? 'vpn' : 'unbounded').i18n,
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                        textDirection: Directionality.of(context),
+                        textScaler: MediaQuery.textScalerOf(context),
+                        maxLines: 1,
+                      )..layout();
+                      // Icon, gaps, status dot, and the pill's inner padding.
+                      final contentWidth = painter.width.ceilToDouble() + 56;
+                      painter.dispose();
+                      final preferredInset =
+                          20 /
                           math.max(
                             1,
                             MediaQuery.textScalerOf(context).scale(14) / 14,
-                          )
-                    : 0,
-              ),
-              child: _item(context, i),
-            ),
+                          );
+                      final inset = math.min(
+                        preferredInset,
+                        math.max(
+                          0.0,
+                          (constraints.maxWidth - contentWidth) / 2,
+                        ),
+                      );
+                      return Padding(
+                        padding: EdgeInsets.symmetric(horizontal: inset),
+                        child: _item(context, i),
+                      );
+                    },
+                  )
+                : _item(context, i),
           ),
       ],
     ),

--- a/scripts/ci/setup-windows-toolchain.sh
+++ b/scripts/ci/setup-windows-toolchain.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# GitHub's Windows image already has a usable MinGW toolchain. Install only
+# when it is missing, rather than downloading a second compiler onto PATH.
+set -euo pipefail
+
+if command -v gcc >/dev/null 2>&1 && command -v make >/dev/null 2>&1 &&
+  target=$(gcc -dumpmachine 2>/dev/null); then
+  if [[ "$target" == x86_64-*-mingw32 ]]; then
+    echo "Using preinstalled MinGW ($target)"
+    gcc --version
+    make --version
+    exit 0
+  fi
+fi
+
+bash "$(dirname "$0")/choco-retry.sh" mingw -y

--- a/scripts/ci/validate_composite_actions.rb
+++ b/scripts/ci/validate_composite_actions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "yaml"
+
+manifests = Dir[".github/actions/**/{action.yml,action.yaml}"].sort
+abort "no composite action manifests found" if manifests.empty?
+
+manifests.each do |path|
+  action = YAML.safe_load(File.read(path), aliases: true, filename: path)
+  abort "#{path}: manifest must be a mapping" unless action.is_a?(Hash)
+
+  runs = action["runs"]
+  unless runs.is_a?(Hash) && runs["using"] == "composite"
+    abort "#{path}: runs.using must be composite"
+  end
+
+  steps = runs["steps"]
+  abort "#{path}: runs.steps must not be empty" unless steps.is_a?(Array) && !steps.empty?
+
+  steps.each_with_index do |step, index|
+    label = "#{path}: runs.steps[#{index}]"
+    abort "#{label} must be a mapping" unless step.is_a?(Hash)
+
+    has_run = step.key?("run")
+    has_uses = step.key?("uses")
+    abort "#{label} must define exactly one of run or uses" unless has_run ^ has_uses
+
+    if has_run && !step["shell"].is_a?(String)
+      abort "#{label} must define shell for run"
+    end
+  end
+end
+
+puts "Validated #{manifests.length} composite action manifests"

--- a/test/features/share_my_connection/action_mode_navigation_test.dart
+++ b/test/features/share_my_connection/action_mode_navigation_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lantern/core/common/common.dart';
 import 'package:lantern/features/share_my_connection/action_mode_widgets.dart';
@@ -37,6 +38,55 @@ void main() {
     expect((strip.decoration! as BoxDecoration).border, isNull);
     expect(tester.takeException(), isNull);
   });
+
+  // Ahem renders each character 14 px wide: Action Mode needs 154 px at 1×,
+  // plus 56 px for the icon, gaps, dot, and inner padding.
+  for (final (width, scale, truncated) in [
+    (393.0, 1.0, true),
+    (460.0, 1.0, false),
+    (780.0, 2.0, false),
+  ]) {
+    testWidgets(
+      'desktop label fits available space at width $width and scale $scale',
+      (tester) async {
+        tester.view.physicalSize = Size(width, 852);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              platform: TargetPlatform.windows,
+              textTheme: const TextTheme(labelLarge: TextStyle(fontSize: 14)),
+            ),
+            builder: (context, child) => MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(textScaler: TextScaler.linear(scale)),
+              child: child!,
+            ),
+            home: Scaffold(
+              body: ActionModeNavigation(
+                selectedIndex: 1,
+                onSelected: (_) {},
+                vpnActive: false,
+                actionActive: true,
+                desktop: true,
+              ),
+            ),
+          ),
+        );
+        final label = find.descendant(
+          of: find.text('unbounded'.i18n),
+          matching: find.byType(RichText),
+        );
+        final paragraph = tester.renderObject<RenderParagraph>(label);
+        expect(paragraph.didExceedMaxLines, truncated);
+        expect(tester.getSize(find.byType(ActionModeNavigation)).width, width);
+        expect(tester.takeException(), isNull);
+      },
+    );
+  }
 
   for (final desktop in [false, true]) {
     for (final brightness in Brightness.values) {


### PR DESCRIPTION
Consolidates repeated Flutter, Go, and Android setup into shared actions. Windows builds reuse compatible installed toolchains, use bounded parallel compilation, and install WebView2 only for jobs that run GUI smoke tests. Android release builds move to Ubuntu. Duplicate caches are removed, and Go compilation caches are separated by target.

## Measured build times

These are historical GitHub Actions measurements from September 4–11, 2026. Durations cover the complete platform job, including setup, packaging, artifact uploads, and post-job cache work; they exclude queue time, prerequisite jobs, and release publication.

| Platform job | Before: median (sample count) | Before: range | PR run 1 | PR run 2 |
| --- | ---: | ---: | ---: | ---: |
| Windows installer | 23m45s (10) | 18m10s–26m27s | [14m14s](https://github.com/getlantern/lantern/actions/runs/34553696476/job/103123515790) | [22m59s](https://github.com/getlantern/lantern/actions/runs/34556828204/job/103132136047) |
| Android APK + AAB | 41m20s (7) | 17m33s–53m43s | [21m19s](https://github.com/getlantern/lantern/actions/runs/34553696476/job/103123515763) | [18m13s](https://github.com/getlantern/lantern/actions/runs/34556828204/job/103132136010) |

The two PR runs have medians of **18m37s for Windows** and **19m46s for Android**, approximately **22%** and **52%** below their historical baselines.

### How to read the comparison

- Both PR runs used revision `01c64ade2` on September 11. The September 10 baseline at `2c6bbfd5d` has the same application source, build files, and dependency versions; the branch changes are in CI setup, scripts, and documentation.
- Windows builds were unsigned, with installer/auth/payment smoke tests skipped on both sides. Android jobs built both APK and AAB; the runner changed from `macos-26` to `ubuntu-24.04` as part of this PR.
- Cache state and runner load were not controlled. The second Windows run spent 4m07s in Flutter/Go post-job steps, versus 33s in the first; those costs are included above. The fastest historical Android job was faster than either PR sample.
- Both listed platform jobs passed in both PR runs. The second workflow later failed in `release-create`, after the builds completed.
- This is a small historical sample, not a guaranteed speedup. The current head includes later main merges and review fixes and has not been rebenchmarked end to end.

<details>
<summary>Baseline runs and individual job timings</summary>

Only successful platform jobs are counted. An overall workflow failure does not discard a successful build job.

| Run | Windows | Android |
| --- | ---: | ---: |
| [34520346226](https://github.com/getlantern/lantern/actions/runs/34520346226) | [25m23s](https://github.com/getlantern/lantern/actions/runs/34520346226/job/103018961779) | [53m43s](https://github.com/getlantern/lantern/actions/runs/34520346226/job/103018962053) |
| [34504258013](https://github.com/getlantern/lantern/actions/runs/34504258013) | [23m59s](https://github.com/getlantern/lantern/actions/runs/34504258013/job/102964097609) | [48m47s](https://github.com/getlantern/lantern/actions/runs/34504258013/job/102964097599) |
| [34477347328](https://github.com/getlantern/lantern/actions/runs/34477347328) | [26m27s](https://github.com/getlantern/lantern/actions/runs/34477347328/job/102872839308) | [17m33s](https://github.com/getlantern/lantern/actions/runs/34477347328/job/102872838995) |
| [34435486688](https://github.com/getlantern/lantern/actions/runs/34435486688) | [22m37s](https://github.com/getlantern/lantern/actions/runs/34435486688/job/102740537355) | [43m15s](https://github.com/getlantern/lantern/actions/runs/34435486688/job/102740537289) |
| [34309314750](https://github.com/getlantern/lantern/actions/runs/34309314750) | [25m10s](https://github.com/getlantern/lantern/actions/runs/34309314750/job/102333235439) | [39m13s](https://github.com/getlantern/lantern/actions/runs/34309314750/job/102333235536) |
| [34185466662](https://github.com/getlantern/lantern/actions/runs/34185466662) | [24m23s](https://github.com/getlantern/lantern/actions/runs/34185466662/job/101933585330) | [41m20s](https://github.com/getlantern/lantern/actions/runs/34185466662/job/101933585354) |
| [34081543703](https://github.com/getlantern/lantern/actions/runs/34081543703) | [18m10s](https://github.com/getlantern/lantern/actions/runs/34081543703/job/101618368558) | [38m17s](https://github.com/getlantern/lantern/actions/runs/34081543703/job/101618368599) |
| [34010401915](https://github.com/getlantern/lantern/actions/runs/34010401915) | [23m31s](https://github.com/getlantern/lantern/actions/runs/34010401915/job/101425673264) | — |
| [33943392085](https://github.com/getlantern/lantern/actions/runs/33943392085) | [22m09s](https://github.com/getlantern/lantern/actions/runs/33943392085/job/101245518696) | — |
| [33835244340](https://github.com/getlantern/lantern/actions/runs/33835244340) | [22m28s](https://github.com/getlantern/lantern/actions/runs/33835244340/job/100907130968) | — |

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI/CD Improvements**
  * Standardized Android, Flutter, and Go toolchain setup across build and test workflows.
  * Improved dependency and build caching for faster, more resilient CI runs.
  * Added validation for workflow configuration and setup scripts.
  * Windows builds now reuse compatible MinGW toolchains and support improved parallel compilation.
  * Android builds now run on Ubuntu 24.04.
  * Workflows automatically run when shared setup components change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

