### PR TITLE
Fix Windows Action Mode tab label truncation

### DIFF
--- a/lib/features/share_my_connection/action_mode_widgets.dart
+++ b/lib/features/share_my_connection/action_mode_widgets.dart
@@ -266,18 +266,42 @@ class ActionModeNavigation extends StatelessWidget {
       children: [
         for (var i = 0; i < 2; i++)
           Expanded(
-            child: Padding(
-              padding: EdgeInsets.symmetric(
-                horizontal: desktop
-                    ? 20 /
+            child: desktop
+                ? LayoutBuilder(
+                    builder: (context, constraints) {
+                      final painter = TextPainter(
+                        text: TextSpan(
+                          text: (i == 0 ? 'vpn' : 'unbounded').i18n,
+                          style: Theme.of(context).textTheme.labelLarge
+                              ?.copyWith(fontWeight: FontWeight.w600),
+                        ),
+                        textDirection: Directionality.of(context),
+                        textScaler: MediaQuery.textScalerOf(context),
+                        maxLines: 1,
+                      )..layout();
+                      // Icon, gaps, status dot, and the pill's inner padding.
+                      final contentWidth = painter.width.ceilToDouble() + 56;
+                      painter.dispose();
+                      final preferredInset =
+                          20 /
                           math.max(
                             1,
                             MediaQuery.textScalerOf(context).scale(14) / 14,
-                          )
-                    : 0,
-              ),
-              child: _item(context, i),
-            ),
+                          );
+                      final inset = math.min(
+                        preferredInset,
+                        math.max(
+                          0.0,
+                          (constraints.maxWidth - contentWidth) / 2,
+                        ),
+                      );
+                      return Padding(
+                        padding: EdgeInsets.symmetric(horizontal: inset),
+                        child: _item(context, i),
+                      );
+                    },
+                  )
+                : _item(context, i),
           ),
       ],
     ),

--- a/test/features/share_my_connection/action_mode_navigation_test.dart
+++ b/test/features/share_my_connection/action_mode_navigation_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:lantern/core/common/common.dart';
 import 'package:lantern/features/share_my_connection/action_mode_widgets.dart';
@@ -37,6 +38,48 @@ void main() {
     expect((strip.decoration! as BoxDecoration).border, isNull);
     expect(tester.takeException(), isNull);
   });
+
+  for (final (width, scale) in [(460.0, 1.0), (780.0, 2.0)]) {
+    testWidgets('desktop label uses available inset space at scale $scale', (
+      tester,
+    ) async {
+      tester.view.physicalSize = Size(width, 852);
+      tester.view.devicePixelRatio = 1;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData(
+            platform: TargetPlatform.windows,
+            textTheme: const TextTheme(labelLarge: TextStyle(fontSize: 14)),
+          ),
+          builder: (context, child) => MediaQuery(
+            data: MediaQuery.of(
+              context,
+            ).copyWith(textScaler: TextScaler.linear(scale)),
+            child: child!,
+          ),
+          home: Scaffold(
+            body: ActionModeNavigation(
+              selectedIndex: 1,
+              onSelected: (_) {},
+              vpnActive: false,
+              actionActive: true,
+              desktop: true,
+            ),
+          ),
+        ),
+      );
+      final label = find.descendant(
+        of: find.text('unbounded'.i18n),
+        matching: find.byType(RichText),
+      );
+      final paragraph = tester.renderObject<RenderParagraph>(label);
+      expect(paragraph.didExceedMaxLines, isFalse);
+      expect(tester.getSize(find.byType(ActionModeNavigation)).width, width);
+      expect(tester.takeException(), isNull);
+    });
+  }
 
   for (final desktop in [false, true]) {
     for (final brightness in Brightness.values) {

--- a/test/features/share_my_connection/action_mode_navigation_test.dart
+++ b/test/features/share_my_connection/action_mode_navigation_test.dart
@@ -39,46 +39,53 @@ void main() {
     expect(tester.takeException(), isNull);
   });
 
-  for (final (width, scale) in [(460.0, 1.0), (780.0, 2.0)]) {
-    testWidgets('desktop label uses available inset space at scale $scale', (
-      tester,
-    ) async {
-      tester.view.physicalSize = Size(width, 852);
-      tester.view.devicePixelRatio = 1;
-      addTearDown(tester.view.resetPhysicalSize);
-      addTearDown(tester.view.resetDevicePixelRatio);
-      await tester.pumpWidget(
-        MaterialApp(
-          theme: ThemeData(
-            platform: TargetPlatform.windows,
-            textTheme: const TextTheme(labelLarge: TextStyle(fontSize: 14)),
-          ),
-          builder: (context, child) => MediaQuery(
-            data: MediaQuery.of(
-              context,
-            ).copyWith(textScaler: TextScaler.linear(scale)),
-            child: child!,
-          ),
-          home: Scaffold(
-            body: ActionModeNavigation(
-              selectedIndex: 1,
-              onSelected: (_) {},
-              vpnActive: false,
-              actionActive: true,
-              desktop: true,
+  // Ahem renders each character 14 px wide: Action Mode needs 154 px at 1×,
+  // plus 56 px for the icon, gaps, dot, and inner padding.
+  for (final (width, scale, truncated) in [
+    (393.0, 1.0, true),
+    (460.0, 1.0, false),
+    (780.0, 2.0, false),
+  ]) {
+    testWidgets(
+      'desktop label fits available space at width $width and scale $scale',
+      (tester) async {
+        tester.view.physicalSize = Size(width, 852);
+        tester.view.devicePixelRatio = 1;
+        addTearDown(tester.view.resetPhysicalSize);
+        addTearDown(tester.view.resetDevicePixelRatio);
+        await tester.pumpWidget(
+          MaterialApp(
+            theme: ThemeData(
+              platform: TargetPlatform.windows,
+              textTheme: const TextTheme(labelLarge: TextStyle(fontSize: 14)),
+            ),
+            builder: (context, child) => MediaQuery(
+              data: MediaQuery.of(
+                context,
+              ).copyWith(textScaler: TextScaler.linear(scale)),
+              child: child!,
+            ),
+            home: Scaffold(
+              body: ActionModeNavigation(
+                selectedIndex: 1,
+                onSelected: (_) {},
+                vpnActive: false,
+                actionActive: true,
+                desktop: true,
+              ),
             ),
           ),
-        ),
-      );
-      final label = find.descendant(
-        of: find.text('unbounded'.i18n),
-        matching: find.byType(RichText),
-      );
-      final paragraph = tester.renderObject<RenderParagraph>(label);
-      expect(paragraph.didExceedMaxLines, isFalse);
-      expect(tester.getSize(find.byType(ActionModeNavigation)).width, width);
-      expect(tester.takeException(), isNull);
-    });
+        );
+        final label = find.descendant(
+          of: find.text('unbounded'.i18n),
+          matching: find.byType(RichText),
+        );
+        final paragraph = tester.renderObject<RenderParagraph>(label);
+        expect(paragraph.didExceedMaxLines, truncated);
+        expect(tester.getSize(find.byType(ActionModeNavigation)).width, width);
+        expect(tester.takeException(), isNull);
+      },
+    );
   }
 
   for (final desktop in [false, true]) {


### PR DESCRIPTION
Windows could show “Action Mo…” in the desktop tab bar even though unused space remained around the pill. The fixed per-tab inset reduced the label's available width before Flutter applied ellipsis.

Measure the localized label using the current font and text scale, and shrink the desktop inset when needed to accommodate the icon, full label, and status dot. Keep the preferred inset wherever it fits and retain ellipsis when the tab genuinely lacks room.

Validation: all 295 Flutter tests pass; targeted Dart analysis and `git diff --check` pass. New Windows-platform widget tests check actual text truncation at 1× and 2× text scale; both fail against the original implementation and pass with this fix. Native Windows execution was not available on the macOS development host.

Report: https://wdynhnkxvsdx.slack.com/archives/C06F5EKHN5S/p1789127321860339


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved desktop navigation spacing so labels and controls fit more reliably across different window widths and text sizes.
  - Improved mobile navigation layout by removing unnecessary spacing around navigation items.

- **Tests**
  - Expanded coverage for desktop navigation across multiple viewport widths and text scales.
  - Added validation for label truncation behavior in narrow layouts.
  - Added checks for rendering errors and correct navigation sizing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->